### PR TITLE
Adding isPR, jobID, and pipelineID to JWT for builds

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -160,18 +160,23 @@ class BuildModel extends BaseModel {
      */
     start() {
         // Make sure that a pipeline and job is associated with the build
-        return this.pipeline
-            // start the build
-            .then(pipeline =>
-                nodeify.withContext(this[executor], 'start', [{
-                    apiUri: this[apiUri],
-                    buildId: this.id,
-                    container: this.container,
-                    token: this[tokenGen](this.id)
-                }])
-                // update github
-                .then(() => this.updateCommitStatus(pipeline))
-                .then(() => this)
+        return this.job
+            .then(job =>
+                job.pipeline.then(pipeline =>
+                    nodeify.withContext(this[executor], 'start', [{
+                        apiUri: this[apiUri],
+                        buildId: this.id,
+                        container: this.container,
+                        token: this[tokenGen](this.id, {
+                            isPR: job.isPR(),
+                            jobId: job.id,
+                            pipelineId: pipeline.id
+                        })
+                    }])
+                    // update github
+                    .then(() => this.updateCommitStatus(pipeline))
+                    .then(() => this)
+                )
             );
     }
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -30,6 +30,7 @@ describe('Build Model', () => {
     let userFactoryMock;
     let jobFactoryMock;
     let scmMock;
+    let tokenGen;
 
     before(() => {
         mockery.enable({
@@ -61,13 +62,13 @@ describe('Build Model', () => {
         scmMock = {
             updateCommitStatus: sinon.stub().resolves(null)
         };
+        tokenGen = sinon.stub().returns(token);
         const uF = {
             getInstance: sinon.stub().returns(userFactoryMock)
         };
         const jF = {
             getInstance: sinon.stub().returns(jobFactoryMock)
         };
-        const tokenGen = sinon.stub().returns(token);
 
         mockery.registerMock('./userFactory', uF);
         mockery.registerMock('./jobFactory', jF);
@@ -293,7 +294,8 @@ describe('Build Model', () => {
                     id: pipelineId,
                     scmUrl,
                     admin: Promise.resolve(adminUser)
-                })
+                }),
+                isPR: () => false
             });
         });
 
@@ -305,6 +307,12 @@ describe('Build Model', () => {
                     buildId,
                     container,
                     token
+                });
+
+                assert.calledWith(tokenGen, buildId, {
+                    isPR: false,
+                    jobId,
+                    pipelineId
                 });
 
                 assert.calledWith(scmMock.updateCommitStatus, {


### PR DESCRIPTION
This will include additional information into the JWT served to builds