### PR TITLE
buildFactory handles executor in construction

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -60,6 +60,7 @@ class BaseFactory {
         };
 
         return nodeify.withContext(this.datastore, 'save', [modelConfig])
+            // add datastore to create config
             .then(modelData => this.createClass(hoek.applyToDefaults(modelData, {
                 datastore: this.datastore
             })));

--- a/lib/build.js
+++ b/lib/build.js
@@ -12,7 +12,6 @@ class BuildModel extends BaseModel {
      * @param  {Object}    config
      * @param  {Object}    config.datastore         Object that will perform operations on the datastore
      * @param  {Object}    config.executor          Object that will perform executor operations
-     * @param  {String}    config.password          Login password
      * @param  {String}    config.username          The user that created this build
      * @param  {String}    config.jobId             The ID of the associated job to start
      * @param  {String}    [config.sha]             The sha of the build
@@ -21,7 +20,6 @@ class BuildModel extends BaseModel {
     constructor(config) {
         super('build', config);
         this.executor = config.executor;
-        this.password = config.password;
         this.username = config.username;
     }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -49,18 +49,20 @@ class BuildFactory extends BaseFactory {
      * Construct a JobFactory object
      * @method constructor
      * @param  {Object}    config
-     * @param  {Object}    config.datastore         Object that will perform operations on the datastore
+     * @param  {Object}    config.datastore     Object that will perform datastore operations
+     * @param  {Object}    config.executor      Object that will perform compute operations
      */
     constructor(config) {
         super('build', config);
+        this.executor = config.executor;
     }
 
     /**
      * Instantiate a Build class
      * @method createClass
      * @param  {Object}     config               Build data
-     * @param  {Datastore}  config.datastore     Datastore instance
      * @param  {String}     config.id            unique id
+     * @param  {Datastore}  config.datastore     Datastore instance
      * @param  {String}     config.username      The user that created this build
      * @param  {String}     config.jobId         The ID of the associated job to start
      * @param  {String}     [config.sha]         The sha of the build
@@ -68,7 +70,12 @@ class BuildFactory extends BaseFactory {
      * @return {Build}
      */
     createClass(config) {
-        return new Build(config);
+        // add executor to config
+        const c = hoek.applyToDefaults(config, {
+            executor: this.executor
+        });
+
+        return new Build(c);
     }
 
     /**
@@ -77,7 +84,6 @@ class BuildFactory extends BaseFactory {
      * @param  {Object}   config                Config object
      * @param  {String}   config.username       The user that created this build
      * @param  {String}   config.jobId          The ID of the associated job to start
-     * @param  {String}   config.executor       Build executor instance
      * @param  {String}   [config.sha]          The sha of the build
      * @param  {String}   [config.container]    The kind of container to use
      * @return {Promise}
@@ -130,13 +136,19 @@ class BuildFactory extends BaseFactory {
     /**
      * Get an instance of the BuildFactory
      * @method getInstance
-     * @param  {Object}     config
-     * @param  {Datastore}  config.datastore
+     * @param  {Object}     [config]            Configuration required for first call
+     * @param  {Datastore}  config.datastore    Datastore instance
+     * @param  {Executor}   config.executor     Executor instance
      * @return {UserFactory}
      */
-    // TODO: config.executor???
     static getInstance(config) {
         if (!instance) {
+            if (!config || !config.datastore) {
+                throw new Error('No datastore provided to BuildFactory');
+            }
+            if (!config.executor) {
+                throw new Error('No executor provided to BuildFactory');
+            }
             instance = new BuildFactory(config);
         }
 

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -60,6 +60,10 @@ class JobFactory extends BaseFactory {
      */
     static getInstance(config) {
         if (!instance) {
+            if (!config || !config.datastore) {
+                throw new Error('No datastore provided to JobFactory');
+            }
+
             instance = new JobFactory(config);
         }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,8 +1,6 @@
 'use strict';
 const BaseModel = require('./base');
 const JobFactory = require('./jobFactory');
-const schema = require('screwdriver-data-schema');
-const MATCH_COMPONENT_BRANCH_NAME = 4;
 
 class PipelineModel extends BaseModel {
     /**
@@ -34,28 +32,6 @@ class PipelineModel extends BaseModel {
         };
 
         return factory.create(jobConfig);
-    }
-
-    /**
-     * Format the scm url to include a branch and make case insensitive
-     * @method formatScmUrl
-     * @param  {String}     scmUrl Github scm url
-     * @return {String}            Lowercase scm url with branch name
-     */
-    formatScmUrl(scmUrl) {
-        let result = scmUrl;
-        const matched = (schema.config.regex.SCM_URL).exec(result);
-        let branchName = matched[MATCH_COMPONENT_BRANCH_NAME];
-
-        // Check if branch name exists
-        if (!branchName) {
-            branchName = '#master';
-        }
-
-        // Do not convert branch name to lowercase
-        result = result.split('#')[0].toLowerCase().concat(branchName);
-
-        return result;
     }
 
     /**

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -58,6 +58,10 @@ class PipelineFactory extends BaseFactory {
      */
     static getInstance(config) {
         if (!instance) {
+            if (!config || !config.datastore) {
+                throw new Error('No datastore provided to PipelineFactory');
+            }
+
             instance = new PipelineFactory(config);
         }
 

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -63,6 +63,10 @@ class UserFactory extends BaseFactory {
      */
     static getInstance(config) {
         if (!instance) {
+            if (!config || !config.datastore) {
+                throw new Error('No datastore provided to UserFactory');
+            }
+
             instance = new UserFactory(config);
         }
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -73,7 +73,6 @@ describe('Build Model', () => {
             datastore,
             username: 'me',
             executor: executorMock,
-            password: 'password',
             id: buildId,
             cause: 'Started by user i_made_the_request',
             container,

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -113,5 +113,16 @@ describe('Job Factory', () => {
 
             assert.equal(f1, f2);
         });
+
+        it('should not require config on second call', () => {
+            const f1 = JobFactory.getInstance({ datastore });
+            const f2 = JobFactory.getInstance();
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(JobFactory.getInstance, Error, 'No datastore provided to JobFactory');
+        });
     });
 });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -108,27 +108,6 @@ describe('Pipeline Model', () => {
         });
     });
 
-    describe('formatScmUrl', () => {
-        const url = 'git@github.com:screwdriver-cd/HASHR.git';
-        const scmUrlBranch = 'git@github.com:screwdriver-cd/HASHR.git#Foo';
-        const formattedScmUrl = 'git@github.com:screwdriver-cd/hashr.git#master';
-        const formattedScmUrlBranch = 'git@github.com:screwdriver-cd/hashr.git#Foo';
-
-        it('adds master branch when there is no branch specified', (done) => {
-            const result = pipeline.formatScmUrl(url);
-
-            assert.equal(result, formattedScmUrl, 'scmUrl is not formatted correctly');
-            done();
-        });
-
-        it('does not add master branch when there is a branch specified', (done) => {
-            const result = pipeline.formatScmUrl(scmUrlBranch);
-
-            assert.equal(result, formattedScmUrlBranch, 'scmUrl is not formatted correctly');
-            done();
-        });
-    });
-
     describe('get admin', () => {
         it('returns admin of pipeline', () => {
             assert.equal(pipeline.admin, 'batman');

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -131,5 +131,19 @@ describe('Pipeline Factory', () => {
 
             assert.equal(f1, f2);
         });
+
+        it('should not require config on second call', () => {
+            const f1 = PipelineFactory.getInstance({ datastore });
+            const f2 = PipelineFactory.getInstance();
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(PipelineFactory.getInstance,
+                Error,
+                'No datastore provided to PipelineFactory'
+            );
+        });
     });
 });

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -102,5 +102,16 @@ describe('User Factory', () => {
 
             assert.equal(f1, f2);
         });
+
+        it('should not require config on second call', () => {
+            const f1 = UserFactory.getInstance({ datastore });
+            const f2 = UserFactory.getInstance();
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(UserFactory.getInstance, Error, 'No datastore provided to UserFactory');
+        });
     });
 });


### PR DESCRIPTION
Needed before: https://github.com/screwdriver-cd/screwdriver/pull/88
- The BuildFactory needs to handle adding executor to Build models.
- All factories should have a more robust getInstance method.
- `pipeline.formatScmUrl()` isn't actually used by anything, so it has been removed
