### PR TITLE
Set code on unfinished steps when build is updated to done

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -6,6 +6,7 @@ const executor = Symbol('executor');
 const apiUri = Symbol('apiUri');
 const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
+const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
 
 /**
  * Update status to SCM
@@ -209,6 +210,24 @@ class BuildModel extends BaseModel {
     }
 
     /**
+     * Abort running steps. If no steps ever ran, abort the first step
+     * @method abortSteps
+     */
+    abortSteps() {
+        const now = (new Date()).toISOString();
+
+        // Fail any running steps
+        this.steps = this.steps.map(step => {
+            if (step.startTime && !step.endTime) {
+                step.endTime = now;
+                step.code = ABORT_CODE;
+            }
+
+            return step;
+        });
+    }
+
+    /**
      * Update a build and update github status
      * @method update
      * @return {Promise}
@@ -220,6 +239,7 @@ class BuildModel extends BaseModel {
         if (this.isDirty('status')) {
             // stop the build if we're done
             if (this.isDone()) {
+                this.abortSteps();
                 prom = prom
                     .then(() => this.stop());
             }


### PR DESCRIPTION
Builds that are aborted by the user or launcher do not result in the step codes being updated. This causes odd behavior in the API and UI related to logging like: https://github.com/screwdriver-cd/screwdriver/issues/248
