### PR TITLE
Pass apiUri and tokenGen to build model

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -4,6 +4,8 @@ const nodeify = require('./nodeify');
 
 // Symbols for private members
 const executor = Symbol('executor');
+const apiUri = Symbol('apiUri');
+const tokenGen = Symbol('tokenGen');
 
 /**
  * Update status to SCM
@@ -25,12 +27,16 @@ class BuildModel extends BaseModel {
      * @param  {Object}    config.executor          Object that will perform executor operations
      * @param  {String}    config.username          The user that created this build
      * @param  {String}    config.jobId             The ID of the associated job to start
+     * @param  {String}    config.apiUri            URI back to the API
+     * @param  {String}    config.tokenGen          Generator for building tokens
      * @param  {String}    [config.sha]             The sha of the build
      * @param  {String}    [config.container]       The kind of container to use
      */
     constructor(config) {
         super('build', config);
         this[executor] = config.executor;
+        this[apiUri] = config.apiUri;
+        this[tokenGen] = config.tokenGen;
         this.username = config.username;
     }
 
@@ -38,10 +44,9 @@ class BuildModel extends BaseModel {
      * Update status to SCM
      * @method updateSCM
      * @param  {Pipeline}   pipeline     The build's pipeline
-     * @param  {String}     [apiUri]     Base uri for api server
      * @return {Promise}
      */
-    updateCommitStatus(pipeline, apiUri) {
+    updateCommitStatus(pipeline) {
         return pipeline.admin
             // update github
             .then(admin => admin.unsealToken())
@@ -50,12 +55,9 @@ class BuildModel extends BaseModel {
                     token: githubToken,
                     scmUrl: pipeline.scmUrl,
                     sha: this.sha,
-                    buildStatus: this.status
+                    buildStatus: this.status,
+                    url: `${this[apiUri]}/v3/builds/${this.id}/logs`
                 };
-
-                if (apiUri) {
-                    config.url = `${apiUri}/v3/builds/${this.id}/logs`;
-                }
 
                 return this.scm.updateCommitStatus(config);
             });
@@ -151,27 +153,21 @@ class BuildModel extends BaseModel {
     /**
      * Start this build and update github status as pending
      * @method start
-     * @param  {Object}  config
-     * @param  {String}  config.apiUri    URI back to the API
-     * @param  {String}  config.tokenGen  Generator for building tokens
      * @return {Promise}
      */
-    start(config) {
-        const apiUri = config.apiUri;
-        const token = config.tokenGen(this.id);
-
+    start() {
         // Make sure that a pipeline and job is associated with the build
         return this.pipeline
             // start the build
             .then(pipeline =>
                 nodeify.withContext(this[executor], 'start', [{
-                    apiUri,
+                    apiUri: this[apiUri],
                     buildId: this.id,
                     container: this.container,
-                    token
+                    token: this[tokenGen](this.id)
                 }])
                 // update github
-                .then(() => this.updateCommitStatus(pipeline, config.apiUri))
+                .then(() => this.updateCommitStatus(pipeline))
                 .then(() => this)
             );
     }

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -97,8 +97,6 @@ class BuildFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        const apiUri = config.apiUri;
-        const tokenGen = config.tokenGen;
         const number = Date.now();
         const createTime = (new Date(number)).toISOString();
         const modelConfig = hoek.applyToDefaults(config, {
@@ -107,10 +105,6 @@ class BuildFactory extends BaseFactory {
             number,
             status: 'QUEUED'
         });
-
-        // These aren't stored
-        delete modelConfig.apiUri;
-        delete modelConfig.tokenGen;
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
@@ -133,10 +127,7 @@ class BuildFactory extends BaseFactory {
 
                         return super.create(modelConfig);
                     })
-                    .then(build =>
-                        build.start({ apiUri, tokenGen })
-                            .then(() => build)
-                    );
+                    .then(build => build.start());
             });
     }
 


### PR DESCRIPTION
Currently, `apiUri` is only available on build `start`, so we can set the `target_url` for github status when we build starts. When the build finishes, we don't have `apiUri` passed in. 

This PR pass in `apiUri` & `tokenGen` to build model so that it's available everywhere. 
