### PR TITLE
Pass in Executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ update(config, callback)
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const Build = new Model.Build(datastore);
+const Build = new Model.Build(datastore, executor);
 const config = {
     page: 2,
     count: 3
@@ -298,14 +298,14 @@ update(config, callback)
 #### Stream
 Stream the log of a build
 ```
-stream(config, response)
+stream(config, callback)
 ```
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
 | config        | Object | Configuration Object |
 | config.buildId | String | The unique ID for the build |
-| response | Object | The response object to stream to|
+| callback | Function | Callback function fn(err, stream) where stream is a Readable stream|
 
 ## Testing
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,6 +1,5 @@
 'use strict';
 const async = require('async');
-const Executor = require('screwdriver-executor-k8s');
 const hashr = require('screwdriver-hashr');
 const hoek = require('hoek');
 const BaseModel = require('./base');
@@ -55,11 +54,11 @@ class BuildModel extends BaseModel {
      * Construct a BuildModel object
      * @method constructor
      * @param  {Object}    datastore         Object that will perform operations on the datastore
-     * @param  {Object}    [executorOptions] Options to configure the executor-k8s module directly
+     * @param  {Object}    executor          Object that will perform executor operations
      */
-    constructor(datastore) {
+    constructor(datastore, executor) {
         super(datastore);
-        this.executor = new Executor({});
+        this.executor = executor;
         this.table = 'builds';
     }
 
@@ -128,10 +127,10 @@ class BuildModel extends BaseModel {
      * @method stream
      * @param  {Object}   config           Config object
      * @param  {String}   config.buildId   The id of the build to stream
-     * @param  {Object}   response         The response object to stream to
+     * @param  {Function} callback         The callback object to return the stream to
      */
-    stream(config, response) {
-        return this.executor.stream(config, response);
+    stream(config, callback) {
+        return this.executor.stream(config, callback);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,6 @@
   "dependencies": {
     "async": "^2.0.0-rc.6",
     "hoek": "^4.0.1",
-    "screwdriver-executor-k8s": "^1.0.10",
     "screwdriver-hashr": "^1.0.30"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -39,12 +39,11 @@ describe('Build Model', () => {
         };
         executorFactoryStub.prototype = executorMock;
         mockery.registerMock('screwdriver-hashr', hashaMock);
-        mockery.registerMock('screwdriver-executor-k8s', executorFactoryStub);
 
         // eslint-disable-next-line global-require
         BuildModel = require('../../lib/build');
 
-        build = new BuildModel(datastore);
+        build = new BuildModel(datastore, executorMock);
     });
 
     afterEach(() => {


### PR DESCRIPTION
With the recent crash regarding `vogels`, should we allow the datastore interface to support promises as well?
