### PR TITLE
Add pipeline model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,121 @@
 npm install screwdriver-models
 ```
 
+### Pipeline Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+
+module.exports = (datastore) => ({
+    method: 'GET',
+    path: '/pipelines',
+    config: {
+        description: 'Get pipelines with pagination',
+        notes: 'Returns all pipeline records',
+        tags: ['api', 'pipelines'],
+        handler: (request, reply) => {
+            const Pipeline = new Model.Pipeline(datastore);
+            Pipeline.list(request.query, reply);
+        },
+        response: {
+            schema: listSchema
+        },
+        validate: {
+            query: schema.pagination
+        }
+    }
+});
+```
+
+
+#### Create
+Create a pipeline & create a default job called `main`
+```
+create(config, callback)
+```
+
+| Parameter        | Type  | Required  |  Description |
+| :-------------   | :---- | :---- | :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.scmUrl | String | Yes | Source Code URL for the application |
+| config.configUrl | String | No | Source Code URL for Screwdriver configuration |
+| callback | Function | Yes | Callback function|
+
+#### Get
+Get a pipeline based on id
+```
+get(id, callback)
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | String | The unique ID for the pipeline |
+| callback | Function | Callback function|
+
+#### List
+List builds with pagination
+```
+list(paginate, callback)
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| paginate        | Object | Pagination Object |
+| paginate.page | Number | The page for pagination |
+| paginate.count | Number | The count for pagination |
+| callback | Function | Callback function |
+
+#### Update
+Update a specific pipeline
+```
+update(config, callback)
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.id | String | The unique ID for the pipeline |
+| config.data | String | The new data to update with |
+| callback | Function | Callback function|
+
+#### Sync
+Sync the pipeline. Look up the configuration in the repo to create and delete jobs if necessary.
+```
+sync(config, callback)
+```
+
+| Parameter        | Type  | Required  |  Description |
+| :-------------   | :---- | :---- | :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.scmUrl | String | Yes | Source Code URL for the application |
+| callback | Function | Yes | Callback function|
+
 ### Build Model
 ```js
 'use strict';
-const BuildModel = require('screwdriver-models');
-const datastore = require('your-datastore');
-const build = new BuildModel(datastore);
-const config = {
-    page: 1
-    count: 2
-}
-build.list(config, (err, data) => {
-    if (err) {
-        throw new Error(err);
+const Model = require('screwdriver-models');
+
+module.exports = (datastore) => ({
+    method: 'GET',
+    path: '/builds',
+    config: {
+        description: 'Get builds with pagination',
+        notes: 'Returns all builds records',
+        tags: ['api', 'builds'],
+        handler: (request, reply) => {
+            const Build = new Model.Build(datastore);
+            Build.list(request.query, reply);
+        },
+        response: {
+            schema: listSchema
+        },
+        validate: {
+            query: schema.pagination
+        }
     }
-    console.log(data);
 });
 ```
+
 #### Create
 Create & start a new build
 ```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+'use strict';
+const Build = require('./lib/buildmodel');
+const Pipeline = require('./lib/pipelinemodel');
+
+module.exports = { Build, Pipeline };

--- a/lib/buildmodel.js
+++ b/lib/buildmodel.js
@@ -3,7 +3,7 @@ const async = require('async');
 const Executor = require('screwdriver-executor-k8s');
 const hashr = require('screwdriver-hashr');
 const hoek = require('hoek');
-const table = 'builds';
+const PipelineModel = require('./pipelinemodel');
 
 /**
  * Given a Job ID, look up the associated Pipeline ID
@@ -26,7 +26,6 @@ function fetchPipelineId(datastore, jobId, callback) {
 /**
  * Given a Pipeline ID, look up the associated SCM Url
  *
- * TODO: Use PipelineModel instead
  * @method fetchScmUrl
  * @param  {Object}    datastore          The datastore object that can retrieve the data from the datastore
  * @param  {Object}    params             An object
@@ -35,14 +34,10 @@ function fetchPipelineId(datastore, jobId, callback) {
  *                                        keys: "pipelineID" and "scmUrl"
  */
 function fetchScmUrl(datastore, params, callback) {
+    const pipelineModel = new PipelineModel(datastore);
     const pipelineId = params.pipelineId;
 
-    datastore.get({
-        table: 'pipelines',
-        params: {
-            id: pipelineId
-        }
-    }, (err, data) => {
+    pipelineModel.get(pipelineId, (err, data) => {
         if (err) {
             return callback(err);
         }
@@ -64,6 +59,7 @@ const BuildModel = class {
     constructor(datastore) {
         this.datastore = datastore;
         this.executor = new Executor({});
+        this.table = 'builds';
     }
 
     /**
@@ -94,7 +90,7 @@ const BuildModel = class {
         async.waterfall([
             (next) => {
                 this.datastore.save({
-                    table: 'builds',
+                    table: this.table,
                     params: {
                         id,
                         data: initialBuildData
@@ -144,7 +140,7 @@ const BuildModel = class {
      */
     get(id, callback) {
         const config = {
-            table,
+            table: this.table,
             params: {
                 id
             }
@@ -162,7 +158,7 @@ const BuildModel = class {
      */
     list(paginate, callback) {
         const config = {
-            table,
+            table: this.table,
             params: {},
             paginate: {
                 count: paginate.count,
@@ -182,7 +178,7 @@ const BuildModel = class {
      */
     update(config, callback) {
         const datastoreConfig = {
-            table,
+            table: this.table,
             params: {
                 id: config.id,
                 data: config.data

--- a/lib/pipelinemodel.js
+++ b/lib/pipelinemodel.js
@@ -1,0 +1,145 @@
+'use strict';
+const hashr = require('screwdriver-hashr');
+const hoek = require('hoek');
+
+const PipelineModel = class {
+    /**
+     * Construct a PipelineModel object
+     * @method constructor
+     * @param  {Object}    datastore         Object that will perform operations on the datastore
+     */
+    constructor(datastore) {
+        this.datastore = datastore;
+        this.table = 'pipelines';
+    }
+
+    /**
+     * Create a pipeline
+     * @method create
+     * @param  {Object}   config                Config object to create the pipeline with
+     * @param  {String}   config.scmUrl         The scmUrl for the application
+     * @param  {String}   [config.configUrl]    The configUrl for the application
+     * @param  {Function} callback              Callback function
+     */
+    create(config, callback) {
+        const pipelineId = hashr.sha1(config.scmUrl);
+
+        /* eslint-disable consistent-return */
+        this.get(pipelineId, (error, data) => {
+            if (data) {
+                return callback(new Error('scmUrl needs to be unique'));
+            }
+
+            const createTime = Date.now();
+            const platform = 'generic@1';
+            const pipelineData = hoek.applyToDefaults({
+                createTime,
+                platform,
+                configUrl: config.scmUrl
+            }, config);
+            const pipelineConfig = {
+                table: this.table,
+                params: {
+                    id: pipelineId,
+                    data: pipelineData
+                }
+            };
+
+            return this.datastore.save(pipelineConfig, callback);
+        });
+    }
+
+    /**
+     * Sync the pipeline by looking up what is currently in yaml and create or delete
+     * jobs if necessary. Right now, this simply creates the job 'main'.
+     * @param  {Object}   config           Config object to create the pipeline with
+     * @param  {String}   config.scmUrl    The scmUrl of the repository
+     * @param  {Function} callback         Callback function
+     */
+    // TODO: make this so that it looks up the yaml & create/delete jobs if necessary
+    sync(config, callback) {
+        const pipelineId = hashr.sha1(config.scmUrl);
+
+        this.get(pipelineId, (error) => {
+            if (error) {
+                return callback(error);
+            }
+
+            // TODO: use job model
+            const name = 'main';
+            const id = hashr.sha1(`${pipelineId}${name}`);
+            const jobConfig = {
+                table: 'jobs',
+                params: {
+                    id,
+                    data: {
+                        name,
+                        pipelineId,
+                        state: 'ENABLED',
+                        triggers: [],
+                        triggeredBy: []
+                    }
+                }
+            };
+
+            return this.datastore.save(jobConfig, callback);
+        });
+    }
+
+    /**
+    * Get a pipeline based on id
+    * @param  {String}   id                The key of the record to retrieve
+    * @return {Function} callback
+    */
+    get(id, callback) {
+        const config = {
+            table: this.table,
+            params: {
+                id
+            }
+        };
+
+        return this.datastore.get(config, callback);
+    }
+
+   /**
+     * List pipelines with pagination
+     * @param  {Object}   paginate           Config object
+     * @param  {Number}   paginate.count     Number of items per page
+     * @param  {Number}   paginate.page      Specific page of the set to return
+     * @return {Function} callback
+     */
+    list(paginate, callback) {
+        const config = {
+            table: this.table,
+            params: {},
+            paginate: {
+                count: paginate.count,
+                page: paginate.page
+            }
+        };
+
+        return this.datastore.scan(config, callback);
+    }
+
+    /**
+    * Update a pipeline
+    * @param  {Object}    config         Config object
+    * @param  {String}    config.id      The key of the record to retrieve
+    * @param  {Object}    config.data    The new data object to update with
+    * @return {Function}  callback
+    */
+    update(config, callback) {
+        const datastoreConfig = {
+            table: this.table,
+            params: {
+                id: config.id,
+                data: config.data
+            }
+        };
+
+        return this.datastore.update(datastoreConfig, callback);
+    }
+};
+
+module.exports = PipelineModel;

--- a/test/lib/buildmodel.test.js
+++ b/test/lib/buildmodel.test.js
@@ -69,6 +69,10 @@ describe('Build Model', () => {
         const result = new BuildModel(datastore);
 
         assert.property(result, 'create');
+        assert.property(result, 'get');
+        assert.property(result, 'list');
+        assert.property(result, 'update');
+        assert.property(result, 'stream');
     });
 
     describe('stream', () => {

--- a/test/lib/pipelinemodel.test.js
+++ b/test/lib/pipelinemodel.test.js
@@ -1,0 +1,239 @@
+'use strict';
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+/**
+ * Stub for Executor K8s factory method
+ * @method executorFactoryStub
+ */
+function executorFactoryStub() {}
+
+describe('Pipeline Model', () => {
+    let PipelineModel;
+    let datastore;
+    let hashaMock;
+    let pipeline;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            get: sinon.stub(),
+            scan: sinon.stub(),
+            update: sinon.stub(),
+            save: sinon.stub()
+        };
+        hashaMock = {
+            sha1: sinon.stub()
+        };
+        mockery.registerMock('screwdriver-hashr', hashaMock);
+        mockery.registerMock('screwdriver-executor-k8s', executorFactoryStub);
+
+        // eslint-disable-next-line global-require
+        PipelineModel = require('../../lib/pipelinemodel');
+
+        pipeline = new PipelineModel(datastore);
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('constructs', () => {
+        const result = new PipelineModel(datastore);
+
+        assert.isOk(result);
+    });
+
+    it('has the correct API', () => {
+        const result = new PipelineModel(datastore);
+
+        assert.property(result, 'create');
+        assert.property(result, 'get');
+        assert.property(result, 'list');
+        assert.property(result, 'update');
+        assert.property(result, 'sync');
+    });
+
+    describe('get', () => {
+        it('calls datastore get and returns correct values', (done) => {
+            datastore.get.yieldsAsync(null, { id: 'as12345', data: 'stuff' });
+            pipeline.get('as12345', (err, data) => {
+                assert.isNull(err);
+                assert.deepEqual(data, {
+                    id: 'as12345',
+                    data: 'stuff'
+                });
+                done();
+            });
+        });
+    });
+
+    describe('list', () => {
+        const paginate = {
+            page: 1,
+            count: 2
+        };
+
+        it('calls datastore scan and returns correct values', (done) => {
+            const returnValue = [
+                {
+                    id: '1321shewp',
+                    scmUrl: 'git@github.com/repo1.git#master'
+                },
+                {
+                    id: '0842wpoe',
+                    scmUrl: 'git@github.com/repo2.git#master'
+                }
+            ];
+
+            datastore.scan.yieldsAsync(null, returnValue);
+            pipeline.list(paginate, (err, data) => {
+                assert.isNull(err);
+                assert.deepEqual(data, returnValue);
+                done();
+            });
+        });
+    });
+
+    describe('update', () => {
+        const config = {
+            id: 'as12345',
+            scmUrl: 'git@github.com/stuff.git#master'
+        };
+
+        it('calls datastore update and returns the new object', (done) => {
+            datastore.update.yieldsAsync(null, { scmUrl: 'git@github.com/stuff.git#master' });
+            pipeline.update(config, (err, result) => {
+                assert.isNull(err);
+                assert.deepEqual(result, { scmUrl: 'git@github.com/stuff.git#master' });
+                done();
+            });
+        });
+    });
+
+    describe('create', () => {
+        let sandbox;
+        let config;
+        const dateNow = 1111111111;
+        const scmUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
+        const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+        const platformName = 'generic@1';
+
+        beforeEach(() => {
+            sandbox = sinon.sandbox.create({
+                useFakeTimers: false
+            });
+            hashaMock.sha1.withArgs(scmUrl).returns(testId);
+
+            config = {
+                table: 'pipelines',
+                params: {
+                    id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    data: {
+                        createTime: dateNow,
+                        scmUrl,
+                        configUrl: scmUrl,
+                        platform: platformName
+                    }
+                }
+            };
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('returns error when the scmUrl already exists', (done) => {
+            datastore.get.yieldsAsync(null, { id: testId, scmUrl });
+            pipeline.create({ scmUrl }, (error) => {
+                assert.isOk(error);
+                assert.equal(error.message, 'scmUrl needs to be unique');
+                done();
+            });
+        });
+
+        it('returns error when the datastore fails to save', (done) => {
+            datastore.get.yieldsAsync(null, null);
+            const testError = new Error('datastoreSaveError');
+
+            datastore.save.yieldsAsync(testError);
+
+            pipeline.create({ scmUrl }, (error) => {
+                assert.isOk(error);
+                assert.equal(error.message, 'datastoreSaveError');
+                done();
+            });
+        });
+
+        it('and correct pipeline data', (done) => {
+            datastore.get.yieldsAsync(null, null);
+            sandbox.useFakeTimers(dateNow);
+            datastore.save.yieldsAsync(null);
+
+            pipeline.create({ scmUrl }, () => {
+                assert.calledWith(datastore.save, config);
+                done();
+            });
+
+            process.nextTick(() => {
+                sandbox.clock.tick();
+            });
+        });
+    });
+
+    describe('sync', () => {
+        const scmUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
+        const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+        const testJobId = 'e398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+        const jobName = 'main';
+
+        it('creates the main job if pipeline exists', (done) => {
+            hashaMock.sha1.withArgs(`${scmUrl}`).returns(testId);
+            hashaMock.sha1.withArgs(`${testId}${jobName}`).returns(testJobId);
+            datastore.get.yieldsAsync(null);
+            datastore.save.yieldsAsync(null);
+            pipeline.sync({ scmUrl }, () => {
+                assert.calledWith(datastore.save, {
+                    table: 'jobs',
+                    params: {
+                        id: testJobId,
+                        data: {
+                            name: 'main',
+                            pipelineId: testId,
+                            state: 'ENABLED',
+                            triggers: [],
+                            triggeredBy: []
+                        }
+                    }
+                });
+                assert.calledWith(hashaMock.sha1, `${testId}main`);
+                done();
+            });
+        });
+
+        it('returns error if pipeline does not exist', (done) => {
+            const err = new Error('blah');
+
+            datastore.get.yieldsAsync(err);
+            pipeline.sync({ scmUrl }, (error) => {
+                assert.isOk(error);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Based on this morning discussion:
- In create: only create the pipeline
- In sync: syncing the pipeline. Right now it only creates the main job. I don't want to add code to do actual syncing yet since the purpose of this PR is to refactor, not to add new features. 
- It's the plugin's responsibility to call pipeline create then pipeline sync. 
- Model will be instantiated in every API call, inside the handler. 
