### PR TITLE
Pipeline sync looks up jobs in screwdriver.yaml and creates them all

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,5 +1,7 @@
 'use strict';
 const BaseModel = require('./base');
+const parser = require('screwdriver-config-parser');
+const nodeify = require('./nodeify');
 
 class PipelineModel extends BaseModel {
     /**
@@ -22,7 +24,7 @@ class PipelineModel extends BaseModel {
      * @method sync
      * @return {Promise}
      */
-    // TODO: make this so that it looks up the yaml & create/delete jobs if necessary
+    // TODO: update existing jobs, delete unneeded jobs
     sync() {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
@@ -31,13 +33,41 @@ class PipelineModel extends BaseModel {
         /* eslint-enable global-require */
 
         const factory = JobFactory.getInstance();
-        const jobConfig = {
-            pipelineId: this.id,
-            name: 'main',
-            containers: ['node:6']
-        };
 
-        return factory.create(jobConfig);
+        // get the admin user that has access to read the file, then get their unsealed git token
+        return this.admin.then(user => user.unsealToken)
+            // fetch the screwdriver.yaml file
+            .then(token =>
+                this.scm.getFile({
+                    scmUrl: this.scmUrl,
+                    path: 'screwdriver.yaml',
+                    token
+                })
+            )
+            // parse the content of the yaml file
+            .then(content => nodeify(parser, content))
+            // get list of jobs to create
+            .then(parsedConfig => {
+                const jobsToCreate = [];
+
+                // Loop through all defined jobs
+                Object.keys(parsedConfig.jobs).forEach(jobName => {
+                    const jobConfig = {
+                        pipelineId: this.id,
+                        name: jobName,
+                        containers: parsedConfig.jobs[jobName].map(j => j.image)
+                    };
+
+                    // add a method to create job
+                    jobsToCreate.push(factory.create(jobConfig));
+                });
+
+                return jobsToCreate;
+            })
+            // Wait until all job.create promises have resolved
+            .then(jobs => Promise.all(jobs))
+            // return the pipeline
+            .then(() => this);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "github": "^2.3.0",
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
+    "screwdriver-config-parser": "^2.0.0",
     "screwdriver-data-schema": "^10.0.1",
     "screwdriver-hashr": "^1.0.30"
   }

--- a/test/data/parser.json
+++ b/test/data/parser.json
@@ -1,0 +1,83 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "4"
+                }
+            },
+            {
+                "image": "node:5",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "5"
+                }
+            },
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "6"
+                }
+            }
+        ],
+        "publish": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "bump",
+                        "command": "npm run bump"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish --tag $NODE_TAG"
+                    },
+                    {
+                        "name": "tag",
+                        "command": "git push origin --tags"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_TAG": "latest"
+                }
+            }
+        ]
+    },
+    "workflow": [
+        "publish"
+    ]
+}


### PR DESCRIPTION
Use scm plugin to fetch screwdriver.yaml, parse contents, and create all jobs listed.
- Will add update & delete in following PR(s)
