### PR TITLE
[DNM] Add getters for pipeline's workflow jobs and job's builds

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -2,6 +2,8 @@
 
 const BaseModel = require('./base');
 const hoek = require('hoek');
+const PAGINATE_PAGE = 1;
+const PAGINATE_COUNT = 25;
 
 class Job extends BaseModel {
     /**
@@ -73,6 +75,43 @@ class Job extends BaseModel {
         });
 
         return secretList;
+    }
+
+    /**
+     * Lazy load the list of builds sorted by createTime
+     * @property builds
+     * @return {Promise}       Resolves to a list of builds
+     */
+    get builds() {
+        const listConfig = {
+            params: {
+                jobId: this.id
+            },
+            paginate: {
+                count: PAGINATE_COUNT,
+                page: PAGINATE_PAGE
+            }
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const BuildFactory = require('./buildFactory');
+        /* eslint-enable global-require */
+        const factory = BuildFactory.getInstance();
+
+        const builds = factory.list(listConfig).then((records) => records.sort(
+            (build1, build2) => new Date(build2.createTime) - new Date(build1.createTime)));
+
+        // ES6 has weird getters and setters in classes,
+        // so we redefine the pipeline property here to resolve to the
+        // resulting promise and not try to recreate the factory, etc.
+        Object.defineProperty(this, 'builds', {
+            enumerable: true,
+            value: builds
+        });
+
+        return builds;
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -155,6 +155,51 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Get jobs in workflow
+     * @property workflowJobs
+     * @return {Promise}        Resolves to a list of jobs that are in the workflow
+     */
+    get workflowJobs() {
+        const listConfig = {
+            params: {
+                pipelineId: this.id
+            },
+            paginate: {
+                count: PAGINATE_COUNT,
+                page: PAGINATE_PAGE
+            }
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const JobFactory = require('./jobFactory');
+        /* eslint-enable global-require */
+        const factory = JobFactory.getInstance();
+
+        const workflow = this.workflow;
+        const workflowJobs = factory.list(listConfig)
+            .then((jobs) => {
+                // filter out jobs that are not in the workflow
+                const filteredJobs = jobs.filter(job => workflow.includes(job.name));
+
+                // sort the jobs by the order they appear in workflow
+                return filteredJobs.sort((job1, job2) =>
+                    workflow.indexOf(job1.name) - workflow.indexOf(job2.name));
+            });
+
+        // ES6 has weird getters and setters in classes,
+        // so we redefine the pipeline property here to resolve to the
+        // resulting promise and not try to recreate the factory, etc.
+        Object.defineProperty(this, 'workflowJobs', {
+            enumerable: true,
+            value: workflowJobs
+        });
+
+        return workflowJobs;
+    }
+
+    /**
      * Fetch all secrets that belong to this pipeline
      * @property secrets
      * @return Promise

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -9,6 +9,7 @@ require('sinon-as-promised');
 
 describe('Job Model', () => {
     let pipelineFactoryMock;
+    let buildFactoryMock;
     let JobModel;
     let datastore;
     let job;
@@ -47,9 +48,16 @@ describe('Job Model', () => {
                 ])
             })
         };
+        buildFactoryMock = {
+            list: sinon.stub()
+        };
 
         mockery.registerMock('./pipelineFactory', {
             getInstance: sinon.stub().returns(pipelineFactoryMock)
+        });
+
+        mockery.registerMock('./buildFactory', {
+            getInstance: sinon.stub().returns(buildFactoryMock)
         });
 
         // eslint-disable-next-line global-require
@@ -108,12 +116,48 @@ describe('Job Model', () => {
         assert.calledOnce(pipelineFactoryMock.get);
     });
 
-    it('can get secrets', () => (
+    it('can get secrets', () =>
         job.secrets.then((secrets) => {
             assert.isArray(secrets);
             assert.equal(secrets.length, 2);
         })
-    ));
+    );
+
+    it('can get all builds', () => {
+        const listConfig = {
+            params: {
+                jobId: '1234'
+            },
+            paginate: {
+                count: 25,
+                page: 1
+            }
+        };
+        const build1 = {
+            id: '9e7a7d519e3f2e29b840d5145c731f28193c9aw4',
+            createTime: '2016-08-18T23:59:23.058Z'
+        };
+        const build2 = {
+            id: '21fa4354ce6fc5b7249835d483f65916b3e5a34s',
+            createTime: '2016-08-18T23:59:21.888Z'
+        };
+        const build3 = {
+            id: '78855123cc7f1b808aac07feff24d7d5362cc312',
+            createTime: '2016-09-13T00:16:20.102Z'
+        };
+
+        buildFactoryMock.list.resolves([build1, build2, build3]);
+        const expected = [build3, build1, build2];
+
+        return job.builds.then((buildList) => {
+            assert.calledWith(buildFactoryMock.list, listConfig);
+            // the builds should be sorted
+            assert.deepEqual(buildList, expected);
+
+            return job.builds;
+            // When we call job.builds again, the factory is not recreated
+        }).then(() => assert.calledOnce(buildFactoryMock.list));
+    });
 
     it('throws error if pipeline missing', () => {
         pipelineFactoryMock.get.resolves(null);


### PR DESCRIPTION
- Add a job.builds, this should replace [getBuildsForJobId](https://github.com/screwdriver-cd/models/blob/master/lib/buildFactory.js#L147-L167). It's still being used by the [api](https://github.com/screwdriver-cd/screwdriver/blob/0e8edac41ee0b8fc1ddce3e93657acc12eb34175/plugins/webhooks/github.js#L80) so not removing it yet
- Add a pipeline.workflowJobs. The API will call this, and go through the jobs in the workflow, get the latest build (using job.builds above and get the first element) and construct the object that @petey  wants in the UI. 
