### PR TITLE
Fix call to get pipeline admin

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -88,7 +88,7 @@ class BuildModel extends BaseModel {
                     // fetch users
                     Promise.all([
                         this.user,
-                        userFactory.get({ username: pipeline.getAdmin() })
+                        userFactory.get({ username: pipeline.admin })
                     ]).then(users => {
                         const buildUser = users[0];
                         const adminUser = users[1];

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -184,7 +184,7 @@ describe('Build Model', () => {
                 pipeline: new Promise(resolve => resolve({
                     id: pipelineId,
                     scmUrl,
-                    getAdmin: () => 'batman'
+                    admin: 'batman'
                 }))
             });
 


### PR DESCRIPTION
The method `getAdmin` was changed to `get admin` and the call to get admins was never updated.
Fixing bug here.

https://github.com/screwdriver-cd/models/blob/f4fbf01f9d5f048d4f44feee602610023c23b01a/lib/pipeline.js#L43
