### PR TITLE
Fix branch name case sensitivity

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -82,13 +82,17 @@ class PipelineModel extends BaseModel {
     formatScmUrl(scmUrl) {
         let result = scmUrl;
         const matched = (schema.config.regex.SCM_URL).exec(result);
+        let branchName = matched[4];
 
         // Check if branch name exists
-        if (!matched[4]) {
-            result = result.concat('#master');
+        if (!branchName) {
+            branchName = '#master';
         }
 
-        return result.toLowerCase();
+        // Do not convert branch name to lowercase
+        result = result.split('#')[0].toLowerCase().concat(branchName);
+
+        return result;
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -4,6 +4,7 @@ const BaseModel = require('./base');
 const JobModel = require('./job');
 const nodeify = require('./nodeify');
 const schema = require('screwdriver-data-schema');
+const MATCH_COMPONENT_BRANCH_NAME = 4;
 
 class PipelineModel extends BaseModel {
     /**
@@ -82,7 +83,7 @@ class PipelineModel extends BaseModel {
     formatScmUrl(scmUrl) {
         let result = scmUrl;
         const matched = (schema.config.regex.SCM_URL).exec(result);
-        let branchName = matched[4];
+        let branchName = matched[MATCH_COMPONENT_BRANCH_NAME];
 
         // Check if branch name exists
         if (!branchName) {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -246,9 +246,9 @@ describe('Pipeline Model', () => {
 
     describe('formatScmUrl', () => {
         const scmUrl = 'git@github.com:screwdriver-cd/HASHR.git';
-        const scmUrlBranch = 'git@github.com:screwdriver-cd/HASHR.git#foo';
+        const scmUrlBranch = 'git@github.com:screwdriver-cd/HASHR.git#Foo';
         const formattedScmUrl = 'git@github.com:screwdriver-cd/hashr.git#master';
-        const formattedScmUrlBranch = 'git@github.com:screwdriver-cd/hashr.git#foo';
+        const formattedScmUrlBranch = 'git@github.com:screwdriver-cd/hashr.git#Foo';
 
         it('adds master branch when there is no branch specified', (done) => {
             const result = pipeline.formatScmUrl(scmUrl);


### PR DESCRIPTION
This PR fixes case sensitivity issue of the branch name. screwdriver-cd/screwdriver#82
`formatScmUrl` funtion will convert scmUrl to lowercase excepting a branch name.

This change breaks relation between pipelineId and scmUrl of existing pipelines. Please just close this PR if you don't want it.
