### PR TITLE
createClass returns build that has apiUri and tokenGen

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -62,6 +62,8 @@ class BuildFactory extends BaseFactory {
     constructor(config) {
         super('build', config);
         this.executor = config.executor;
+        this.apiUri = null;
+        this.tokenGen = null;
     }
 
     /**
@@ -79,7 +81,9 @@ class BuildFactory extends BaseFactory {
     createClass(config) {
         // add executor to config
         const c = hoek.applyToDefaults(config, {
-            executor: this.executor
+            executor: this.executor,
+            apiUri: this.apiUri,
+            tokenGen: this.tokenGen
         });
 
         return new Build(c);
@@ -89,8 +93,6 @@ class BuildFactory extends BaseFactory {
      * Create a new Build
      * @method create
      * @param  {Object}    config                Config object
-     * @param  {String}    config.apiUri         URI back to the API
-     * @param  {Function}  config.tokenGen       Generator for building tokens
      * @param  {String}    config.jobId          The job associated with this build
      * @param  {String}    config.username       The user that created this build
      * @param  {String}    [config.sha]          The sha of the build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
So that when factory.get is called (for example in https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/build.js#L32), apiUri will be available in updateCommitStatus
