### PR TITLE
Remove getBuildsForJobId

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -144,28 +144,6 @@ class BuildFactory extends BaseFactory {
     }
 
     /**
-     * Gets all the builds for a given jobId
-     * @method getBuildsForJobId
-     * @param  {Object}   config                Config object
-     * @param  {String}   config.jobId          The jobId of the build to filter for
-     * @return {Promise}                        List of Build models
-     */
-    getBuildsForJobId(config) {
-        const listConfig = {
-            params: {
-                jobId: config.jobId
-            },
-            paginate: {
-                count: 25, // This limit is set by the matrix restriction
-                page: 1
-            }
-        };
-
-        return this.list(listConfig)
-            .then((records) => records.sort((build1, build2) => build1.number - build2.number));
-    }
-
-    /**
      * Get an instance of the BuildFactory
      * @method getInstance
      * @param  {Object}     [config]            Configuration required for first call

--- a/lib/job.js
+++ b/lib/job.js
@@ -133,6 +133,28 @@ class Job extends BaseModel {
     }
 
     /**
+     * Return all running builds that belong to this job
+     * @return {Promise}        List of running builds
+     */
+    getRunningBuilds() {
+        const listConfig = {
+            params: {
+                jobId: this.id,
+                status: ['RUNNING', 'QUEUED']
+            }
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const BuildFactory = require('./buildFactory');
+        /* eslint-enable global-require */
+        const factory = BuildFactory.getInstance();
+
+        return factory.list(listConfig);
+    }
+
+    /**
      * Remove all builds associated with this job and the job itself
      * @return {Promise}        Resolves to null if remove successfully
      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -272,68 +272,6 @@ describe('Build Factory', () => {
         });
     });
 
-    describe('getBuildsForJobId', () => {
-        const config = {
-            jobId: 'jobId',
-            paginate: {
-                page: 1,
-                count: 25
-            }
-        };
-        const buildData = [{
-            jobId: 'jobId',
-            number: 1
-        }, {
-            jobId: 'jobId',
-            number: 3
-        }, {
-            jobId: 'jobId',
-            number: 2
-        }];
-
-        beforeEach(() => {
-            datastore.scan.resolves(buildData);
-        });
-
-        it('promises to call getBuildsForJobId', () =>
-            factory.getBuildsForJobId(config)
-                .then((builds) => {
-                    assert.isArray(builds);
-                    assert.calledWith(datastore.scan, {
-                        table: 'builds',
-                        params: {
-                            jobId: 'jobId'
-                        },
-                        paginate: {
-                            page: 1,
-                            count: 25
-                        }
-                    });
-
-                    // make result is sorted Build models
-                    builds.forEach((model, iter) => {
-                        assert.instanceOf(model, Build);
-                        // TODO: should these be sorted decending?
-                        assert.equal(model.number, iter + 1);
-                    });
-                })
-        );
-
-        it('rejects when datastore.scan fails', () => {
-            const expectedError = new Error('noBuildsNoJobsNoService');
-
-            datastore.scan.rejects(expectedError);
-
-            return factory.getBuildsForJobId(config)
-                .then(() => {
-                    assert.fail('This should not fail the test');
-                })
-                .catch((err) => {
-                    assert.deepEqual(err, expectedError);
-                });
-        });
-    });
-
     describe('getInstance', () => {
         let config;
 

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -264,6 +264,21 @@ describe('Job Model', () => {
         });
     });
 
+    describe('getRunningBuilds', () => {
+        it('gets all running builds', () => {
+            const expected = {
+                params: {
+                    jobId: '1234',
+                    status: ['RUNNING', 'QUEUED']
+                }
+            };
+
+            return job.getRunningBuilds().then(() => {
+                assert.calledWith(buildFactoryMock.list, expected);
+            });
+        });
+    });
+
     describe('remove', () => {
         afterEach(() => {
             buildFactoryMock.list.reset();


### PR DESCRIPTION
- Remove getBuildsForJobId
- Add a function to get all running builds. This is to simplify the actions required in the API for PR sync. We won't need to call getBuilds recursively when pagination is added.

Relates to https://github.com/screwdriver-cd/screwdriver/issues/241
