### PR TITLE
Exposing the generateId function and consuming the keys from data-schema

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1,14 +1,34 @@
 'use strict';
+const schema = require('screwdriver-data-schema');
+const hashr = require('screwdriver-hashr');
 
 class BaseModel {
-
     /**
      * Construct a BaseModel object
      * @method constructor
+     * @param  {String}    modelName         Name of the model to get from data-schema
      * @param  {Object}    datastore         Object that will perform operations on the datastore
      */
-    constructor(datastore) {
+    constructor(modelName, datastore) {
+        this.model = schema.models[modelName];
+        this.table = this.model.tableName;
         this.datastore = datastore;
+    }
+
+    /**
+     * Generate the id for the model
+     * @method generateId
+     * @param  {Object}   config Object to generate a hashed ID for
+     * @return {String}          SHA1 unique ID
+     */
+    generateId(config) {
+        const hashObject = {};
+
+        this.model.keys.forEach((keyName) => {
+            hashObject[keyName] = config[keyName];
+        });
+
+        return hashr.sha1(hashObject);
     }
 
     /**

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,6 +1,5 @@
 'use strict';
 const async = require('async');
-const hashr = require('screwdriver-hashr');
 const hoek = require('hoek');
 const BaseModel = require('./base');
 const PipelineModel = require('./pipeline');
@@ -57,9 +56,8 @@ class BuildModel extends BaseModel {
      * @param  {Object}    executor          Object that will perform executor operations
      */
     constructor(datastore, executor) {
-        super(datastore);
+        super('build', datastore);
         this.executor = executor;
-        this.table = 'builds';
     }
 
     /**
@@ -74,7 +72,7 @@ class BuildModel extends BaseModel {
         const container = config.container || 'node:4';
         const jobId = config.jobId;
         const now = Date.now();
-        const id = hashr.sha1({
+        const id = this.generateId({
             jobId,
             number: now
         });

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,5 +1,4 @@
 'use strict';
-const hashr = require('screwdriver-hashr');
 const BaseModel = require('./base');
 
 class JobModel extends BaseModel {
@@ -9,8 +8,7 @@ class JobModel extends BaseModel {
      * @param  {Object}    datastore         Object that will perform operations on the datastore
      */
     constructor(datastore) {
-        super(datastore);
-        this.table = 'jobs';
+        super('job', datastore);
     }
 
     /**
@@ -23,7 +21,7 @@ class JobModel extends BaseModel {
     create(config, callback) {
         const pipelineId = config.pipelineId;
         const name = config.name;
-        const id = hashr.sha1(`${pipelineId}${name}`);
+        const id = this.generateId(config);
         const jobConfig = {
             table: this.table,
             params: {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,5 +1,4 @@
 'use strict';
-const hashr = require('screwdriver-hashr');
 const hoek = require('hoek');
 const BaseModel = require('./base');
 const JobModel = require('./job');
@@ -11,8 +10,7 @@ class PipelineModel extends BaseModel {
      * @param  {Object}    datastore         Object that will perform operations on the datastore
      */
     constructor(datastore) {
-        super(datastore);
-        this.table = 'pipelines';
+        super('pipeline', datastore);
     }
 
     /**
@@ -24,7 +22,7 @@ class PipelineModel extends BaseModel {
      * @param  {Function} callback              fn(err, data) where data is the newly created object
      */
     create(config, callback) {
-        const id = hashr.sha1(config.scmUrl);
+        const id = this.generateId(config);
         const createTime = Date.now();
         const platform = 'generic@1';
         const data = hoek.applyToDefaults({
@@ -52,7 +50,7 @@ class PipelineModel extends BaseModel {
      */
     // TODO: make this so that it looks up the yaml & create/delete jobs if necessary
     sync(config, callback) {
-        const pipelineId = hashr.sha1(config.scmUrl);
+        const pipelineId = this.generateId(config);
 
         this.get(pipelineId, (error, data) => {
             if (error) {

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,5 +1,4 @@
 'use strict';
-const hashr = require('screwdriver-hashr');
 const BaseModel = require('./base');
 
 class PlatformModel extends BaseModel {
@@ -9,8 +8,7 @@ class PlatformModel extends BaseModel {
      * @param  {Object}    datastore         Object that will perform operations on the datastore
      */
     constructor(datastore) {
-        super(datastore);
-        this.table = 'platforms';
+        super('platform', datastore);
     }
 
     /**
@@ -22,10 +20,7 @@ class PlatformModel extends BaseModel {
      * @param  {Function} callback              fn(err, data) where data is the newly created object
      */
     create(config, callback) {
-        const id = hashr.sha1({
-            name: config.name,
-            version: config.version
-        });
+        const id = this.generateId(config);
         const platformConfig = {
             table: this.table,
             params: {

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,5 +1,4 @@
 'use strict';
-const hashr = require('screwdriver-hashr');
 const BaseModel = require('./base');
 
 class UserModel extends BaseModel {
@@ -9,8 +8,7 @@ class UserModel extends BaseModel {
      * @param  {Object}    datastore         Object that will perform operations on the datastore
      */
     constructor(datastore) {
-        super(datastore);
-        this.table = 'users';
+        super('user', datastore);
     }
 
     /**
@@ -22,7 +20,7 @@ class UserModel extends BaseModel {
      * @param  {Function} callback              fn(err, data) where data is the new object created
      */
     create(config, callback) {
-        const id = hashr.sha1(config.username);
+        const id = this.generateId(config);
         const userConfig = {
             table: this.table,
             params: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {
@@ -42,6 +42,7 @@
   "dependencies": {
     "async": "^2.0.0-rc.6",
     "hoek": "^4.0.1",
+    "screwdriver-data-schema": "^5.0.4",
     "screwdriver-hashr": "^1.0.30"
   }
 }

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -8,6 +8,8 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('Base Model', () => {
     let BaseModel;
     let datastore;
+    let modelMock;
+    let hashaMock;
     let base;
     const baseData = {
         id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
@@ -32,10 +34,24 @@ describe('Base Model', () => {
             update: sinon.stub()
         };
 
+        modelMock = {
+            models: {
+                base: {
+                    tableName: 'base',
+                    keys: ['foo', 'bar']
+                }
+            }
+        };
+        hashaMock = {
+            sha1: sinon.stub()
+        };
+        mockery.registerMock('screwdriver-hashr', hashaMock);
+        mockery.registerMock('screwdriver-data-schema', modelMock);
+
         // eslint-disable-next-line global-require
         BaseModel = require('../../lib/base');
 
-        base = new BaseModel(datastore);
+        base = new BaseModel('base', datastore);
     });
 
     afterEach(() => {
@@ -46,6 +62,20 @@ describe('Base Model', () => {
 
     after(() => {
         mockery.disable();
+    });
+
+    describe('generateId', () => {
+        it('generates a fancy ID', () => {
+            hashaMock.sha1.withArgs({
+                foo: '1234',
+                bar: '2345'
+            }).returns('OK');
+            assert.equal(base.generateId({
+                foo: '1234',
+                bar: '2345',
+                zap: '4444'
+            }), 'OK');
+        });
     });
 
     describe('get', () => {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -74,7 +74,9 @@ describe('Job Model', () => {
                 name
             }, (err) => {
                 assert.isNull(err);
-                assert.calledWith(hashaMock.sha1, `${pipelineId}${name}`);
+                assert.calledWith(hashaMock.sha1, {
+                    pipelineId, name
+                });
                 assert.calledWith(datastore.save, saveConfig);
                 done();
             });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -62,7 +62,9 @@ describe('Pipeline Model', () => {
             sandbox = sinon.sandbox.create({
                 useFakeTimers: false
             });
-            hashaMock.sha1.withArgs(scmUrl).returns(testId);
+            hashaMock.sha1.withArgs({
+                scmUrl
+            }).returns(testId);
 
             config = {
                 table: 'pipelines',
@@ -116,8 +118,13 @@ describe('Pipeline Model', () => {
         const jobName = 'main';
 
         it('creates the main job if pipeline exists', (done) => {
-            hashaMock.sha1.withArgs(`${scmUrl}`).returns(pipelineId);
-            hashaMock.sha1.withArgs(`${pipelineId}${jobName}`).returns(jobId);
+            hashaMock.sha1.withArgs({
+                scmUrl
+            }).returns(pipelineId);
+            hashaMock.sha1.withArgs({
+                pipelineId,
+                name: jobName
+            }).returns(jobId);
             datastore.get.yieldsAsync(null, {
                 id: pipelineId
             });
@@ -134,7 +141,10 @@ describe('Pipeline Model', () => {
                         }
                     }
                 });
-                assert.calledWith(hashaMock.sha1, `${pipelineId}main`);
+                assert.calledWith(hashaMock.sha1, {
+                    pipelineId,
+                    name: 'main'
+                });
                 done();
             });
         });

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -56,7 +56,7 @@ describe('User Model', () => {
         const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
 
         beforeEach(() => {
-            hashaMock.sha1.withArgs(username).returns(testId);
+            hashaMock.sha1.withArgs({ username }).returns(testId);
 
             config = {
                 username: 'me',


### PR DESCRIPTION
Kinda significant refactoring.  Broke all the hashes (hence the major version bump).

We are now using the `tableName` and the `keys` from the `data-schema` module.
