### PR TITLE
scmPlugin is a requirement for factories

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -7,6 +7,7 @@ const dirty = Symbol();
 const model = Symbol();
 const table = Symbol();
 const datastore = Symbol();
+const scmPlugin = Symbol();
 
 class BaseModel {
     /**
@@ -15,11 +16,13 @@ class BaseModel {
      * @param  {String}     modelName           Name of the model to get from data-schema
      * @param  {Object}     config
      * @param  {Object}     config.datastore    Object that will perform operations on the datastore
+     * @param  {Object}     config.scmPlugin    Object that will perform operations on scm resources
      */
     constructor(modelName, config) {
         this[model] = schema.models[modelName];
         this[table] = this[model].tableName;
         this[datastore] = config.datastore;
+        this[scmPlugin] = config.scmPlugin;
         this[rowData] = {};
         this[dirty] = [];
 
@@ -38,6 +41,10 @@ class BaseModel {
                 enumerable: true
             });
         });
+    }
+
+    get scm() {
+        return this[scmPlugin];
     }
 
     /**

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -11,11 +11,13 @@ class BaseFactory {
      * @param  {String}    modelName            Name of the model to get from data-schema
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {Object}    config.scmPlugin     Object that will perform operations on scm resource
      */
     constructor(modelName, config) {
         this.model = schema.models[modelName];
         this.table = this.model.tableName;
         this.datastore = config.datastore;
+        this.scmPlugin = config.scmPlugin;
     }
 
     /**
@@ -69,6 +71,7 @@ class BaseFactory {
         return nodeify.withContext(this.datastore, 'save', [modelConfig])
             .then(modelData => this.createClass(hoek.applyToDefaults(config, {
                 datastore: this.datastore,
+                scmPlugin: this.scmPlugin,
                 id: modelData.id
             })));
     }
@@ -144,6 +147,36 @@ class BaseFactory {
 
                 return result;
             });
+    }
+
+    /**
+     * Get an instance of a Factory
+     * @method getInstance
+     * @param  {Object}     ClassDef            Class definition of a factory
+     * @param  {Object}     instance            The current instance of a factory
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore    A datastore instance
+     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @return {Factory}
+     */
+    static getInstance(ClassDef, instance, config) {
+        let inst = instance;
+
+        if (!inst) {
+            const className = ClassDef.name;
+
+            if (!config || !config.datastore) {
+                throw new Error(`No datastore provided to ${className}`);
+            }
+
+            if (!config || !config.scmPlugin) {
+                throw new Error(`No scm plugin provided to ${className}`);
+            }
+
+            inst = new ClassDef(config);
+        }
+
+        return inst;
     }
 }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -170,18 +170,15 @@ class BuildFactory extends BaseFactory {
      * @param  {Object}     [config]            Configuration required for first call
      * @param  {Datastore}  config.datastore    Datastore instance
      * @param  {Executor}   config.executor     Executor instance
-     * @return {UserFactory}
+     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @return {BuildFactory}
      */
     static getInstance(config) {
-        if (!instance) {
-            if (!config || !config.datastore) {
-                throw new Error('No datastore provided to BuildFactory');
-            }
-            if (!config.executor) {
-                throw new Error('No executor provided to BuildFactory');
-            }
-            instance = new BuildFactory(config);
+        if (!instance && (!config || !config.executor)) {
+            throw new Error('No executor provided to BuildFactory');
         }
+
+        instance = BaseFactory.getInstance(BuildFactory, instance, config);
 
         return instance;
     }

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -49,20 +49,15 @@ class JobFactory extends BaseFactory {
     }
 
     /**
-     * Get an instance of the UserFactory
+     * Get an instance of the JobFactory
      * @method getInstance
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore
-     * @return {UserFactory}
+     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @return {JobFactory}
      */
     static getInstance(config) {
-        if (!instance) {
-            if (!config || !config.datastore) {
-                throw new Error('No datastore provided to JobFactory');
-            }
-
-            instance = new JobFactory(config);
-        }
+        instance = BaseFactory.getInstance(JobFactory, instance, config);
 
         return instance;
     }

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -50,20 +50,15 @@ class PipelineFactory extends BaseFactory {
     }
 
     /**
-     * Get an instance of the UserFactory
+     * Get an instance of the PipelineFactory
      * @method getInstance
      * @param  {Object}     config
-     * @param  {Datastore}  config.datastore
-     * @return {UserFactory}
+     * @param  {Datastore}  config.datastore    A datastore instance
+     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @return {PipelineFactory}
      */
     static getInstance(config) {
-        if (!instance) {
-            if (!config || !config.datastore) {
-                throw new Error('No datastore provided to PipelineFactory');
-            }
-
-            instance = new PipelineFactory(config);
-        }
+        instance = BaseFactory.getInstance(PipelineFactory, instance, config);
 
         return instance;
     }

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -64,17 +64,12 @@ class UserFactory extends BaseFactory {
      * Get an instance of the UserFactory
      * @method getInstance
      * @param  {Object}     config
-     * @param  {Datastore}  config.datastore
+     * @param  {Datastore}  config.datastore    A datastore instance
+     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
      * @return {UserFactory}
      */
     static getInstance(config) {
-        if (!instance) {
-            if (!config || !config.datastore) {
-                throw new Error('No datastore provided to UserFactory');
-            }
-
-            instance = new UserFactory(config);
-        }
+        instance = BaseFactory.getInstance(UserFactory, instance, config);
 
         return instance;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -11,6 +11,7 @@ describe('Base Model', () => {
     let schemaMock;
     let base;
     let config;
+    let scmPlugin;
 
     before(() => {
         mockery.enable({
@@ -20,6 +21,9 @@ describe('Base Model', () => {
     });
 
     beforeEach(() => {
+        scmPlugin = {
+            foo: 'foo'
+        };
         datastore = {
             get: sinon.stub(),
             scan: sinon.stub(),
@@ -41,6 +45,7 @@ describe('Base Model', () => {
 
         config = {
             datastore,
+            scmPlugin,
             id: 'as12345',
             foo: 'foo',
             bar: 'bar'
@@ -148,6 +153,12 @@ describe('Base Model', () => {
     describe('toJson', () => {
         it('should give an object representation of the model data', () => {
             assert.deepEqual(base.toJson(), { id: 'as12345', foo: 'foo', bar: 'bar' });
+        });
+    });
+
+    describe('scm', () => {
+        it('should have a getter for the scm plugin', () => {
+            assert.equal(base.scm, scmPlugin);
         });
     });
 });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -313,26 +313,29 @@ describe('Build Factory', () => {
     });
 
     describe('getInstance', () => {
-        it('should encapsulate new, and act as a singleton', () => {
-            const f1 = BuildFactory.getInstance({ datastore, executor });
-            const f2 = BuildFactory.getInstance({ datastore, executor });
+        let config;
+
+        beforeEach(() => {
+            config = { datastore, executor, scmPlugin: {} };
+        });
+
+        it('should utilize BaseFactory to get an instance', () => {
+            const f1 = BuildFactory.getInstance(config);
+            const f2 = BuildFactory.getInstance(config);
+
+            assert.instanceOf(f1, BuildFactory);
+            assert.instanceOf(f2, BuildFactory);
 
             assert.equal(f1, f2);
         });
 
-        it('should not require config on second call', () => {
-            const f1 = BuildFactory.getInstance({ datastore, executor });
-            const f2 = BuildFactory.getInstance();
+        it('should throw when config does not have everything necessary', () => {
+            assert.throw(BuildFactory.getInstance,
+                Error, 'No executor provided to BuildFactory');
 
-            assert.equal(f1, f2);
-        });
-
-        it('should throw when config not supplied', () => {
-            assert.throw(BuildFactory.getInstance, Error, 'No datastore provided to BuildFactory');
-            assert.throw(() => { BuildFactory.getInstance({ datastore }); },
-                Error,
-                'No executor provided to BuildFactory'
-            );
+            assert.throw(() => {
+                BuildFactory.getInstance({ executor, scm: {} });
+            }, Error, 'No datastore provided to BuildFactory');
         });
     });
 });

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -111,16 +111,18 @@ describe('Job Factory', () => {
     });
 
     describe('getInstance', () => {
-        it('should encapsulate new, and act as a singleton', () => {
-            const f1 = JobFactory.getInstance({ datastore });
-            const f2 = JobFactory.getInstance({ datastore });
+        let config;
 
-            assert.equal(f1, f2);
+        beforeEach(() => {
+            config = { datastore, scmPlugin: {} };
         });
 
-        it('should not require config on second call', () => {
-            const f1 = JobFactory.getInstance({ datastore });
-            const f2 = JobFactory.getInstance();
+        it('should utilize BaseFactory to get an instance', () => {
+            const f1 = JobFactory.getInstance(config);
+            const f2 = JobFactory.getInstance(config);
+
+            assert.instanceOf(f1, JobFactory);
+            assert.instanceOf(f2, JobFactory);
 
             assert.equal(f1, f2);
         });

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -125,25 +125,25 @@ describe('Pipeline Factory', () => {
     });
 
     describe('getInstance', () => {
-        it('should encapsulate new, and act as a singleton', () => {
-            const f1 = PipelineFactory.getInstance({ datastore });
-            const f2 = PipelineFactory.getInstance({ datastore });
+        let config;
 
-            assert.equal(f1, f2);
+        beforeEach(() => {
+            config = { datastore, scmPlugin: {} };
         });
 
-        it('should not require config on second call', () => {
-            const f1 = PipelineFactory.getInstance({ datastore });
-            const f2 = PipelineFactory.getInstance();
+        it('should utilize BaseFactory to get an instance', () => {
+            const f1 = PipelineFactory.getInstance(config);
+            const f2 = PipelineFactory.getInstance(config);
+
+            assert.instanceOf(f1, PipelineFactory);
+            assert.instanceOf(f2, PipelineFactory);
 
             assert.equal(f1, f2);
         });
 
         it('should throw when config not supplied', () => {
             assert.throw(PipelineFactory.getInstance,
-                Error,
-                'No datastore provided to PipelineFactory'
-            );
+                Error, 'No datastore provided to PipelineFactory');
         });
     });
 });

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -96,22 +96,25 @@ describe('User Factory', () => {
     });
 
     describe('getInstance', () => {
-        it('should encapsulate new, and act as a singleton', () => {
-            const f1 = UserFactory.getInstance({ datastore });
-            const f2 = UserFactory.getInstance({ datastore });
+        let config;
 
-            assert.equal(f1, f2);
+        beforeEach(() => {
+            config = { datastore, scmPlugin: {} };
         });
 
-        it('should not require config on second call', () => {
-            const f1 = UserFactory.getInstance({ datastore });
-            const f2 = UserFactory.getInstance();
+        it('should utilize BaseFactory to get an instance', () => {
+            const f1 = UserFactory.getInstance(config);
+            const f2 = UserFactory.getInstance(config);
+
+            assert.instanceOf(f1, UserFactory);
+            assert.instanceOf(f2, UserFactory);
 
             assert.equal(f1, f2);
         });
 
         it('should throw when config not supplied', () => {
-            assert.throw(UserFactory.getInstance, Error, 'No datastore provided to UserFactory');
+            assert.throw(UserFactory.getInstance,
+                Error, 'No datastore provided to UserFactory');
         });
     });
 });


### PR DESCRIPTION
- Forces factories to require an scmPlugin for `getInstance`
- Refactor `getInstance` methods so there is less duplicated code
- Base model exposes scmPlugin as `Model.scm`
- Refactor BaseFactory tests so as not to depend on a specific table's schema
