### PR TITLE
get and sort builds for a specific job

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -120,6 +120,7 @@ class BaseFactory {
      * @param  {Object}   config.paginate         Pagination parameters
      * @param  {Number}   config.paginate.count   Number of items per page
      * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @param  {String}   [config.sort]           Sorting option. 'ascending' or 'descending'
      * @return {Promise}
      */
     list(config) {
@@ -131,6 +132,10 @@ class BaseFactory {
                 page: config.paginate.page
             }
         };
+
+        if (config.sort) {
+            scanConfig.sort = config.sort;
+        }
 
         return nodeify.withContext(this.datastore, 'scan', [scanConfig])
             .then(data => {

--- a/lib/job.js
+++ b/lib/job.js
@@ -2,6 +2,8 @@
 
 const BaseModel = require('./base');
 const hoek = require('hoek');
+const PAGINATE_PAGE = 1;
+const PAGINATE_COUNT = 50;
 
 class Job extends BaseModel {
     /**
@@ -81,6 +83,44 @@ class Job extends BaseModel {
      */
     isPR() {
         return /^PR\-/.test(this.name);
+    }
+
+    /**
+     * Return builds that belong to this job
+     * @param  {Object}   [config]                  Configuration object
+     * @param  {String}   [config.sort]             Ascending or descending
+     * @param  {Object}   [config.paginate]         Pagination parameters
+     * @param  {Number}   [config.paginate.count]   Number of items per page
+     * @param  {Number}   [config.paginate.page]    Specific page of the set to return
+     * @return {Promise}                            List of builds
+     */
+    getBuilds(config) {
+        const sort = (config && config.sort) ? config.sort.toLowerCase() : 'descending';
+        let paginate = {
+            page: PAGINATE_PAGE,
+            count: PAGINATE_COUNT
+        };
+
+        if (config && config.paginate) {
+            paginate = hoek.applyToDefaults(paginate, config.paginate);
+        }
+
+        const listConfig = {
+            params: {
+                jobId: this.id
+            },
+            sort,                 // Sort by primary sort key
+            paginate
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const BuildFactory = require('./buildFactory');
+        /* eslint-enable global-require */
+        const factory = BuildFactory.getInstance();
+
+        return factory.list(listConfig);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -237,6 +237,20 @@ describe('Base Factory', () => {
                 });
         });
 
+        it('calls datastore scan with sorting option returns correct values', () => {
+            datastore.scan.yieldsAsync(null, returnValue);
+
+            return factory.list({ paginate, sort: 'ascending' })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        paginate,
+                        sort: 'ascending'
+                    });
+                });
+        });
+
         it('handles when the scan does not return an array', () => {
             datastore.scan.yieldsAsync(null, null);
 


### PR DESCRIPTION
Add a `getBuilds()` method for job. This optionally takes in a config object that specifies pagination & sorting options. If they are not passed in, use the default config: 

```
paginate: {
   page: 1, 
   count: 50
},
sort: 'descending'
```

If a field is missing, it will use the default value for that field. Sorting is always on primary range key for now, which is `build.number`

This will be use by the API for the route `jobs/id/builds`: https://github.com/screwdriver-cd/screwdriver/pull/186

Waiting on @FenrirUnbound 's implementation of the datastore. 

Solves https://github.com/screwdriver-cd/screwdriver/issues/187
