### PR TITLE
Use repo's owner username in createstatus

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -104,20 +104,16 @@ class BuildModel extends BaseModel {
                     token
                 }])
                 .then(() =>
-                    // fetch users
-                    Promise.all([
-                        this.user,
-                        userFactory.get({ username: pipeline.admin })
-                    ]).then(users => {
-                        const buildUser = users[0];
-                        const adminUser = users[1];
+                    userFactory.get({ username: pipeline.admin })
+                    .then(adminUser => {
+                        const repoInfo = githubHelper.getInfo(pipeline.scmUrl);
 
                         return githubHelper.run({
                             user: adminUser,
                             action: 'createStatus',
                             params: {
-                                user: buildUser.username,
-                                repo: githubHelper.getInfo(pipeline.scmUrl).repo,
+                                user: repoInfo.user,
+                                repo: repoInfo.repo,
                                 sha: this.sha,
                                 state: 'pending',
                                 context: 'screwdriver'

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -173,7 +173,6 @@ describe('Build Model', () => {
     describe('start', () => {
         let sandbox;
         let tokenGen;
-        const user = { username: 'me' };
         const adminUser = { username: 'batman' };
         const pipelineId = 'cf23df2207d99a74fbe169e3eba035e633b65d94';
         const scmUrl = 'git@github.com:screwdriver-cd/models.git#master';
@@ -199,9 +198,9 @@ describe('Build Model', () => {
 
             tokenGen = sinon.stub().returns(token);
 
-            userFactoryMock.get.withArgs(user).resolves(user);
             userFactoryMock.get.withArgs(adminUser).resolves(adminUser);
             githubMock.getInfo.returns({
+                user: 'screwdriver-cd',
                 repo: 'models'
             });
             githubMock.run.resolves(null);
@@ -226,7 +225,7 @@ describe('Build Model', () => {
                     user: adminUser,
                     action: 'createStatus',
                     params: {
-                        user: user.username,
+                        user: 'screwdriver-cd',
                         repo: 'models',
                         sha,
                         state: 'pending',


### PR DESCRIPTION
The github API requires the Repository's user instead of the build user when updating the status.

```
github.com/<user>/<repo>
```

is the target for the update
