### PR TITLE
Get github permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ create(config, callback)
 | Parameter        | Type  | Required  |  Description |
 | :-------------   | :---- | :---- | :-------------|
 | config        | Object | Yes | Configuration Object |
+| config.admins | Array | Yes | Array of admins for this pipeline |
 | config.scmUrl | String | Yes | Source Code URL for the application |
 | config.configUrl | String | No | Source Code URL for Screwdriver configuration |
 | callback | Function | Yes | Callback function fn(err, data) where data is the new pipeline that is created |
@@ -386,6 +387,20 @@ unsealToken(sealed, callback)
 | :-------------   | :---- | :-------------|
 | sealed | String | The token to unseal |
 | callback | Function | Callback function fn(err, unsealed) where unsealed is the unsealed token |
+
+
+#### Get User's Permissions For a Repo
+Get user's permissions for a specific repo
+```
+getPermissions(config, callback)
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config | Object | Configuration object |
+| config.username | String | Username |
+| config.scmUrl | String | The scmUrl of the repo |
+| callback | Function | Callback function fn(err, permissions) where permissions is an object that includes the following keys: admin, pull, push with boolean values |
 
 ## Testing
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -17,7 +17,7 @@ class PipelineModel extends BaseModel {
      * Create a pipeline
      * @method create
      * @param  {Object}   config                Config object to create the pipeline with
-     * @param  {Object}   config.owners         The owners of this repository
+     * @param  {Object}   config.admins         The admins of this repository
      * @param  {String}   config.scmUrl         The scmUrl for the application
      * @param  {String}   [config.configUrl]    The configUrl for the application
      * @param  {Function} callback              fn(err, data) where data is the newly created object

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -17,6 +17,7 @@ class PipelineModel extends BaseModel {
      * Create a pipeline
      * @method create
      * @param  {Object}   config                Config object to create the pipeline with
+     * @param  {Object}   config.owners         The owners of this repository
      * @param  {String}   config.scmUrl         The scmUrl for the application
      * @param  {String}   [config.configUrl]    The configUrl for the application
      * @param  {Function} callback              fn(err, data) where data is the newly created object

--- a/lib/user.js
+++ b/lib/user.js
@@ -2,7 +2,8 @@
 const BaseModel = require('./base');
 const iron = require('iron');
 const async = require('async');
-const github = require('github');
+const Github = require('github');
+const schema = require('screwdriver-data-schema');
 
 class UserModel extends BaseModel {
     /**
@@ -65,6 +66,7 @@ class UserModel extends BaseModel {
      */
     getPermissions(config, callback) {
         const id = this.generateId({ username: config.username });
+        const github = new Github();
 
         async.waterfall([
             (next) => {
@@ -74,7 +76,7 @@ class UserModel extends BaseModel {
                 this.unsealToken(user.token, next);
             },
             (unsealed, next) => {
-                const matched = config.scmUrl.match(/^git@([^:]+):([^\/]+)\/(.+?)\.git(\/.+)?$/);
+                const matched = (schema.config.regex.SCM_URL).exec(config.scmUrl);
 
                 github.authenticate({
                     type: 'oauth',

--- a/lib/user.js
+++ b/lib/user.js
@@ -4,8 +4,29 @@ const iron = require('iron');
 const async = require('async');
 const Github = require('github');
 const schema = require('screwdriver-data-schema');
+const Breaker = require('circuit-fuses');
+const github = new Github();
+
+/**
+ * Github command to run
+ * @param  {Object}   options            An object that tells what command & params to run
+ * @param  {String}   options.token      Github token
+ * @param  {String}   options.action     Github method. For example: get
+ * @param  {Object}   options.params     Parameters to run with
+ * @param  {Function} callback           Callback function from github API
+ */
+function githubCommand(options, callback) {
+    github.authenticate({
+        type: 'oauth',
+        token: options.token
+    });
+    github.repos[options.action](options.params, callback);
+}
+
+const githubBreaker = new Breaker(githubCommand);
 
 class UserModel extends BaseModel {
+
     /**
      * Construct a UserModel object
      * @method constructor
@@ -66,7 +87,6 @@ class UserModel extends BaseModel {
      */
     getPermissions(config, callback) {
         const id = this.generateId({ username: config.username });
-        const github = new Github();
 
         async.waterfall([
             (next) => {
@@ -78,13 +98,13 @@ class UserModel extends BaseModel {
             (unsealed, next) => {
                 const matched = (schema.config.regex.SCM_URL).exec(config.scmUrl);
 
-                github.authenticate({
-                    type: 'oauth',
-                    token: unsealed
-                });
-                github.repos.get({
-                    user: matched[2],
-                    repo: matched[3]
+                githubBreaker.runCommand({
+                    token: unsealed,
+                    action: 'get',
+                    params: {
+                        user: matched[2],
+                        repo: matched[3]
+                    }
                 }, next);
             }
         ], (err, repo) => {

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,6 +1,8 @@
 'use strict';
 const BaseModel = require('./base');
 const iron = require('iron');
+const async = require('async');
+const github = require('github');
 
 class UserModel extends BaseModel {
     /**
@@ -51,6 +53,45 @@ class UserModel extends BaseModel {
      */
     unsealToken(sealed, callback) {
         return iron.unseal(sealed, this.password, iron.defaults, callback);
+    }
+
+    /**
+     * Get permissions on a specific repo
+     * @param  {String}  config.username        Username
+     * @param  {String}  config.scmUrl          The scmUrl of the repository
+     * @return {Function} callback              fn(err, permissions) where permissions is an object
+     *                                          that contains the permissions for [admin, push, pull]
+     *                                          Example: {admin: false, push: true, pull: true}
+     */
+    getPermissions(config, callback) {
+        const id = this.generateId({ username: config.username });
+
+        async.waterfall([
+            (next) => {
+                this.get(id, next);
+            },
+            (user, next) => {
+                this.unsealToken(user.token, next);
+            },
+            (unsealed, next) => {
+                const matched = config.scmUrl.match(/^git@([^:]+):([^\/]+)\/(.+?)\.git(\/.+)?$/);
+
+                github.authenticate({
+                    type: 'oauth',
+                    token: unsealed
+                });
+                github.repos.get({
+                    user: matched[2],
+                    repo: matched[3]
+                }, next);
+            }
+        ], (err, repo) => {
+            if (err) {
+                return callback(err);
+            }
+
+            return callback(null, repo.permissions);
+        });
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
-    "async": "^2.0.0",
+    "async": "^2.0.1",
+    "github": "^2.3.0",
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-data-schema": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,13 @@
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",
     "jenkins-mocha": "^2.6.0",
+    "joi": "^9.0.4",
     "mockery": "^1.7.0",
     "sinon": "^1.17.4"
   },
   "dependencies": {
     "async": "^2.0.1",
+    "circuit-fuses": "^1.0.0",
     "github": "^2.3.0",
     "hoek": "^4.0.1",
     "iron": "^4.0.1",

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -56,6 +56,7 @@ describe('Pipeline Model', () => {
         const dateNow = 1111111111;
         const scmUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
         const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+        const admins = ['me'];
 
         beforeEach(() => {
             sandbox = sinon.sandbox.create({
@@ -70,6 +71,7 @@ describe('Pipeline Model', () => {
                 params: {
                     id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
                     data: {
+                        admins,
                         createTime: dateNow,
                         scmUrl,
                         configUrl: scmUrl
@@ -87,7 +89,7 @@ describe('Pipeline Model', () => {
 
             datastore.save.yieldsAsync(testError);
 
-            pipeline.create({ scmUrl }, (error) => {
+            pipeline.create({ scmUrl, admins }, (error) => {
                 assert.isOk(error);
                 assert.equal(error.message, 'datastoreSaveError');
                 done();
@@ -98,7 +100,7 @@ describe('Pipeline Model', () => {
             sandbox.useFakeTimers(dateNow);
             datastore.save.yieldsAsync(null);
 
-            pipeline.create({ scmUrl }, () => {
+            pipeline.create({ scmUrl, admins }, () => {
                 assert.calledWith(datastore.save, config);
                 done();
             });


### PR DESCRIPTION
This PR does 2 things:

1) Add a method to get the user's permissions of a specific repository. This takes in a config object:
`{ username: 'd2lam', scmUrl: 'git@github.com:screwdriver-cd/models.git'}` and returns the permissions:  `{admin: true, push: true, pull: true}`

2) Add admins field for pipeline create. This will be passed in from the api when calling pipeline.create

Waiting on https://github.com/screwdriver-cd/data-schema/pull/16
