### PR TITLE
List config expects pagination to be defined

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -2,6 +2,8 @@
 const schema = require('screwdriver-data-schema');
 const hashr = require('screwdriver-hashr');
 const hoek = require('hoek');
+const PAGINATE_PAGE = 1;
+const PAGINATE_COUNT = 50;
 
 class BaseFactory {
     /**
@@ -114,12 +116,12 @@ class BaseFactory {
     /**
      * List records with pagination and filter options
      * @method list
-     * @param  {Object}   config                  Config object
-     * @param  {Object}   config.params           Parameters to filter on
-     * @param  {Object}   config.paginate         Pagination parameters
-     * @param  {Number}   config.paginate.count   Number of items per page
-     * @param  {Number}   config.paginate.page    Specific page of the set to return
-     * @param  {String}   [config.sort]           Sorting option. 'ascending' or 'descending'
+     * @param  {Object}   config                    Config object
+     * @param  {Object}   config.params             Parameters to filter on
+     * @param  {Object}   [config.paginate]         Pagination parameters
+     * @param  {Number}   [config.paginate.count]   Number of items per page
+     * @param  {Number}   [config.paginate.page]    Specific page of the set to return
+     * @param  {String}   [config.sort]             Sorting option. 'ascending' or 'descending'
      * @return {Promise}
      */
     list(config) {
@@ -127,8 +129,8 @@ class BaseFactory {
             table: this.table,
             params: config.params || {},
             paginate: {
-                count: config.paginate.count,
-                page: config.paginate.page
+                count: hoek.reach(config, 'paginate.count', { default: PAGINATE_COUNT }),
+                page: hoek.reach(config, 'paginate.page', { default: PAGINATE_PAGE })
             }
         };
 

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -248,6 +248,20 @@ describe('Base Factory', () => {
                 })
         );
 
+        it('sets default paginate values', () =>
+            factory.list({})
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        paginate: {
+                            page: 1,
+                            count: 50
+                        }
+                    });
+                })
+        );
+
         it('calls datastore scan with sorting option returns correct values', () =>
             factory.list({ paginate, sort: 'ascending' })
                 .then(() => {


### PR DESCRIPTION
We don't have pagination, but baseFactory's list method still expects pagination to be passed in: https://github.com/screwdriver-cd/models/blob/master/lib/baseFactory.js#L125-L133

This is causing:

```
161007/234620.188, [request,server,error] data: TypeError: Cannot read property 'count' of undefined
    at BuildFactory.list (/usr/src/app/node_modules/screwdriver-models/lib/baseFactory.js:130:39)
    at Job.getRunningBuilds (/usr/src/app/node_modules/screwdriver-models/lib/job.js:154:24)
    at stopJob (/usr/src/app/node_modules/screwdriver-api/plugins/webhooks/github.js:28:16)
    at jobFactory.get.then.job (/usr/src/app/node_modules/screwdriver-api/plugins/webhooks/github.js:115:13)
    at process._tickDomainCallback (internal/process/next_tick.js:129:7)
```
