### PR TITLE
Getting builds by job id

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -48,23 +48,25 @@ class BaseModel {
     }
 
     /**
-     * List records with pagination
-     * @param  {Object}   paginate           Config object
-     * @param  {Number}   paginate.count     Number of items per page
-     * @param  {Number}   paginate.page      Specific page of the set to return
-     * @return {Function} callback           fn(err, result) where result is an array of records
+     * List records with pagination and filter options
+     * @param  {Object}   config                  Config object
+     * @param  {Object}   config.params           Parameters to filter on
+     * @param  {Object}   config.paginate         Pagination parameters
+     * @param  {Number}   config.paginate.count   Number of items per page
+     * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @return {Function} callback                fn(err, result) where result is an array of records
      */
-    list(paginate, callback) {
-        const config = {
+    list(config, callback) {
+        const scanConfig = {
             table: this.table,
-            params: {},
+            params: config.params || {},
             paginate: {
-                count: paginate.count,
-                page: paginate.page
+                count: config.paginate.count,
+                page: config.paginate.page
             }
         };
 
-        return this.datastore.scan(config, callback);
+        return this.datastore.scan(scanConfig, callback);
     }
 
     /**

--- a/lib/build.js
+++ b/lib/build.js
@@ -121,6 +121,34 @@ class BuildModel extends BaseModel {
     }
 
     /**
+     * Gets all the builds for a jobId
+     * @method getBuildsForJobId
+     * @param  {Object}   config                Config object
+     * @param  {String}   config.jobId          The jobId of the build to filter for
+     * @param  {Function} callback         The callback object to return the stream to
+     */
+    getBuildsForJobId(config, callback) {
+        const listConfig = {
+            params: {
+                jobId: config.jobId
+            },
+            paginate: {
+                count: 25, // This limit is set by the matrix restriction
+                page: 1
+            }
+        };
+
+        this.list(listConfig, (err, records) => {
+            if (err) {
+                return callback(err);
+            }
+            records.sort((build1, build2) => build1.number - build2.number);
+
+            return callback(null, records);
+        });
+    }
+
+    /**
      * Stream a build
      * @method stream
      * @param  {Object}   config           Config object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -108,7 +108,7 @@ describe('Base Model', () => {
             ];
 
             datastore.scan.yieldsAsync(null, returnValue);
-            base.list(paginate, (err, data) => {
+            base.list({ paginate }, (err, data) => {
                 assert.isNull(err);
                 assert.deepEqual(data, returnValue);
                 done();


### PR DESCRIPTION
This PR is adding in a function to the build model that will get all builds for a given job Id

This is needed for webhooks.

This PR also changes the contract for the `base.list` function which is why the versions is bumped

This PR also depends on https://github.com/screwdriver-cd/datastore-dynamodb/pull/11
