### PR TITLE
Properly handle missing job or user model in build.create

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -38,6 +38,14 @@ function getCommitSha(datastore, config) {
         const job = models[0];
         const user = models[1];
 
+        if (!job) {
+            throw new Error('Job does not exist');
+        }
+
+        if (!user) {
+            throw new Error('User does not exist');
+        }
+
         return job.pipeline
             .then(pipeline => githubHelper.getInfo(pipeline.scmUrl))
             .then(repoInfo => githubHelper.run({
@@ -91,6 +99,7 @@ class BuildFactory extends BaseFactory {
      * @param  {Function}  config.tokenGen       Generator for building tokens
      * @param  {String}    config.username       The user that created this build
      * @param  {String}    [config.sha]          The sha of the build
+     * @param  {String}    [config.jobId]        The job associated with this build (req. if sha not defined)
      * @param  {String}    [config.container]    The kind of container to use
      * @return {Promise}
      */

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -258,4 +258,36 @@ describe('Build Model', () => {
             });
         });
     });
+
+    describe('job', () => {
+        it('has a job getter', () => {
+            jobFactoryMock.get.resolves(null);
+            // when we fetch a job it resolves to a promise
+            assert.isFunction(build.job.then);
+            // and a factory is called to create that promise
+            assert.calledWith(jobFactoryMock.get, jobId);
+
+            // When we call build.job again it is still a promise
+            assert.isFunction(build.job.then);
+            // ...but the factory was not recreated, since the promise is stored
+            // as the model's pipeline property, now
+            assert.calledOnce(jobFactoryMock.get);
+        });
+    });
+
+    describe('user', () => {
+        it('has a user getter', () => {
+            userFactoryMock.get.resolves(null);
+            // when we fetch a user it resolves to a promise
+            assert.isFunction(build.user.then);
+            // and a factory is called to create that promise
+            assert.calledWith(userFactoryMock.get, { username: config.username });
+
+            // When we call build.user again it is still a promise
+            assert.isFunction(build.user.then);
+            // ...but the factory was not recreated, since the promise is stored
+            // as the model's pipeline property, now
+            assert.calledOnce(userFactoryMock.get);
+        });
+    });
 });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -208,6 +208,26 @@ describe('Build Factory', () => {
                 });
             });
         });
+
+        it('properly handles rejection due to missing models', () => {
+            jobFactoryMock.get.resolves(null);
+            userFactoryMock.get.resolves(null);
+
+            return factory.create({ apiUri, username, jobId, tokenGen }).catch(err => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message, 'Job does not exist');
+            });
+        });
+
+        it('properly handles rejection due to missing models', () => {
+            jobFactoryMock.get.resolves({});
+            userFactoryMock.get.resolves(null);
+
+            return factory.create({ apiUri, username, jobId, tokenGen }).catch(err => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message, 'User does not exist');
+            });
+        });
     });
 
     describe('getBuildsForJobId', () => {


### PR DESCRIPTION
When the datastore returns null when looking for a job, build.create throws a runtime error. This should catch the error and return something better.

Also added proper tests for build.job and build.user.
