### PR TITLE
[stop:1] Add build stop on done and refresh SCM repo on pipeline save

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const factory = Model.PipelineFactory.getInstance({
 });
 const config = {
     params: {
-        configUrl: 'banana'
+        scmUrl: 'banana'
     },
     paginate {
         page: 2,
@@ -53,7 +53,6 @@ factory.create(config).then(model => {
 | config        | Object | Yes | Configuration Object |
 | config.admins | Object | Yes | Admins for this pipeline, e.g { batman: true } |
 | config.scmUrl | String | Yes | Source Code URL for the application |
-| config.configUrl | String | No | Source Code URL for Screwdriver configuration |
 
 #### Get
 Get a pipeline based on id. Can pass the generatedId for the pipeline, or the unique keys for the model, and the id will be determined automatically.
@@ -91,7 +90,7 @@ const factory = Model.PipelineFactory.getInstance({
 });
 const scmUrl = 'git@git.corp.yahoo.com:foo/BAR.git';
 factory.get({ scmUrl }).then(model => {
-    model.configUrl = 'git@git.corp.yahoo.com:foo/bar.git#master';
+    model.scmUrl = 'git@git.corp.yahoo.com:foo/bar.git#master';
     return model.update();
 })
 ```

--- a/lib/build.js
+++ b/lib/build.js
@@ -214,38 +214,43 @@ class BuildModel extends BaseModel {
      * @return {Promise}
      */
     update() {
-        const dirty = this.isDirty('status');
+        let prom = Promise.resolve();
 
-        return super.update()
-            .then(() => {
-                if (!dirty) {
-                    return this;
-                }
+        // check if the status is changing
+        if (this.isDirty('status')) {
+            // stop the build if we're done
+            if (this.isDone()) {
+                prom = prom
+                    .then(() => this.stop());
+            }
+            // update scm with status
+            prom = prom
+                .then(() => this.pipeline)
+                .then(pipeline => this.updateCommitStatus(pipeline));
+        }
 
-                // update scm with status
-                return this.pipeline
-                    .then(pipeline => this.updateCommitStatus(pipeline))
-                    .then(() => this);
-            });
+        return prom
+            .then(() => super.update())
+            .then(() => this);
     }
 
     /**
-     * Stop a build and update github status as failure
+     * Stop a build
      * @method stop
      * @return {Promise}
      */
     stop() {
-        if (this.status !== 'QUEUED' && this.status !== 'RUNNING') {
-            return Promise.resolve(null);
-        }
-
-        // We are aborting the build here, setting the status so SCM updated properly
-        this.status = 'ABORTED';
-
-        // stop the build
         return this[executor].stop({ buildId: this.id })
-            // update status
-            .then(() => this.update());
+            .then(() => this);
+    }
+
+    /**
+     * Check if a build is doesntMatter
+     * @method isDone
+     * @return boolean
+     */
+    isDone() {
+        return ['ABORTED', 'FAILURE', 'SUCCESS'].includes(this.status);
     }
 }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -245,7 +245,7 @@ class BuildModel extends BaseModel {
     }
 
     /**
-     * Check if a build is doesntMatter
+     * Check if a build is done
      * @method isDone
      * @return boolean
      */

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -16,7 +16,6 @@ class PipelineModel extends BaseModel {
      * @param  {Object}   config.admins         The admins of this repository
      * @param  {String}   config.scmUrl         The scmUrl for the application
      * @param  {String}   config.createTime     The time the pipeline was created
-     * @param  {String}   config.configUrl      The configUrl for the application
      */
     constructor(config) {
         super('pipeline', config);
@@ -38,14 +37,17 @@ class PipelineModel extends BaseModel {
 
         const factory = JobFactory.getInstance();
 
-        // get the pipeline configuration
-        return this.getConfiguration()
+        // update the generated scm repo
+        return this.refreshScmRepo()
+            // get the pipeline configuration
+            .then(() => this.getConfiguration())
             // get list of jobs to create
             .then(parsedConfig => {
                 this.workflow = parsedConfig.workflow;
 
                 return this.update()
                     .then(() => this.jobs)
+                    // update job list
                     .then((existingJobs) => {
                         const jobsToSync = [];
                         const jobsProcessed = [];
@@ -227,28 +229,28 @@ class PipelineModel extends BaseModel {
         const workflow = this.workflow;
 
         return factory.list(listConfig)
-        .then((jobs) => {
-            // If archived is true, don't sort and just return jobs
-            if (listConfig.params.archived) {
-                return jobs;
-            }
+            .then((jobs) => {
+                // If archived is true, don't sort and just return jobs
+                if (listConfig.params.archived) {
+                    return jobs;
+                }
 
-            // If archived is false, sort by workflow then PR jobs
-            // get jobs in the workflow
-            let workflowJobs = jobs.filter(job => workflow.includes(job.name));
+                // If archived is false, sort by workflow then PR jobs
+                // get jobs in the workflow
+                let workflowJobs = jobs.filter(job => workflow.includes(job.name));
 
-            // sort them by the order that they appear in workflow
-            workflowJobs = workflowJobs.sort((job1, job2) =>
-                workflow.indexOf(job1.name) - workflow.indexOf(job2.name));
+                // sort them by the order that they appear in workflow
+                workflowJobs = workflowJobs.sort((job1, job2) =>
+                    workflow.indexOf(job1.name) - workflow.indexOf(job2.name));
 
-            // get PR jobs
-            let prJobs = jobs.filter(job => job.isPR());
+                // get PR jobs
+                let prJobs = jobs.filter(job => job.isPR());
 
-            // sort them by pr number
-            prJobs = prJobs.sort((job1, job2) => job1.prNum - job2.prNum);
+                // sort them by pr number
+                prJobs = prJobs.sort((job1, job2) => job1.prNum - job2.prNum);
 
-            return workflowJobs.concat(prJobs);
-        });
+                return workflowJobs.concat(prJobs);
+            });
     }
 
     /**
@@ -271,6 +273,34 @@ class PipelineModel extends BaseModel {
             )
             // parse the content of the yaml file
             .then(content => nodeify(parser, content));
+    }
+
+    /**
+     * Update the SCM Repo based on the SCM URL
+     * @method refreshScmRepo
+     * @return {Promise}
+     */
+    refreshScmRepo() {
+        // Skip if no changes
+        if (!this.isDirty('scmUrl') && this.scmRepo) {
+            return Promise.resolve();
+        }
+
+        // get the admin of the pipeline
+        return this.admin
+            // and their token
+            .then(user => user.unsealToken())
+            // get the expanded repo information
+            .then(token =>
+                this.scm.getRepoId({
+                    scmUrl: this.scmUrl,
+                    token
+                })
+            )
+            // and store it
+            .then(scmRepo => {
+                this.scmRepo = scmRepo;
+            });
     }
 }
 

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -24,7 +24,6 @@ class PipelineFactory extends BaseFactory {
      * @param  {String}    config.id            unique id
      * @param  {Object}    config.admins        hash of admin usernames
      * @param  {String}    config.scmUrl        url of source
-     * @param  {String}    [config.configUrl]   url of configuration
      * @return {Pipeline}
      */
     createClass(config) {
@@ -37,13 +36,11 @@ class PipelineFactory extends BaseFactory {
      * @param  {Object}   config                Config object
      * @param  {Object}   config.admins         The admins of this repository
      * @param  {String}   config.scmUrl         The scmUrl for the application
-     * @param  {String}   [config.configUrl]    The configUrl for the application
      * @return {Promise}
      */
     create(config) {
         const modelConfig = hoek.applyToDefaults({
-            createTime: (new Date()).toISOString(),
-            configUrl: config.scmUrl
+            createTime: (new Date()).toISOString()
         }, config);
 
         return super.create(modelConfig);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -50,7 +50,6 @@ describe('Pipeline Factory', () => {
             datastore,
             id: testId,
             scmUrl,
-            configUrl: scmUrl,
             createTime: nowTime,
             admins
         };
@@ -85,8 +84,7 @@ describe('Pipeline Factory', () => {
                 data: {
                     admins,
                     createTime: nowTime,
-                    scmUrl,
-                    configUrl: scmUrl
+                    scmUrl
                 }
             }
         };
@@ -109,8 +107,7 @@ describe('Pipeline Factory', () => {
                 id: testId,
                 admins,
                 createTime: nowTime,
-                scmUrl,
-                configUrl: scmUrl
+                scmUrl
             };
 
             datastore.save.yieldsAsync(null, expected);


### PR DESCRIPTION
Couple changes:
- `build.stop` just stops the job now (doesn't update the build or github status)
- `build.update` will stop the job if the build is done (helps cleanup old resources)
- `pipeline.sync` will update the `scmRepo` object
