### PR TITLE
[6] Archive jobs

### DIFF
--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -43,7 +43,7 @@ class JobFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        const c = hoek.applyToDefaults(config, { state: 'ENABLED' });
+        const c = hoek.applyToDefaults(config, { state: 'ENABLED', archived: false });
 
         return super.create(c);
     }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -56,10 +56,11 @@ class PipelineModel extends BaseModel {
                             // if it's in the yaml, update it
                             if (parsedConfigJobNames.includes(job.name)) {
                                 job.permutations = parsedConfig.jobs[job.name];
+                                job.archived = false;
                                 jobsToSync.push(job.update());
-                            // if it's not in the yaml, disable it
+                            // if it's not in the yaml and archive it
                             } else if (!job.isPR()) {
-                                job.state = 'DISABLED';
+                                job.archived = true;
                                 jobsToSync.push(job.update());
                             }
                             // if it's a PR, leave it alone

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -77,7 +77,8 @@ describe('Job Factory', () => {
                 data: {
                     name,
                     pipelineId,
-                    state: 'ENABLED'
+                    state: 'ENABLED',
+                    archived: false
                 }
             }
         };
@@ -91,6 +92,7 @@ describe('Job Factory', () => {
                 name,
                 pipelineId,
                 state: 'ENABLED',
+                archived: false,
                 id: jobId
             };
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -227,6 +227,7 @@ describe('Pipeline Model', () => {
             return pipeline.sync()
                 .then(() => {
                     assert.calledOnce(jobs[0].update);
+                    assert.deepEqual(jobs[0].archived, false);
                     assert.deepEqual(jobs[0].permutations, [{
                         commands: [
                             { command: 'npm install', name: 'init' },
@@ -265,7 +266,7 @@ describe('Pipeline Model', () => {
             return pipeline.sync()
                 .then(() => {
                     assert.calledOnce(jobs[0].update);
-                    assert.equal(jobs[0].state, 'DISABLED');
+                    assert.equal(jobs[0].archived, true);
                 });
         });
 


### PR DESCRIPTION
The previous PR was for displaying non-archived jobs. 
This PR does the actual archiving on pipeline sync and job create.

For PR jobs, the change would need to be inside API: https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/github.js

Solves https://github.com/screwdriver-cd/screwdriver/issues/188
