### PR TITLE
Create github status when the build starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ update(config, callback)
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const Build = new Model.Build(datastore, executor);
+const Build = new Model.Build(datastore, executor, password);
 const config = {
     page: 2,
     count: 3

--- a/lib/base.js
+++ b/lib/base.js
@@ -33,6 +33,7 @@ class BaseModel {
 
     /**
      * Get a record based on id
+     * @method get
      * @param  {String}   id                The id of the record to retrieve
      * @return {Function} callback          fn(err, result) where result is the record with the specific id
      */
@@ -49,6 +50,7 @@ class BaseModel {
 
     /**
      * List records with pagination and filter options
+     * @method list
      * @param  {Object}   config                  Config object
      * @param  {Object}   config.params           Parameters to filter on
      * @param  {Object}   config.paginate         Pagination parameters
@@ -71,6 +73,7 @@ class BaseModel {
 
     /**
      * Update a record
+     * @method update
      * @param  {Object}    config         Config object
      * @param  {String}    config.id      The id of the record to retrieve
      * @param  {Object}    config.data    The new data object to update with

--- a/lib/build.js
+++ b/lib/build.js
@@ -4,10 +4,11 @@ const hoek = require('hoek');
 const BaseModel = require('./base');
 const PipelineModel = require('./pipeline');
 const JobModel = require('./job');
+const UserModel = require('./user');
+const githubHelper = require('./github');
 
 /**
  * Given a Job ID, look up the associated Pipeline ID
- *
  * @method fetchJob
  * @param  {Object}        datastore The datastore object that can retrieve the data from the datastore
  * @param  {String}        jobId     The ID of the job to look at
@@ -21,7 +22,6 @@ function fetchJob(datastore, jobId, callback) {
 
 /**
  * Given a Pipeline ID, look up the associated SCM Url
- *
  * @method fetchScmUrl
  * @param  {Object}    datastore          The datastore object that can retrieve the data from the datastore
  * @param  {Object}    params             An object
@@ -54,23 +54,29 @@ class BuildModel extends BaseModel {
      * @method constructor
      * @param  {Object}    datastore         Object that will perform operations on the datastore
      * @param  {Object}    executor          Object that will perform executor operations
+     * @param  {String}    password          Login password
      */
-    constructor(datastore, executor) {
+    constructor(datastore, executor, password) {
         super('build', datastore);
         this.executor = executor;
+        this.password = password;
+        this.user = new UserModel(datastore, password);
     }
 
     /**
      * Create & start a new build
      * @method create
      * @param  {Object}   config                Config object
+     * @param  {String}   config.username       Username
      * @param  {String}   config.jobId          The ID of the associated job to start
+     * @param  {String}   config.sha            The sha of the build
      * @param  {String}   [config.container]    The kind of container to use
      * @param  {Function} callback              fn(err, data) where data is the newly created object
      */
     create(config, callback) {
         const container = config.container || 'node:4';
         const jobId = config.jobId;
+        const sha = config.sha;
         const now = Date.now();
         const id = this.generateId({
             jobId,
@@ -82,8 +88,10 @@ class BuildModel extends BaseModel {
             jobId,
             createTime: now,
             number: now,
-            status: 'QUEUED'
+            status: 'QUEUED',
+            sha
         };
+        let repoInfo;
 
         async.waterfall([
             (next) => {
@@ -98,26 +106,39 @@ class BuildModel extends BaseModel {
                 });
             },
             async.apply(fetchJob, this.datastore, jobId),
-            async.apply(fetchScmUrl, this.datastore)
-        ], (err, data) => {
+            async.apply(fetchScmUrl, this.datastore),
+            (data, next) => {
+                repoInfo = githubHelper.getInfo(data.scmUrl);
+                this.executor.start({
+                    buildId: id,
+                    container,
+                    jobId,
+                    jobName: data.jobName,
+                    pipelineId: data.pipelineId,
+                    scmUrl: data.scmUrl
+                }, next);
+            },
+            (next) => {
+                // Create github status
+                githubHelper.run({
+                    user: this.user,
+                    username: config.username,
+                    action: 'createStatus',
+                    params: {
+                        user: repoInfo.user,
+                        repo: repoInfo.repo,
+                        sha,
+                        state: 'pending',
+                        context: 'screwdriver'
+                    }
+                }, next);
+            }
+        ], (err) => {
             if (err) {
                 return callback(err);
             }
 
-            return this.executor.start({
-                buildId: id,
-                container,
-                jobId,
-                jobName: data.jobName,
-                pipelineId: data.pipelineId,
-                scmUrl: data.scmUrl
-            }, (executorErr) => {
-                if (executorErr) {
-                    return callback(executorErr);
-                }
-
-                return callback(null, hoek.applyToDefaults({ id }, initialBuildData));
-            });
+            return callback(null, hoek.applyToDefaults({ id }, initialBuildData));
         });
     }
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,0 +1,88 @@
+'use strict';
+const async = require('async');
+const Breaker = require('circuit-fuses');
+const schema = require('screwdriver-data-schema');
+const Github = require('github');
+const github = new Github();
+let cached = null;
+
+/**
+ * Github command to run
+ * @method githubCommand
+ * @param  {Object}   options            An object that tells what command & params to run
+ * @param  {String}   options.action     Github method. For example: get
+ * @param  {Object}   options.params     Parameters to run with
+ * @param  {Function} callback           Callback function from github API
+ */
+function githubCommand(options, callback) {
+    github.repos[options.action](options.params, callback);
+}
+
+/**
+ * Get the circuit breaker
+ * @method getBreaker
+ * @return {Breaker}        The circuit breaker
+ */
+function getBreaker() {
+    if (!cached) {
+        cached = new Breaker(githubCommand);
+    }
+
+    return cached;
+}
+
+/**
+ * Get repo information
+ * @method getInfo
+ * @param  {String} scmUrl      scmUrl of the repo
+ * @return {Object}             An object with the user, repo, and branch
+ */
+function getInfo(scmUrl) {
+    const matched = (schema.config.regex.SCM_URL).exec(scmUrl);
+
+    return {
+        user: matched[2],
+        repo: matched[3],
+        branch: matched[4].slice(1)
+    };
+}
+
+/**
+ * Run command. This first gets the user, then unseal the user's token and call the github command
+ * @method run
+ * @param  {Object}   config            Configuration object
+ * @param  {Model}    config.user       User Model
+ * @param  {String}   config.username   Username to authenticate
+ * @param  {String}   config.action     Method to invoke. For example: get, createStatus
+ * @param  [Object]   config.params     Params to pass into the github command
+ * @param  {Function} callback          Callback function that is returned from calling the github command
+ */
+function run(config, callback) {
+    const user = config.user;
+    const userId = user.generateId({ username: config.username });
+    const githubBreaker = getBreaker();
+
+    async.waterfall([
+        (next) => {
+            user.get(userId, next);
+        },
+        (result, next) => {
+            user.unsealToken(result.token, next);
+        },
+        (unsealed, next) => {
+            github.authenticate({
+                type: 'oauth',
+                token: unsealed
+            });
+            githubBreaker.runCommand({
+                action: config.action,
+                params: config.params || {}
+            }, next);
+        }
+    ], callback);
+}
+module.exports = {
+    getBreaker,
+    getInfo,
+    run
+};

--- a/lib/job.js
+++ b/lib/job.js
@@ -13,6 +13,7 @@ class JobModel extends BaseModel {
 
     /**
      * Create a job
+     * @method create
      * @param  {Object}    config               Config object
      * @param  {String}    config.pipelineId    The pipeline that the job belongs to
      * @param  {String}    config.name          The job name

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -43,6 +43,7 @@ class PipelineModel extends BaseModel {
     /**
      * Sync the pipeline by looking up what is currently in yaml and create or delete
      * jobs if necessary. Right now, this simply creates the job 'main'.
+     * @method sync
      * @param  {Object}   config           Config object to create the pipeline with
      * @param  {String}   config.scmUrl    The scmUrl of the repository
      * @param  {Function} callback         Callback function

--- a/lib/user.js
+++ b/lib/user.js
@@ -9,6 +9,7 @@ const github = new Github();
 
 /**
  * Github command to run
+ * @method githubCommand
  * @param  {Object}   options            An object that tells what command & params to run
  * @param  {String}   options.token      Github token
  * @param  {String}   options.action     Github method. For example: get
@@ -61,6 +62,7 @@ class UserModel extends BaseModel {
 
     /**
      * Seal token
+     * @method sealToken
      * @param  {String}   token      User's github token
      * @param  {Function} callback   fn(err, sealed) where sealed is the sealed token
      */
@@ -70,6 +72,7 @@ class UserModel extends BaseModel {
 
     /**
      * Unseal token
+     * @method unsealToken
      * @param  {String}   sealed      Sealed token
      * @param  {Function} callback    fn(err, unsealed) where unsealed is the unsealed token
      */
@@ -79,6 +82,7 @@ class UserModel extends BaseModel {
 
     /**
      * Get permissions on a specific repo
+     * @method getPermissions
      * @param  {String}  config.username        Username
      * @param  {String}  config.scmUrl          The scmUrl of the repository
      * @return {Function} callback              fn(err, permissions) where permissions is an object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {

--- a/test/lib/github.test.js
+++ b/test/lib/github.test.js
@@ -1,0 +1,220 @@
+'use strict';
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Github', () => {
+    const scmUrl = 'git@github.com:screwdriver-cd/data-schema.git#master';
+    let schemaMock;
+    let userMock;
+    let breakerMock;
+    let github;
+    let githubMock;
+
+    /**
+     * Stub for Breaker factory method
+     */
+    function BreakerFactory() {}
+
+    /**
+     * Stub for Github factory method
+     */
+    function GithubFactory() {}
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        schemaMock = {
+            config: {
+                regex: {
+                    SCM_URL: /^git@([^:]+):([^\/]+)\/(.+?)\.git(#.+)?$/
+                }
+            }
+        };
+        userMock = {
+            get: sinon.stub(),
+            unsealToken: sinon.stub(),
+            generateId: sinon.stub()
+        };
+        githubMock = {
+            authenticate: sinon.stub(),
+            repos: {
+                get: sinon.stub()
+            }
+        };
+        breakerMock = {
+            runCommand: sinon.stub()
+        };
+        mockery.registerMock('screwdriver-data-schema', schemaMock);
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('getInfo returns the correct info', () => {
+        // eslint-disable-next-line global-require
+        github = require('../../lib/github');
+        const matched = github.getInfo(scmUrl);
+
+        assert.deepEqual(matched, {
+            user: 'screwdriver-cd',
+            repo: 'data-schema',
+            branch: 'master'
+        });
+    });
+
+    describe('getBreaker', () => {
+        beforeEach(() => {
+            BreakerFactory.prototype.runCommand = breakerMock.runCommand;
+            mockery.registerMock('circuit-fuses', BreakerFactory);
+
+            // eslint-disable-next-line global-require
+            github = require('../../lib/github');
+        });
+
+        it('getBreaker returns cached', () => {
+            const breaker1 = github.getBreaker();
+            const breaker2 = github.getBreaker();
+
+            assert.deepEqual(breaker1, breaker2);
+        });
+    });
+
+    describe('run with Mocked Breaker', () => {
+        const id = '4b8d9b530d2e5e297b4f470d5b0a6e1310d29c5e';
+        const username = 'myself';
+        const token = 'sealedToken';
+        let config;
+        let userData;
+
+        beforeEach(() => {
+            BreakerFactory.prototype.runCommand = breakerMock.runCommand;
+            mockery.registerMock('circuit-fuses', BreakerFactory);
+
+            // eslint-disable-next-line global-require
+            github = require('../../lib/github');
+            config = {
+                user: userMock,
+                username,
+                action: 'get',
+                params: {
+
+                }
+            };
+            userData = {
+                id,
+                username,
+                token
+            };
+        });
+
+        it('returns error if fails to get user', (done) => {
+            const err = new Error('getUserError');
+
+            userMock.generateId.withArgs({ username: config.username }).returns(id);
+            userMock.get.withArgs(id).yieldsAsync(err);
+            github.run(config, (error) => {
+                assert.isOk(error);
+                done();
+            });
+        });
+
+        it('returns error if fails to unseal token', (done) => {
+            const err = new Error('unsealTokenError');
+
+            userMock.generateId.withArgs({ username: config.username }).returns(id);
+            userMock.get.withArgs(id).yieldsAsync(null, userData);
+            userMock.unsealToken.withArgs(token).yieldsAsync(err);
+            github.run(config, (error) => {
+                assert.isOk(error);
+                done();
+            });
+        });
+
+        it('returns error if fails to run command', (done) => {
+            const err = new Error('breakerError');
+
+            userMock.generateId.withArgs({ username: config.username }).returns(id);
+            userMock.get.withArgs(id).yieldsAsync(null, userData);
+            userMock.unsealToken.withArgs(token).yieldsAsync(null, 'unsealedToken');
+            breakerMock.runCommand.withArgs({
+                action: 'get',
+                params: {}
+            }).yieldsAsync(err);
+            github.run(config, (error) => {
+                assert.isOk(error);
+                done();
+            });
+        });
+
+        it('returns correct response', (done) => {
+            const response = { message: 'some response from github' };
+
+            userMock.generateId.withArgs({ username: config.username }).returns(id);
+            userMock.get.withArgs(id).yieldsAsync(null, userData);
+            userMock.unsealToken.withArgs(token).yieldsAsync(null, 'unsealedToken');
+            breakerMock.runCommand.yieldsAsync(null, response);
+            github.run(config, (error, res) => {
+                assert.isNull(error);
+                assert.deepEqual(res, response);
+                done();
+            });
+        });
+    });
+
+    describe('run without Mocked Breaker', () => {
+        const id = '4b8d9b530d2e5e297b4f470d5b0a6e1310d29c5e';
+        const username = 'myself';
+        const token = 'sealedToken';
+        let config;
+        let userData;
+
+        beforeEach(() => {
+            GithubFactory.prototype = githubMock;
+            mockery.registerMock('github', GithubFactory);
+
+            // eslint-disable-next-line global-require
+            github = require('../../lib/github');
+            config = {
+                user: userMock,
+                username,
+                action: 'get',
+                params: {
+                    user: 'myself'
+                }
+            };
+            userData = {
+                id,
+                username,
+                token
+            };
+        });
+
+        it('calls github function correctly', (done) => {
+            userMock.generateId.withArgs({ username: config.username }).returns(id);
+            userMock.get.withArgs(id).yieldsAsync(null, userData);
+            userMock.unsealToken.withArgs(token).yieldsAsync(null, 'unsealedToken');
+            githubMock.repos.get.yieldsAsync(null, {});
+            githubMock.authenticate.returns();
+            github.run(config, (error, res) => {
+                assert.calledWith(githubMock.repos.get, config.params);
+                assert.isNull(error);
+                assert.deepEqual(res, {});
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR creates a github status when a build starts.
- Build model now takes in a 3rd parameter `password`. This is because we need to create a User model inside the constructor so that we can pass that into githubHelper. We would need to change the api to pass it in, similar to this: https://github.com/screwdriver-cd/screwdriver/blob/master/bin/server#L39
- Build create now takes in 2 extra params: config.username and config.sha: https://github.com/screwdriver-cd/screwdriver/pull/66
- Github helper has the run command, which get the user, unseal the user's token, and call github command. 
