### PR TITLE
be explicit about the this arg for nodeify

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -47,7 +47,7 @@ class BaseModel {
             }
         };
 
-        return nodeify(this.datastore.get, config, callback);
+        return nodeify.withContext(this.datastore, 'get', [config], callback);
     }
 
     /**
@@ -71,7 +71,7 @@ class BaseModel {
             }
         };
 
-        return nodeify(this.datastore.scan, scanConfig, callback);
+        return nodeify.withContext(this.datastore, 'scan', [scanConfig], callback);
     }
 
     /**
@@ -92,7 +92,7 @@ class BaseModel {
             }
         };
 
-        return nodeify(this.datastore.update, datastoreConfig, callback);
+        return nodeify.withContext(this.datastore, 'update', [datastoreConfig], callback);
     }
 }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -110,25 +110,25 @@ class BuildModel extends BaseModel {
                 initialBuildData.sha = response.sha;
 
                 // Save build data to datastore
-                return nodeify(this.datastore.save, {
+                return nodeify.withContext(this.datastore, 'save', [{
                     table: this.table,
                     params: {
                         id,
                         data: initialBuildData
                     }
-                })
+                }])
                 .then(() => nodeify.success(response));
             })
             .then((response) =>
                 // Start the build
-                nodeify(this.executor.start, {
+                nodeify.withContext(this.executor, 'start', [{
                     buildId: id,
                     container,
                     jobId,
                     jobName: response.jobName,
                     pipelineId: response.pipelineId,
                     scmUrl: response.scmUrl
-                })
+                }])
                 .then(() => nodeify.success(response))
             )
             .then((response) =>
@@ -137,7 +137,7 @@ class BuildModel extends BaseModel {
             )
             .then((response) =>
                 // Create github status
-                nodeify(githubHelper.run, {
+                nodeify.withContext(githubHelper, 'run', [{
                     user: this.user,
                     username: response.admin,
                     action: 'createStatus',
@@ -148,7 +148,7 @@ class BuildModel extends BaseModel {
                         state: 'pending',
                         context: 'screwdriver'
                     }
-                })
+                }])
             )
             .then(() => nodeify.success(hoek.applyToDefaults({ id }, initialBuildData), callback))
             .catch((err) => nodeify.fail(err, callback));
@@ -191,7 +191,7 @@ class BuildModel extends BaseModel {
      * @return {Promise}                   If no callback is given, a Promise is returned
      */
     stream(config, callback) {
-        return nodeify(this.executor.stream, config, callback);
+        return nodeify.withContext(this.executor, 'stream', [config], callback);
     }
 
     /**

--- a/lib/job.js
+++ b/lib/job.js
@@ -37,7 +37,7 @@ class JobModel extends BaseModel {
             }
         };
 
-        return nodeify(this.datastore.save, jobConfig, callback);
+        return nodeify.withContext(this.datastore, 'save', [jobConfig], callback);
     }
 }
 

--- a/lib/nodeify.js
+++ b/lib/nodeify.js
@@ -1,7 +1,8 @@
 'use strict';
 
 /**
- * Determine whether to return a promise or use the callback
+ * Determine whether to return a promise or use the callback. Disregards context
+ * when invoking the given func
  * @method nodeify
  * @param  {Function}  func       The function to call
  * @param  {Object}    config     The parameters to pass to the function
@@ -36,6 +37,42 @@ function nodeify() {
         return func.apply(null, args);
     });
 }
+
+/**
+ * Invoke a particular function with a specific context for the "this" argument. It then
+ * determines whether to return a promise or use the callback
+ * @method withContext
+ * @param  {Object}   context       The context for the "this" argument
+ * @param  {String}   funcName      Function name to invoke on the context
+ * @param  {Array}   argumentsList  Argument list to pass to the function named by "funcName"
+ * @param  {Function} [callback]    Optional. Callback to invoke when func is completed.
+ * @return {Promise}                If no callback is provided, a Promise is returned.
+ */
+nodeify.withContext = (context, funcName, argumentsList, callback) => {
+    const func = context[funcName];
+    const args = argumentsList.slice();
+
+    if (typeof callback === 'function') {
+        args.push(callback);
+
+        // To allow thrown errors to _NOT_ be caught in the promise chain
+        return process.nextTick(() => func.apply(context, args));
+    }
+
+    return new Promise((resolve, reject) => {
+        const internalCallback = (err, data) => {
+            if (err) {
+                return reject(err);
+            }
+
+            return resolve(data);
+        };
+
+        args.push(internalCallback);
+
+        return func.apply(context, args);
+    });
+};
 
 /**
  * Handle a failure case either with a Promise or via callback

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -40,7 +40,7 @@ class PipelineModel extends BaseModel {
             }
         };
 
-        return nodeify(this.datastore.save, pipelineConfig, callback);
+        return nodeify.withContext(this.datastore, 'save', [pipelineConfig], callback);
     }
 
     /**

--- a/lib/user.js
+++ b/lib/user.js
@@ -58,7 +58,7 @@ class UserModel extends BaseModel {
             }
         };
 
-        return nodeify(this.datastore.save, userConfig, callback);
+        return nodeify.withContext(this.datastore, 'save', [userConfig], callback);
     }
 
     /**
@@ -69,7 +69,7 @@ class UserModel extends BaseModel {
      * @return {Promise}             If no callback is provided, a Promise is returned.
      */
     sealToken(token, callback) {
-        return nodeify(iron.seal, token, this.password, iron.defaults, callback);
+        return nodeify.withContext(iron, 'seal', [token, this.password, iron.defaults], callback);
     }
 
     /**
@@ -80,7 +80,8 @@ class UserModel extends BaseModel {
      * @return {Promise}              If no callback is provided, a Promise is returned.
      */
     unsealToken(sealed, callback) {
-        return nodeify(iron.unseal, sealed, this.password, iron.defaults, callback);
+        return nodeify.withContext(iron, 'unseal',
+            [sealed, this.password, iron.defaults], callback);
     }
 
     /**
@@ -101,14 +102,14 @@ class UserModel extends BaseModel {
             .then((unsealedToken) => {
                 const matched = (schema.config.regex.SCM_URL).exec(config.scmUrl);
 
-                return nodeify(githubBreaker.runCommand, {
+                return nodeify.withContext(githubBreaker, 'runCommand', [{
                     token: unsealedToken,
                     action: 'get',
                     params: {
                         user: matched[2],
                         repo: matched[3]
                     }
-                });
+                }]);
             })
             .then((repoData) => nodeify.success(repoData.permissions, callback))
             .catch((err) => nodeify.fail(err, callback));

--- a/test/lib/nodeify.test.js
+++ b/test/lib/nodeify.test.js
@@ -60,6 +60,39 @@ describe('nodeify', () => {
         });
     });
 
+    describe('withContext', () => {
+        const args = [
+            'firstArg',
+            'secondArg'
+        ];
+        let context;
+        const expectedData = 'theDataReturnedFromMagicalMethod';
+
+        beforeEach(() => {
+            context = {
+                magicalMethod: sinon.stub()
+            };
+
+            context.magicalMethod.yieldsAsync(null, expectedData);
+        });
+
+        it('invokes the function with context', (done) => {
+            nodeify.withContext(context, 'magicalMethod', args, (err, data) => {
+                assert.isNull(err);
+                assert.deepEqual(data, expectedData);
+                assert.calledWith(context.magicalMethod, args[0], args[1]);
+                done();
+            });
+        });
+
+        it('promises to invoke the function with context', () =>
+            nodeify.withContext(context, 'magicalMethod', args)
+                .then((data) => {
+                    assert.deepEqual(data, expectedData);
+                })
+        );
+    });
+
     describe('fail', () => {
         it('invokes the callback with a failure', (done) => {
             const expectedError = new Error('hanShotSecond');


### PR DESCRIPTION
We experienced an issue where the `datastore.save` performs: 
1. Validation
2. Calls `this._save`

Because of the extra level of indirection, a call to `nodeify(datastore.save)` would result in `this_save` to be unresolved. More specifically, the `this` is undefined, and so the datastore will throw a "cannot call 'save' of undefined". 

This PR aims to amend that bug.
