### PR TITLE
pass uiUri into build models for target_url

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -6,6 +6,7 @@ const nodeify = require('./nodeify');
 const executor = Symbol('executor');
 const apiUri = Symbol('apiUri');
 const tokenGen = Symbol('tokenGen');
+const uiUri = Symbol('uiUri');
 
 /**
  * Update status to SCM
@@ -28,6 +29,7 @@ class BuildModel extends BaseModel {
      * @param  {String}    config.username          The user that created this build
      * @param  {String}    config.jobId             The ID of the associated job to start
      * @param  {String}    config.apiUri            URI back to the API
+     * @param  {String}    config.uiUri             URI back to the UI
      * @param  {String}    config.tokenGen          Generator for building tokens
      * @param  {String}    [config.sha]             The sha of the build
      * @param  {String}    [config.container]       The kind of container to use
@@ -37,6 +39,7 @@ class BuildModel extends BaseModel {
         this[executor] = config.executor;
         this[apiUri] = config.apiUri;
         this[tokenGen] = config.tokenGen;
+        this[uiUri] = config.uiUri;
         this.username = config.username;
     }
 
@@ -56,7 +59,7 @@ class BuildModel extends BaseModel {
                     scmUrl: pipeline.scmUrl,
                     sha: this.sha,
                     buildStatus: this.status,
-                    url: `${this[apiUri]}/v3/builds/${this.id}/logs`
+                    url: `${this[uiUri]}/builds/${this.id}`
                 };
 
                 return this.scm.updateCommitStatus(config);

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -58,10 +58,12 @@ class BuildFactory extends BaseFactory {
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform datastore operations
      * @param  {Object}    config.executor      Object that will perform compute operations
+     * @param  {String}    config.uiUri         Partial Uri including hostname and namespace for ui for git notifications
      */
     constructor(config) {
         super('build', config);
         this.executor = config.executor;
+        this.uiUri = config.uiUri;
         this.apiUri = null;
         this.tokenGen = null;
     }
@@ -83,7 +85,8 @@ class BuildFactory extends BaseFactory {
         const c = hoek.applyToDefaults(config, {
             executor: this.executor,
             apiUri: this.apiUri,
-            tokenGen: this.tokenGen
+            tokenGen: this.tokenGen,
+            uiUri: this.uiUri
         });
 
         return new Build(c);
@@ -175,6 +178,9 @@ class BuildFactory extends BaseFactory {
     static getInstance(config) {
         if (!instance && (!config || !config.executor)) {
             throw new Error('No executor provided to BuildFactory');
+        }
+        if (!instance && (!config || !config.uiUri)) {
+            throw new Error('No uiUri provided to BuildFactory');
         }
 
         instance = BaseFactory.getInstance(BuildFactory, instance, config);

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -9,6 +9,7 @@ require('sinon-as-promised');
 
 describe('Build Model', () => {
     const apiUri = 'https://notify.com/some/endpoint';
+    const uiUri = 'https://display.com/some/endpoint';
     const jobId = '62089f642bbfd1886623964b4cff12db59869e5d';
     const now = 112233445566;
     const buildId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
@@ -18,7 +19,7 @@ describe('Build Model', () => {
     const pipelineId = 'cf23df2207d99a74fbe169e3eba035e633b65d94';
     const scmUrl = 'git@github.com:screwdriver-cd/models.git#master';
     const token = 'equivalentToOneQuarter';
-    const url = `${apiUri}/v3/builds/${buildId}/logs`;
+    const url = `${uiUri}/builds/${buildId}`;
     let BuildModel;
     let datastore;
     let executorMock;
@@ -92,7 +93,8 @@ describe('Build Model', () => {
             sha,
             scmPlugin: scmMock,
             apiUri,
-            tokenGen
+            tokenGen,
+            uiUri
         };
         build = new BuildModel(config);
     });
@@ -119,11 +121,11 @@ describe('Build Model', () => {
 
         // Also added a username members
         assert.strictEqual(build.username, config.username);
-        // executor is private
+        // private keys are private
         assert.isUndefined(build.executor);
-        // apiUri and tokenGen are private
         assert.isUndefined(build.apiUri);
         assert.isUndefined(build.tokenGen);
+        assert.isUndefined(build.uiUri);
     });
 
     describe('updateCommitStatus', () => {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -16,6 +16,7 @@ class Build {
         this.executor = config.executor;
         this.apiUri = config.apiUri;
         this.tokenGen = config.tokenGen;
+        this.uiUri = config.uiUri;
 
         this.start = startStub.resolves(this);
     }
@@ -33,6 +34,7 @@ describe('Build Factory', () => {
     let jobFactory;
     const apiUri = 'https://notify.com/some/endpoint';
     const tokenGen = sinon.stub();
+    const uiUri = 'http://display.com/some/endpoint';
 
     before(() => {
         mockery.enable({
@@ -78,7 +80,7 @@ describe('Build Factory', () => {
         // eslint-disable-next-line global-require
         BuildFactory = require('../../lib/buildFactory');
 
-        factory = new BuildFactory({ datastore, executor, scmPlugin: scmMock });
+        factory = new BuildFactory({ datastore, executor, scmPlugin: scmMock, uiUri });
         factory.apiUri = apiUri;
         factory.tokenGen = tokenGen;
     });
@@ -101,6 +103,7 @@ describe('Build Factory', () => {
             assert.deepEqual(model.executor, executor);
             assert.strictEqual(model.apiUri, apiUri);
             assert.deepEqual(model.tokenGen, tokenGen);
+            assert.strictEqual(model.uiUri, uiUri);
         });
     });
 
@@ -192,6 +195,7 @@ describe('Build Factory', () => {
                 assert.strictEqual(model.container, container);
                 assert.strictEqual(model.apiUri, apiUri);
                 assert.deepEqual(model.tokenGen, tokenGen);
+                assert.strictEqual(model.uiUri, uiUri);
                 assert.notCalled(userFactoryMock.get);
             });
         });
@@ -335,7 +339,7 @@ describe('Build Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, executor, scmPlugin: {} };
+            config = { datastore, executor, scmPlugin: {}, uiUri };
         });
 
         it('should utilize BaseFactory to get an instance', () => {
@@ -353,8 +357,12 @@ describe('Build Factory', () => {
                 Error, 'No executor provided to BuildFactory');
 
             assert.throw(() => {
-                BuildFactory.getInstance({ executor, scm: {} });
+                BuildFactory.getInstance({ executor, scm: {}, uiUri });
             }, Error, 'No datastore provided to BuildFactory');
+
+            assert.throw(() => {
+                BuildFactory.getInstance({ executor, scm: {}, datastore });
+            }, Error, 'No uiUri provided to BuildFactory');
         });
     });
 });


### PR DESCRIPTION
In order to generate the correct urls for the build page, we need the ui uri to be passed through to the build model.
