### PR TITLE
Sanitize datastore saves by valid keys

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -55,14 +55,21 @@ class BaseFactory {
             table: this.table,
             params: {
                 id,
-                data: config
+                data: {}
             }
         };
 
+        // Filter for valid keys
+        this.model.allKeys.forEach((key) => {
+            if (config[key]) {
+                modelConfig.params.data[key] = config[key];
+            }
+        });
+
         return nodeify.withContext(this.datastore, 'save', [modelConfig])
-            // add datastore to create config
-            .then(modelData => this.createClass(hoek.applyToDefaults(modelData, {
-                datastore: this.datastore
+            .then(modelData => this.createClass(hoek.applyToDefaults(config, {
+                datastore: this.datastore,
+                id: modelData.id
             })));
     }
 

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -115,7 +115,6 @@ describe('Build Factory', () => {
                     createTime: dateNow,
                     number: dateNow,
                     status: 'QUEUED',
-                    username,
                     jobId,
                     sha
                 }
@@ -147,6 +146,17 @@ describe('Build Factory', () => {
                 assert.deepEqual(model.executor, executor);
                 assert.isFalse(jobFactoryMock.get.called);
                 assert.isFalse(userFactoryMock.get.called);
+            });
+        });
+
+        it('ignores extraneous parameters', () => {
+            const expected = {};
+            const garbage = 'garbageData';
+
+            datastore.save.yieldsAsync(null, expected);
+
+            return factory.create({ garbage, username, jobId, sha }).then(() => {
+                assert.calledWith(datastore.save, saveConfig);
             });
         });
 


### PR DESCRIPTION
Currently, anything that is passed to a `.create()` will be stored in the datastore table. This PR intends to filter the incoming data, so that we only save values assigned to valid columns. In addition, this change will make sure that the Model is constructed with the correct parameters.

This will help with PR #41 in order to filter out the overloaded parameters field.
