### PR TITLE
Add S3cr3t model

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ npm install screwdriver-models
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.PipelineFactory.getInstance({ datastore });
+const factory = Model.PipelineFactory.getInstance({
+    datastore,
+    scmPlugin
+});
 const config = {
     params: {
         configUrl: 'banana'
@@ -82,7 +85,10 @@ Example:
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.PipelineFactory.getInstance({ datastore });
+const factory = Model.PipelineFactory.getInstance({
+    datastore,
+    scmPlugin
+});
 const scmUrl = 'git@git.corp.yahoo.com:foo/BAR.git';
 factory.get({ scmUrl }).then(model => {
     model.configUrl = 'git@git.corp.yahoo.com:foo/bar.git#master';
@@ -110,7 +116,10 @@ Example:
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.PipelineFactory.getInstance({ datastore });
+const factory = Model.PipelineFactory.getInstance({
+    datastore,
+    scmPlugin
+});
 const scmUrl = 'git@git.corp.yahoo.com:foo/BAR.git';
 factory.get({ scmUrl }).then(model => {
     const formattedScmUrl = model.formatScmUrl(model.scmUrl);
@@ -123,7 +132,9 @@ factory.get({ scmUrl }).then(model => {
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.JobFactory.getInstance({ datastore });
+const factory = Model.JobFactory.getInstance({
+    datastore
+});
 const config = {
     params: {
         pipelineId: 'aabbccdd1234'
@@ -181,7 +192,9 @@ factory.get({ pipelineId, name }).then(model => {
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.JobFactory.getInstance({ datastore });
+const factory = Model.JobFactory.getInstance({
+    datastore
+});
 
 factory.get(id).then(model => {
     model.name = 'hello';
@@ -200,7 +213,12 @@ model.update()
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.BuildFactory.getInstance({ datastore });
+const factory = Model.BuildFactory.getInstance({  
+    datastore,
+    scmPlugin,
+    executor,
+    uiUri
+});
 const config = {
     params: {
         jobId: 'aaabbccdd1234'
@@ -261,7 +279,12 @@ factory.get({ jobId, number }).then(model => {
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.BuildFactory.getInstance(config);
+const factory = Model.BuildFactory.getInstance({  
+    datastore,
+    scmPlugin,
+    executor,
+    uiUri
+});
 
 factory.get(id).then(model => {
     model.state = 'FAILURE';
@@ -286,7 +309,11 @@ model.stream()
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.UserFactory.getInstance({ datastore });
+const factory = Model.UserFactory.getInstance({
+    datastore,
+    scmPlugin,
+    password            // Password to seal/unseal user's token
+});
 const config = {
     params: {
         username: 'batman'
@@ -344,7 +371,11 @@ factory.get({ username }).then(model => {
 ```js
 'use strict';
 const Model = require('screwdriver-models');
-const factory = Model.UserFactory.getInstance({ datastore });
+const factory = Model.UserFactory.getInstance({
+    datastore,
+    scmPlugin,
+    password                    // Password to seal/unseal user's token
+});
 const config = {
     username: 'myself',
     token: 'eyJksd3',            // User's github token
@@ -390,6 +421,92 @@ model.getPermissions(scmUrl)
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
 | scmUrl | String | The scmUrl of the repo |
+
+
+### Secret Factory
+#### Search
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.SecretFactory.getInstance({
+    datastore,
+    password            // Password for encryption operations
+});
+const config = {
+    params: {
+        pipelineId: '2d991790bab1ac8576097ca87f170df73410b55c'
+    },
+    paginate {
+        page: 2,
+        count: 3
+    }
+}
+
+factory.list(config).then(secrets => {
+    // Do stuff with list of secrets
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Config Object |
+| config.paginate.page | Number | The page for pagination |
+| config.paginate.count | Number | The count for pagination |
+| config.params | Object | fields to search on |
+
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with secret model
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.pipelineId | String | Yes | Pipeline that this secret belongs to |
+| config.name | String | Yes | Secret name |
+| config.value | String | Yes | Secret value |
+| config.allowInPR | String | Yes | Flag to denote if this secret can be shown in PR builds |
+
+#### Get
+Get a secret based on id. Can pass the generatedId for the secret, or the combination of pipelineId and secret name, and the id will be determined automatically.
+```js
+factory.get(id).then(model => {
+    // do stuff with secret model
+});
+
+factory.get({ pipelineId, name }).then(model => {
+    // do stuff with secret model
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | String | The unique ID for the build |
+| config.pipelineId | String | Pipeline that the secret belongs to |
+| config.name | String | Secret name |
+
+
+### Secret Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.SecretFactory.getInstance({
+    datastore,
+    password            // Password for encryption operations
+});
+const config = {
+    pipelineId: '2d991790bab1ac8576097ca87f170df73410b55c',
+    name: 'NPM_TOKEN',
+    value: banana,
+    allowInPR: false
+}
+
+factory.create(config)
+    .then(model => // do something
+    });
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,12 @@ factory.create(config)
     });
 ```
 
+#### Update
+Update a specific secret
+```
+model.update()
+```
+
 ## Testing
 
 ```bash

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -158,7 +158,8 @@ class BaseFactory {
      * @param  {Object}     instance            The current instance of a factory
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore    A datastore instance
-     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @param  {ScmPlugin}  [config.scmPlugin]  A scm plugin instance
+     * @param  {Executor}   [config.executor]   An executor instance
      * @return {Factory}
      */
     static getInstance(ClassDef, instance, config) {
@@ -169,10 +170,6 @@ class BaseFactory {
 
             if (!config || !config.datastore) {
                 throw new Error(`No datastore provided to ${className}`);
-            }
-
-            if (!config || !config.scmPlugin) {
-                throw new Error(`No scm plugin provided to ${className}`);
             }
 
             inst = new ClassDef(config);

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -158,8 +158,6 @@ class BaseFactory {
      * @param  {Object}     instance            The current instance of a factory
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore    A datastore instance
-     * @param  {ScmPlugin}  [config.scmPlugin]  A scm plugin instance
-     * @param  {Executor}   [config.executor]   An executor instance
      * @return {Factory}
      */
     static getInstance(ClassDef, instance, config) {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -182,6 +182,9 @@ class BuildFactory extends BaseFactory {
         if (!instance && (!config || !config.uiUri)) {
             throw new Error('No uiUri provided to BuildFactory');
         }
+        if (!instance && (!config || !config.scmPlugin)) {
+            throw new Error('No scm plugin provided to BuildFactory');
+        }
 
         instance = BaseFactory.getInstance(BuildFactory, instance, config);
 

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -53,7 +53,6 @@ class JobFactory extends BaseFactory {
      * @method getInstance
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore
-     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
      * @return {JobFactory}
      */
     static getInstance(config) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -3,6 +3,8 @@
 const BaseModel = require('./base');
 const parser = require('screwdriver-config-parser');
 const nodeify = require('./nodeify');
+const PAGINATE_PAGE = 1;
+const PAGINATE_COUNT = 25;
 
 class PipelineModel extends BaseModel {
     /**
@@ -121,8 +123,8 @@ class PipelineModel extends BaseModel {
                 pipelineId: this.id
             },
             paginate: {
-                count: 25, // This limit is set by the matrix restriction
-                page: 1
+                count: PAGINATE_COUNT, // This limit is set by the matrix restriction
+                page: PAGINATE_PAGE
             }
         };
 
@@ -144,6 +146,42 @@ class PipelineModel extends BaseModel {
         });
 
         return jobs;
+    }
+
+    /**
+     * Fetch all secrets that belong to this pipeline
+     * @property secrets
+     * @return Promise
+    */
+    get secrets() {
+        const listConfig = {
+            params: {
+                pipelineId: this.id
+            },
+            paginate: {
+                count: PAGINATE_COUNT,
+                page: PAGINATE_PAGE
+            }
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const SecretFactory = require('./secretFactory');
+        /* eslint-enable global-require */
+        const factory = SecretFactory.getInstance();
+
+        const secrets = factory.list(listConfig);
+
+        // ES6 has weird getters and setters in classes,
+        // so we redefine the pipeline property here to resolve to the
+        // resulting promise and not try to recreate the factory, etc.
+        Object.defineProperty(this, 'secrets', {
+            enumerable: true,
+            value: secrets
+        });
+
+        return secrets;
     }
 
     /**

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -58,6 +58,9 @@ class PipelineFactory extends BaseFactory {
      * @return {PipelineFactory}
      */
     static getInstance(config) {
+        if (!instance && (!config || !config.scmPlugin)) {
+            throw new Error('No scm plugin provided to PipelineFactory');
+        }
         instance = BaseFactory.getInstance(PipelineFactory, instance, config);
 
         return instance;

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -1,0 +1,21 @@
+'use strict';
+const BaseModel = require('./base');
+
+class SecretModel extends BaseModel {
+
+    /**
+     * Construct a SecretModel object
+     * @method constructor
+     * @param  {Object}   config                Config object to create the secret with
+     * @param  {Object}   config.datastore      Object that will perform operations on the datastore
+     * @param  {String}   config.pipelineId     Pipeline Id
+     * @param  {String}   config.name           Secret name
+     * @param  {String}   config.value          Secret value
+     * @param  {Boolean}  config.allowInPR      Whether this secret can be shown in PR builds
+     */
+    constructor(config) {
+        super('secret', config);
+    }
+}
+
+module.exports = SecretModel;

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -1,5 +1,9 @@
 'use strict';
 const BaseModel = require('./base');
+const nodeify = require('./nodeify');
+const iron = require('iron');
+// Get symbols for private fields
+const password = Symbol();
 
 class SecretModel extends BaseModel {
 
@@ -12,9 +16,25 @@ class SecretModel extends BaseModel {
      * @param  {String}   config.name           Secret name
      * @param  {String}   config.value          Secret value
      * @param  {Boolean}  config.allowInPR      Whether this secret can be shown in PR builds
+     * @param  {String}   config.password       The encryption password
      */
     constructor(config) {
         super('secret', config);
+        this[password] = config.password;
+    }
+
+    /**
+     * Update a secret with sealed secret value
+     * @method update
+     * @return {Promise}
+     */
+    update() {
+        return nodeify.withContext(iron, 'seal', [this.value, this[password], iron.defaults])
+            .then(sealed => {
+                this.value = sealed;
+
+                return super.update();
+            });
     }
 }
 

--- a/lib/secretFactory.js
+++ b/lib/secretFactory.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const Secret = require('./secret');
+const iron = require('iron');
+const nodeify = require('./nodeify');
+const hoek = require('hoek');
+// Get symbols for private fields
+const password = Symbol();
+
+let instance;
+
+/**
+ * Seal secret value
+ * @method sealSecret
+ * @param  {String}         secretvalue     Secret value to seal
+ * @param  {String}         pw              Password to seal with
+ * @return {Promise}
+ */
+function sealSecret(secretvalue, pw) {
+    return nodeify.withContext(iron, 'seal', [secretvalue, pw, iron.defaults]);
+}
+
+/**
+ * Unseal secret value and return the secret with the unsealed value
+ * @param  {SecretModel}        secret  Secret to unseal
+ * @param  {String}             pw      Password to unseal with[description]
+ * @return {Promise}
+ */
+function unsealSecret(secret, pw) {
+    return nodeify.withContext(iron, 'unseal', [secret.value, pw, iron.defaults])
+        .then(unsealed => {
+            secret.value = unsealed;
+
+            return secret;
+        });
+}
+
+class SecretFactory extends BaseFactory {
+    /**
+     * Construct a SecretFactory object
+     * @method constructor
+     * @param  {Object}    config
+     * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {String}    config.password      Password for encryption operations
+     */
+    constructor(config) {
+        super('secret', config);
+        this[password] = config.password;
+    }
+
+    /**
+     * Instantiate a Secret class
+     * @method createClass
+     * @param  config
+     * @return {Secret}
+     */
+    createClass(config) {
+        return new Secret(config);
+    }
+
+    /**
+     * Create a secret model
+     * Need to seal the secret before saving
+     * @method create
+     * @param  {Object}     config
+     * @param  {String}     config.pipelineId      Pipeline Id
+     * @param  {String}     config.name            Secret name
+     * @param  {String}     config.value           Secret value
+     * @param  {Boolean}    config.allowInPR       Whether this secret can be shown in PR builds
+     * @return {Promise}
+     */
+    create(config) {
+        return sealSecret(config.value, this[password])
+            .then(sealed => super.create(hoek.applyToDefaults(config, { value: sealed })));
+    }
+
+    /**
+     * Get a secret based on id
+     * @method get
+     * @param  {Mixed}   config    The configuration from which an id is generated or the actual id
+     * @return {Promise}
+     */
+    get(config) {
+        return super.get(config)
+            .then(secret => unsealSecret(secret, this[password]));
+    }
+
+    /**
+     * List secrets with pagination and filter options
+     * @method list
+     * @param  {Object}   config                  Config object
+     * @param  {Object}   config.params           Parameters to filter on
+     * @param  {Object}   config.paginate         Pagination parameters
+     * @param  {Number}   config.paginate.count   Number of items per page
+     * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @return {Promise}
+     */
+    list(config) {
+        return super.list(config).then(secrets =>
+            Promise.all(secrets.map(secret => unsealSecret(secret, this[password]))));
+    }
+
+    /**
+     * Get an instance of the SecretFactory
+     * @method getInstance
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore    A datastore instance
+     * @param  {String}     config.password     Password for encryption operations
+     * @return {SecretFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(SecretFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = SecretFactory;

--- a/lib/secretFactory.js
+++ b/lib/secretFactory.js
@@ -56,7 +56,9 @@ class SecretFactory extends BaseFactory {
      * @return {Secret}
      */
     createClass(config) {
-        return new Secret(config);
+        const c = hoek.applyToDefaults(config, { password: this[password] });
+
+        return new Secret(c);
     }
 
     /**

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -69,6 +69,9 @@ class UserFactory extends BaseFactory {
      * @return {UserFactory}
      */
     static getInstance(config) {
+        if (!instance && (!config || !config.scmPlugin)) {
+            throw new Error('No scm plugin provided to UserFactory');
+        }
         instance = BaseFactory.getInstance(UserFactory, instance, config);
 
         return instance;

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -288,9 +288,6 @@ describe('Base Factory', () => {
             assert.throw(() => {
                 BaseFactory.getInstance(BF, null);
             }, Error, 'No datastore provided to BF');
-            assert.throw(() => {
-                BaseFactory.getInstance(BF, null, { datastore });
-            }, Error, 'No scm plugin provided to BF');
         });
     });
 });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -357,11 +357,15 @@ describe('Build Factory', () => {
                 Error, 'No executor provided to BuildFactory');
 
             assert.throw(() => {
-                BuildFactory.getInstance({ executor, scm: {}, uiUri });
+                BuildFactory.getInstance({ executor, scmPlugin: {}, uiUri });
             }, Error, 'No datastore provided to BuildFactory');
 
             assert.throw(() => {
-                BuildFactory.getInstance({ executor, scm: {}, datastore });
+                BuildFactory.getInstance({ executor, datastore, uiUri });
+            }, Error, 'No scm plugin provided to BuildFactory');
+
+            assert.throw(() => {
+                BuildFactory.getInstance({ executor, scmPlugin: {}, datastore });
             }, Error, 'No uiUri provided to BuildFactory');
         });
     });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -18,6 +18,7 @@ describe('Pipeline Model', () => {
     let scmMock;
     let jobFactoryMock;
     let userFactoryMock;
+    let secretFactoryMock;
 
     const dateNow = 1111111111;
     const scmUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
@@ -49,6 +50,9 @@ describe('Pipeline Model', () => {
         userFactoryMock = {
             get: sinon.stub()
         };
+        secretFactoryMock = {
+            list: sinon.stub()
+        };
         scmMock = {
             getFile: sinon.stub()
         };
@@ -60,6 +64,8 @@ describe('Pipeline Model', () => {
         mockery.registerMock('./userFactory', {
             getInstance: sinon.stub().returns(userFactoryMock)
         });
+        mockery.registerMock('./secretFactory', {
+            getInstance: sinon.stub().returns(secretFactoryMock) });
 
         mockery.registerMock('screwdriver-hashr', hashaMock);
         mockery.registerMock('screwdriver-config-parser', parserMock);
@@ -296,6 +302,32 @@ describe('Pipeline Model', () => {
             // ...but the factory was not recreated, since the promise is stored
             // as the model's pipeline property, now
             assert.calledOnce(jobFactoryMock.list);
+        });
+    });
+
+    describe('get secrets', () => {
+        it('has a secrets getter', () => {
+            const listConfig = {
+                params: {
+                    pipelineId: pipeline.id
+                },
+                paginate: {
+                    count: 25, // This limit is set by the matrix restriction
+                    page: 1
+                }
+            };
+
+            secretFactoryMock.list.resolves(null);
+            // when we fetch secrets it resolves to a promise
+            assert.isFunction(pipeline.secrets.then);
+            // and a factory is called to create that promise
+            assert.calledWith(secretFactoryMock.list, listConfig);
+
+            // When we call pipeline.secrets again it is still a promise
+            assert.isFunction(pipeline.secrets.then);
+            // ...but the factory was not recreated, since the promise is stored
+            // as the model's pipeline property, now
+            assert.calledOnce(secretFactoryMock.list);
         });
     });
 

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -142,9 +142,17 @@ describe('Pipeline Factory', () => {
             assert.equal(f1, f2);
         });
 
-        it('should throw when config not supplied', () => {
+        it('should throw when config does not have everything necessary', () => {
             assert.throw(PipelineFactory.getInstance,
-                Error, 'No datastore provided to PipelineFactory');
+                Error, 'No scm plugin provided to PipelineFactory');
+
+            assert.throw(() => {
+                PipelineFactory.getInstance({ datastore });
+            }, Error, 'No scm plugin provided to PipelineFactory');
+
+            assert.throw(() => {
+                PipelineFactory.getInstance({ scmPlugin: {} });
+            }, Error, 'No datastore provided to PipelineFactory');
         });
     });
 });

--- a/test/lib/secret.test.js
+++ b/test/lib/secret.test.js
@@ -1,28 +1,98 @@
 'use strict';
 const assert = require('chai').assert;
 const sinon = require('sinon');
+const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
-const SecretModel = require('../../lib/secret');
-const BaseModel = require('../../lib/base');
 
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('Secret Model', () => {
-    it('is constructed properly', () => {
-        const createConfig = {
-            datastore: {},
+    const password = 'password';
+    let BaseModel;
+    let SecretModel;
+    let ironMock;
+    let datastore;
+    let createConfig;
+    let secret;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            update: sinon.stub()
+        };
+        ironMock = {
+            seal: sinon.stub(),
+            unseal: sinon.stub(),
+            defaults: {}
+        };
+
+        mockery.registerMock('iron', ironMock);
+
+        // eslint-disable-next-line global-require
+        BaseModel = require('../../lib/base');
+
+        // eslint-disable-next-line global-require
+        SecretModel = require('../../lib/secret');
+
+        createConfig = {
+            datastore,
             id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
             pipelineId: 'e124fb192747c9a0124e9e5b4e6e8e841cf8c71c',
             name: 'secret',
             value: 'batman',
-            allowInPR: true
+            allowInPR: true,
+            password
         };
-        const secret = new SecretModel(createConfig);
+        secret = new SecretModel(createConfig);
+    });
 
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
         assert.instanceOf(secret, SecretModel);
         assert.instanceOf(secret, BaseModel);
         schema.models.secret.allKeys.forEach(key => {
             assert.strictEqual(secret[key], createConfig[key]);
+        });
+    });
+
+    describe('update', () => {
+        beforeEach(() => {
+            ironMock.seal.yieldsAsync(null, 'sealedspiderman');
+        });
+
+        it('promises to update a secret and seal the value before datastore saves it', () => {
+            datastore.update.yieldsAsync(null, {});
+
+            secret.value = 'spiderman';
+
+            return secret.update()
+                .then(() => {
+                    assert.calledWith(ironMock.seal, 'spiderman', password, ironMock.defaults);
+                    assert.isTrue(datastore.update.calledWith({
+                        table: 'secrets',
+                        params: {
+                            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                            data: {
+                                value: 'sealedspiderman'
+                            }
+                        }
+                    }));
+                });
         });
     });
 });

--- a/test/lib/secret.test.js
+++ b/test/lib/secret.test.js
@@ -1,0 +1,28 @@
+'use strict';
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const schema = require('screwdriver-data-schema');
+const SecretModel = require('../../lib/secret');
+const BaseModel = require('../../lib/base');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Secret Model', () => {
+    it('is constructed properly', () => {
+        const createConfig = {
+            datastore: {},
+            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+            pipelineId: 'e124fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+            name: 'secret',
+            value: 'batman',
+            allowInPR: true
+        };
+        const secret = new SecretModel(createConfig);
+
+        assert.instanceOf(secret, SecretModel);
+        assert.instanceOf(secret, BaseModel);
+        schema.models.secret.allKeys.forEach(key => {
+            assert.strictEqual(secret[key], createConfig[key]);
+        });
+    });
+});

--- a/test/lib/secretFactory.test.js
+++ b/test/lib/secretFactory.test.js
@@ -1,0 +1,240 @@
+'use strict';
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Secret Factory', () => {
+    const password = 'totallySecurePassword';
+    const pipelineId = 'pipeline1';
+    const allowInPR = true;
+    const name = 'npm_token';
+    const sealed = 'erwijx342';
+    const unsealed = 'batman';
+    const secretData = {
+        id: 'abc123',
+        pipelineId,
+        name,
+        value: sealed,
+        allowInPR: true
+    };
+    let SecretFactory;
+    let datastore;
+    let hashaMock;
+    let ironMock;
+    let factory;
+    let Secret;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            scan: sinon.stub(),
+            get: sinon.stub()
+        };
+        hashaMock = {
+            sha1: sinon.stub()
+        };
+        ironMock = {
+            seal: sinon.stub(),
+            unseal: sinon.stub(),
+            defaults: 'defaults'
+        };
+
+        mockery.registerMock('screwdriver-hashr', hashaMock);
+        mockery.registerMock('iron', ironMock);
+
+        // eslint-disable-next-line global-require
+        Secret = require('../../lib/secret');
+        // eslint-disable-next-line global-require
+        SecretFactory = require('../../lib/secretFactory');
+
+        factory = new SecretFactory({ datastore, password });
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a Secret', () => {
+            const model = factory.createClass(secretData);
+
+            assert.instanceOf(model, Secret);
+        });
+    });
+
+    describe('create', () => {
+        it('should create a Secret', () => {
+            const generatedId = 'aabbccdd';
+            const expected = {
+                pipelineId,
+                name,
+                value: sealed,
+                allowInPR,
+                id: generatedId
+            };
+
+            ironMock.seal.yieldsAsync(null, sealed);
+            hashaMock.sha1.returns(generatedId);
+            datastore.save.yieldsAsync(null, expected);
+
+            return factory.create({
+                pipelineId,
+                name,
+                value: unsealed,
+                allowInPR
+            }).then(model => {
+                assert.calledWith(ironMock.seal, unsealed, password, 'defaults');
+                assert.instanceOf(model, Secret);
+                Object.keys(expected).forEach(key => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+    });
+
+    describe('get', () => {
+        const id = 'abc123';
+        const expected = {
+            pipelineId,
+            name,
+            value: unsealed,
+            allowInPR,
+            id
+        };
+
+        beforeEach(() => {
+            datastore.get.withArgs({
+                table: 'secrets',
+                params: {
+                    id
+                }
+            }).yieldsAsync(null, secretData);
+            hashaMock.sha1.returns(id);
+            ironMock.unseal.yieldsAsync(null, unsealed);
+        });
+
+        it('calls datastore get with id and returns correct values', () =>
+            factory.get(id)
+                .then(model => {
+                    assert.calledWith(ironMock.unseal, sealed, password, 'defaults');
+                    assert.instanceOf(model, Secret);
+                    assert.isTrue(datastore.get.calledOnce);
+                    Object.keys(expected).forEach(key => {
+                        assert.strictEqual(model[key], expected[key]);
+                    });
+                })
+        );
+
+        it('calls datastore get with config.id and returns correct values', () =>
+            factory.get({ id })
+                .then(model => {
+                    assert.calledWith(ironMock.unseal, sealed, password, 'defaults');
+                    assert.instanceOf(model, Secret);
+                    assert.isTrue(datastore.get.calledOnce);
+                    Object.keys(expected).forEach(key => {
+                        assert.strictEqual(model[key], expected[key]);
+                    });
+                })
+        );
+
+        it('calls datastore get with id generated from config and returns correct values', () =>
+            factory.get({ pipelineId, name })
+                .then(model => {
+                    assert.calledWith(ironMock.unseal, sealed, password, 'defaults');
+                    assert.instanceOf(model, Secret);
+                    assert.isTrue(datastore.get.calledOnce);
+                    Object.keys(expected).forEach(key => {
+                        assert.strictEqual(model[key], expected[key]);
+                    });
+                })
+        );
+    });
+
+    describe('list', () => {
+        const paginate = {
+            page: 1,
+            count: 2
+        };
+        const datastoreReturnValue = [{
+            id: '151c9b11e4a9a27e9e374daca6e59df37d8cf00f',
+            pipelineId: 'pipeline1',
+            name: 'secret1',
+            value: 'sealedsecret1value',
+            allowInPR: true
+        }, {
+            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+            pipelineId: 'pipeline1',
+            name: 'secret2',
+            value: 'sealedsecret2value',
+            allowInPR: false
+        }];
+
+        const returnValue = [{
+            id: '151c9b11e4a9a27e9e374daca6e59df37d8cf00f',
+            pipelineId: 'pipeline1',
+            name: 'secret1',
+            value: 'batman',
+            allowInPR: true
+        }, {
+            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+            pipelineId: 'pipeline1',
+            name: 'secret2',
+            value: 'superman',
+            allowInPR: false
+        }];
+
+        it('calls datastore scan and returns correct values', () => {
+            datastore.scan.yieldsAsync(null, datastoreReturnValue);
+            ironMock.unseal.withArgs('sealedsecret1value', password).yieldsAsync(null, 'batman');
+            ironMock.unseal.withArgs('sealedsecret2value', password).yieldsAsync(null, 'superman');
+
+            return factory.list({ paginate })
+                .then(arr => {
+                    assert.isArray(arr);
+                    assert.equal(arr.length, 2);
+                    assert.deepEqual(arr, returnValue);
+                    arr.forEach(model => {
+                        assert.instanceOf(model, Secret);
+                    });
+                });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+        });
+
+        it('should get an instance', () => {
+            const f1 = SecretFactory.getInstance(config);
+            const f2 = SecretFactory.getInstance(config);
+
+            assert.instanceOf(f1, SecretFactory);
+            assert.instanceOf(f2, SecretFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(SecretFactory.getInstance,
+                Error, 'No datastore provided to SecretFactory');
+        });
+    });
+});

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -112,9 +112,17 @@ describe('User Factory', () => {
             assert.equal(f1, f2);
         });
 
-        it('should throw when config not supplied', () => {
+        it('should throw when config does not have everything necessary', () => {
             assert.throw(UserFactory.getInstance,
-                Error, 'No datastore provided to UserFactory');
+                Error, 'No scm plugin provided to UserFactory');
+
+            assert.throw(() => {
+                UserFactory.getInstance({ datastore });
+            }, Error, 'No scm plugin provided to UserFactory');
+
+            assert.throw(() => {
+                UserFactory.getInstance({ scmPlugin: {} });
+            }, Error, 'No datastore provided to UserFactory');
         });
     });
 });


### PR DESCRIPTION
- Add a S3cr3t model. When `create`, it will seal the s3cr3t and store into the datastore. When `get`, it will unseal the s3cr3t and return the value. 
- S3cr3t does not use `scmPlugin`, so we add a check in `getInstance` so that it won't fail if `scmPlugin` is not passed in. Also, in `list`, we don't include `scmPlugin` in the config when calling `createClass`. 
- Add a `pipeline.secrets` to fetch all the s3cr3ts that belong to a pipeline
- Update README

Feature: https://github.com/screwdriver-cd/screwdriver/issues/148
