### PR TITLE
adding in build stop method

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -201,10 +201,21 @@ class BuildModel extends BaseModel {
      * @method stream
      * @param  {Object}   config           Config object
      * @param  {String}   config.buildId   The id of the build to stream
-     * @param  {Function} callback         The callback object to return the stream to
+     * @param  {Function} callback         The callback function to return the stream to
      */
     stream(config, callback) {
         return this.executor.stream(config, callback);
+    }
+
+    /**
+     * Stop a build
+     * @method stop
+     * @param  {Object}   config           Config object
+     * @param  {String}   config.buildId   The id of the build to stop
+     * @param  {Function} callback         The callback function
+     */
+    stop(config, callback) {
+        return this.executor.stop(config, callback);
     }
 }
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -46,7 +46,8 @@ describe('Build Model', () => {
         };
         executorMock = {
             start: sinon.stub(),
-            stream: sinon.stub()
+            stream: sinon.stub(),
+            stop: sinon.stub()
         };
         githubMock = {
             getBreaker: sinon.stub(),
@@ -94,6 +95,18 @@ describe('Build Model', () => {
             assert.calledWith(executorMock.stream, {
                 buildId
             }, streamStub);
+        });
+    });
+
+    describe('stop', () => {
+        it('calls executor stop with correct values', () => {
+            const stopStub = sinon.stub();
+            const buildId = 'as12345';
+
+            build.stop({ buildId }, stopStub);
+            assert.calledWith(executorMock.stop, {
+                buildId
+            }, stopStub);
         });
     });
 


### PR DESCRIPTION
This PR adds in a `stop` method to the build model for stopping a specific build

Dependent on: https://github.com/screwdriver-cd/executor-k8s/pull/27
