### PR TITLE
Base model tracks changed fields

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1,6 +1,9 @@
 'use strict';
 const schema = require('screwdriver-data-schema');
 const nodeify = require('./nodeify');
+// Get symbols for private fields
+const rowData = Symbol();
+const dirty = Symbol();
 
 class BaseModel {
     /**
@@ -11,14 +14,32 @@ class BaseModel {
      * @param  {Object}     config.datastore    Object that will perform operations on the datastore
      */
     constructor(modelName, config) {
+        // TODO: make these "private", too
         this.model = schema.models[modelName];
         this.table = this.model.tableName;
         this.datastore = config.datastore;
+        this[rowData] = {};
+        this[dirty] = [];
 
-        // TODO: dynamically create setters to enable dirty bits for updates
+        const setter = (key, val) => {
+            this[rowData][key] = val;
+            this[dirty].push(key);
+        };
+        const getter = (key) => this[rowData][key];
+
         this.model.allKeys.forEach(key => {
-            this[key] = config[key];
+            this[rowData][key] = config[key];
+
+            Object.defineProperty(this, key, {
+                get: getter.bind(this, key),
+                set: setter.bind(this, key),
+                enumerable: true
+            });
         });
+    }
+
+    get isDirty() {
+        return this[dirty].length > 0;
     }
 
     /**
@@ -29,8 +50,13 @@ class BaseModel {
     update() {
         const data = {};
 
-        this.model.allKeys.forEach(key => {
-            data[key] = this[key];
+        if (!this.isDirty) {
+            return nodeify.success(this);
+        }
+
+        // only update dirty fields
+        this[dirty].forEach(key => {
+            data[key] = this[rowData][key];
         });
         delete data.id;
 
@@ -44,7 +70,11 @@ class BaseModel {
 
         // TODO: sync `this` with db response?
         return nodeify.withContext(this.datastore, 'update', [datastoreConfig])
-            .then(() => this);
+            .then(() => {
+                this[dirty] = [];
+
+                return this;
+            });
     }
 
     /**
@@ -53,13 +83,7 @@ class BaseModel {
      * @return {Object}
      */
     toJson() {
-        const result = {};
-
-        this.model.allKeys.forEach(key => {
-            result[key] = this[key];
-        });
-
-        return result;
+        return this[rowData];
     }
 
     /**


### PR DESCRIPTION
- Store the rowData passed to the constructor in a private field and dynamically generate getters and setters for class members.
- Save dirty bits for fields changed with setters.
- Update only those fields that have changed since the model was constructed, or the last update operation was run
