### PR TITLE
Make non-schema properties private

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -4,6 +4,9 @@ const nodeify = require('./nodeify');
 // Get symbols for private fields
 const rowData = Symbol();
 const dirty = Symbol();
+const model = Symbol();
+const table = Symbol();
+const datastore = Symbol();
 
 class BaseModel {
     /**
@@ -14,10 +17,9 @@ class BaseModel {
      * @param  {Object}     config.datastore    Object that will perform operations on the datastore
      */
     constructor(modelName, config) {
-        // TODO: make these "private", too
-        this.model = schema.models[modelName];
-        this.table = this.model.tableName;
-        this.datastore = config.datastore;
+        this[model] = schema.models[modelName];
+        this[table] = this[model].tableName;
+        this[datastore] = config.datastore;
         this[rowData] = {};
         this[dirty] = [];
 
@@ -27,7 +29,7 @@ class BaseModel {
         };
         const getter = (key) => this[rowData][key];
 
-        this.model.allKeys.forEach(key => {
+        this[model].allKeys.forEach(key => {
             this[rowData][key] = config[key];
 
             Object.defineProperty(this, key, {
@@ -61,7 +63,7 @@ class BaseModel {
         delete data.id;
 
         const datastoreConfig = {
-            table: this.table,
+            table: this[table],
             params: {
                 id: this.id,
                 data
@@ -69,7 +71,7 @@ class BaseModel {
         };
 
         // TODO: sync `this` with db response?
-        return nodeify.withContext(this.datastore, 'update', [datastoreConfig])
+        return nodeify.withContext(this[datastore], 'update', [datastoreConfig])
             .then(() => {
                 this[dirty] = [];
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -3,6 +3,9 @@ const BaseModel = require('./base');
 const nodeify = require('./nodeify');
 const githubHelper = require('./github');
 
+// Symbols for private members
+const executor = Symbol('executor');
+
 class BuildModel extends BaseModel {
     /**
      * Construct a BuildModel object
@@ -17,7 +20,7 @@ class BuildModel extends BaseModel {
      */
     constructor(config) {
         super('build', config);
-        this.executor = config.executor;
+        this[executor] = config.executor;
         this.username = config.username;
     }
 
@@ -97,7 +100,7 @@ class BuildModel extends BaseModel {
         return this.job.then(job =>
             job.pipeline.then(pipeline =>
                 // Start the build
-                nodeify.withContext(this.executor, 'start', [{
+                nodeify.withContext(this[executor], 'start', [{
                     apiUri,
                     buildId: this.id,
                     container: this.container,
@@ -135,7 +138,7 @@ class BuildModel extends BaseModel {
      * @return {Promise}
      */
     stream() {
-        return nodeify.withContext(this.executor, 'stream', [{ buildId: this.id }]);
+        return nodeify.withContext(this[executor], 'stream', [{ buildId: this.id }]);
     }
 
     /**
@@ -144,7 +147,7 @@ class BuildModel extends BaseModel {
      * @return {Promise}
      */
     stop() {
-        return nodeify.withContext(this.executor, 'stop', [{ buildId: this.id }]);
+        return nodeify.withContext(this[executor], 'stop', [{ buildId: this.id }]);
     }
 }
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -4,6 +4,8 @@ const iron = require('iron');
 const githubHelper = require('./github');
 const nodeify = require('./nodeify');
 const schema = require('screwdriver-data-schema');
+// Get symbols for private fields
+const password = Symbol();
 
 class UserModel extends BaseModel {
 
@@ -18,7 +20,7 @@ class UserModel extends BaseModel {
      */
     constructor(config) {
         super('user', config);
-        this.password = config.password;
+        this[password] = config.password;
     }
 
     /**
@@ -29,7 +31,7 @@ class UserModel extends BaseModel {
      */
     sealToken(token) {
         // TODO: automatically update user model and datastore with new sealed token???
-        return nodeify.withContext(iron, 'seal', [token, this.password, iron.defaults]);
+        return nodeify.withContext(iron, 'seal', [token, this[password], iron.defaults]);
     }
 
     /**
@@ -39,7 +41,7 @@ class UserModel extends BaseModel {
      */
     unsealToken() {
         return nodeify.withContext(iron, 'unseal',
-            [this.token, this.password, iron.defaults]);
+            [this.token, this[password], iron.defaults]);
     }
 
     /**

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -5,6 +5,9 @@ const User = require('./user');
 const iron = require('iron');
 const nodeify = require('./nodeify');
 const hoek = require('hoek');
+// Get symbols for private fields
+const password = Symbol();
+
 let instance;
 /**
  * Seal token
@@ -12,8 +15,8 @@ let instance;
  * @param  {String}   token      Token to seal
  * @return {Promise}
  */
-const sealToken = (token, password) =>
-    nodeify.withContext(iron, 'seal', [token, password, iron.defaults]);
+const sealToken = (token, pw) =>
+    nodeify.withContext(iron, 'seal', [token, pw, iron.defaults]);
 
 class UserFactory extends BaseFactory {
     /**
@@ -25,7 +28,7 @@ class UserFactory extends BaseFactory {
      */
     constructor(config) {
         super('user', config);
-        this.password = config.password;
+        this[password] = config.password;
     }
 
     /**
@@ -35,7 +38,7 @@ class UserFactory extends BaseFactory {
      * @return {User}
      */
     createClass(config) {
-        const c = hoek.applyToDefaults(config, { password: this.password });
+        const c = hoek.applyToDefaults(config, { password: this[password] });
 
         return new User(c);
     }
@@ -50,8 +53,8 @@ class UserFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        return sealToken(config.token, this.password).then(token => {
-            const modelConfig = hoek.applyToDefaults(config, { token, password: this.password });
+        return sealToken(config.token, this[password]).then(token => {
+            const modelConfig = hoek.applyToDefaults(config, { token, password: this[password] });
 
             return super.create(modelConfig);
         });

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -8,7 +8,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('Base Model', () => {
     let BaseModel;
     let datastore;
-    let modelMock;
+    let schemaMock;
     let base;
     let config;
 
@@ -26,7 +26,7 @@ describe('Base Model', () => {
             update: sinon.stub()
         };
 
-        modelMock = {
+        schemaMock = {
             models: {
                 base: {
                     tableName: 'base',
@@ -34,7 +34,7 @@ describe('Base Model', () => {
                 }
             }
         };
-        mockery.registerMock('screwdriver-data-schema', modelMock);
+        mockery.registerMock('screwdriver-data-schema', schemaMock);
 
         // eslint-disable-next-line global-require
         BaseModel = require('../../lib/base');
@@ -62,9 +62,15 @@ describe('Base Model', () => {
     describe('constructor', () => {
         it('constructs properly', () => {
             assert.instanceOf(base, BaseModel);
-            Object.keys(config).forEach(key => {
+            schemaMock.models.base.allKeys.forEach(key => {
                 assert.strictEqual(base[key], config[key]);
             });
+            // datastore is private
+            assert.isUndefined(base.datastore);
+        });
+
+        it('exposes as ownProperties only those keys defined in the schema', () => {
+            assert.deepEqual(Object.getOwnPropertyNames(base), schemaMock.models.base.allKeys);
         });
     });
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -2,6 +2,7 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
+const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -108,9 +109,14 @@ describe('Build Model', () => {
         assert.isFunction(build.stop);
         assert.isFunction(build.stream);
 
-        Object.keys(config).forEach(key => {
+        schema.models.build.allKeys.forEach(key => {
             assert.strictEqual(build[key], config[key]);
         });
+
+        // Also added a username members
+        assert.strictEqual(build.username, config.username);
+        // executor is private
+        assert.isUndefined(build.executor);
     });
 
     describe('stream', () => {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -2,6 +2,7 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
+const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
 require('sinon-as-promised');
@@ -63,7 +64,7 @@ describe('Job Model', () => {
         assert.instanceOf(job, BaseModel);
         assert.isFunction(job.update);
 
-        Object.keys(config).forEach(key => {
+        schema.models.job.allKeys.forEach(key => {
             assert.strictEqual(job[key], config[key]);
         });
     });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2,6 +2,7 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
+const schema = require('screwdriver-data-schema');
 
 require('sinon-as-promised');
 sinon.assert.expose(assert, { prefix: '' });
@@ -75,7 +76,7 @@ describe('Pipeline Model', () => {
         assert.instanceOf(pipeline, PipelineModel);
         assert.instanceOf(pipeline, BaseModel);
 
-        Object.keys(pipelineConfig).forEach(key => {
+        schema.models.pipeline.allKeys.forEach(key => {
             assert.strictEqual(pipeline[key], pipelineConfig[key]);
         });
     });

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -2,6 +2,7 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
+const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -74,9 +75,11 @@ describe('User Model', () => {
     it('is constructed properly', () => {
         assert.instanceOf(user, UserModel);
         assert.instanceOf(user, BaseModel);
-        Object.keys(createConfig).forEach(key => {
+        schema.models.user.allKeys.forEach(key => {
             assert.strictEqual(user[key], createConfig[key]);
         });
+        // password is private
+        assert.isUndefined(user.password);
     });
 
     describe('seal token', () => {


### PR DESCRIPTION
This makes all properties that are not part of the model schema more "private". This prevents accidental exposure of datastore, executor, and encryption password to objects that have a handle to various models. This causes things like Object.getOwnPropertyNames() to only expose properties that we want to be exposed; usually fields from the model schema.
