### PR TITLE
PR sync reads screwdriver yaml from its branch instead of master branch

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -26,9 +26,10 @@ class PipelineModel extends BaseModel {
      * Create, update, or disable jobs if necessary.
      * Store/update the pipeline workflow
      * @method sync
+     * @param  [String]   scmUrl                Optional scmUrl to sync
      * @return {Promise}
      */
-    sync() {
+    sync(scmUrl) {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -40,7 +41,7 @@ class PipelineModel extends BaseModel {
         // update the generated scm repo
         return this.refreshScmRepo()
             // get the pipeline configuration
-            .then(() => this.getConfiguration())
+            .then(() => this.getConfiguration(scmUrl))
             // get list of jobs to create
             .then(parsedConfig => {
                 this.workflow = parsedConfig.workflow;

--- a/test/data/prParser.json
+++ b/test/data/prParser.json
@@ -1,0 +1,72 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "4"
+                }
+            },
+            {
+                "image": "node:5",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "5"
+                }
+            },
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "6"
+                }
+            }
+        ],
+        "functional": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "functional",
+                        "command": "npm run functional"
+                    }
+                ]
+            }
+        ]
+    },
+    "workflow": [
+        "main",
+        "functional"
+    ]
+}


### PR DESCRIPTION
Currently, PR build reads screwdriver.yaml from master branch. I think we can add this, then in webhooks, pass in the scmUrl: https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/github.js#L208 
