### PR TITLE
Ensuring that sync will return null when the pipeline does not exist

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -54,9 +54,12 @@ class PipelineModel extends BaseModel {
     sync(config, callback) {
         const pipelineId = hashr.sha1(config.scmUrl);
 
-        this.get(pipelineId, (error) => {
+        this.get(pipelineId, (error, data) => {
             if (error) {
                 return callback(error);
+            }
+            if (!data) {
+                return callback(null, null);
             }
 
             const jobModel = new JobModel(this.datastore);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -118,7 +118,9 @@ describe('Pipeline Model', () => {
         it('creates the main job if pipeline exists', (done) => {
             hashaMock.sha1.withArgs(`${scmUrl}`).returns(pipelineId);
             hashaMock.sha1.withArgs(`${pipelineId}${jobName}`).returns(jobId);
-            datastore.get.yieldsAsync(null);
+            datastore.get.yieldsAsync(null, {
+                id: pipelineId
+            });
             datastore.save.yieldsAsync(null);
             pipeline.sync({ scmUrl }, () => {
                 assert.calledWith(datastore.save, {
@@ -137,12 +139,21 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('returns error if pipeline does not exist', (done) => {
+        it('returns error if datastore explodes', (done) => {
             const err = new Error('blah');
 
             datastore.get.yieldsAsync(err);
             pipeline.sync({ scmUrl }, (error) => {
                 assert.isOk(error);
+                done();
+            });
+        });
+
+        it('returns null if pipeline does not exist', (done) => {
+            datastore.get.yieldsAsync(null, null);
+            pipeline.sync({ scmUrl }, (error, data) => {
+                assert.isNull(error);
+                assert.isNull(data);
                 done();
             });
         });


### PR DESCRIPTION
This seems like a strange problem to have.  I expected the datastore to throw an error, instead it just returns null.
