### PR TITLE
Skip unseal if secret does not exist

### DIFF
--- a/lib/secretFactory.js
+++ b/lib/secretFactory.js
@@ -84,8 +84,13 @@ class SecretFactory extends BaseFactory {
      * @return {Promise}
      */
     get(config) {
-        return super.get(config)
-            .then(secret => unsealSecret(secret, this[password]));
+        return super.get(config).then(secret => {
+            if (!secret) {
+                return secret;
+            }
+
+            return unsealSecret(secret, this[password]);
+        });
     }
 
     /**

--- a/test/lib/secretFactory.test.js
+++ b/test/lib/secretFactory.test.js
@@ -163,6 +163,22 @@ describe('Secret Factory', () => {
                     });
                 })
         );
+
+        it('skip unseal when secret not found', () => {
+            datastore.get.withArgs({
+                table: 'secrets',
+                params: {
+                    id
+                }
+            }).resolves(null);
+
+            return factory.get({ pipelineId, name })
+                .then(model => {
+                    assert.isTrue(datastore.get.calledOnce);
+                    assert.notCalled(ironMock.unseal);
+                    assert.isNull(model);
+                });
+        });
     });
 
     describe('list', () => {


### PR DESCRIPTION
This is a bug. If secret does not exist, we should skip the unsealing of secret. Otherwise, it will try to read `secret.value` where secret is `null`
