### PR TITLE
Removing the Plugin in ScmPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install screwdriver-models
 const Model = require('screwdriver-models');
 const factory = Model.PipelineFactory.getInstance({
     datastore,
-    scmPlugin
+    scm
 });
 const config = {
     params: {
@@ -86,7 +86,7 @@ Example:
 const Model = require('screwdriver-models');
 const factory = Model.PipelineFactory.getInstance({
     datastore,
-    scmPlugin
+    scm
 });
 const scmUrl = 'git@git.corp.yahoo.com:foo/BAR.git';
 factory.get({ scmUrl }).then(model => {
@@ -99,31 +99,6 @@ factory.get({ scmUrl }).then(model => {
 Sync the pipeline. Look up the configuration in the repo to create and delete jobs if necessary.
 ```
 model.sync()
-```
-
-#### Format the Scm Url
-Format the scm url. Will make the scm url lower case and add a #master branch name if a branch name is not already specified.
-```
-model.formatScmUrl(scmUrl)
-```
-
-| Parameter        | Type  | Required  |  Description |
-| :-------------   | :---- | :---- | :-------------|
-| scmUrl        | String | Yes | Github scm url |
-
-Example:
-```js
-'use strict';
-const Model = require('screwdriver-models');
-const factory = Model.PipelineFactory.getInstance({
-    datastore,
-    scmPlugin
-});
-const scmUrl = 'git@git.corp.yahoo.com:foo/BAR.git';
-factory.get({ scmUrl }).then(model => {
-    const formattedScmUrl = model.formatScmUrl(model.scmUrl);
-    console.log(formattedScmUrl);   // Prints 'git@git.corp.yahoo.com:foo/bar.git#master'
-})
 ```
 
 ### Job Factory
@@ -214,7 +189,7 @@ model.update()
 const Model = require('screwdriver-models');
 const factory = Model.BuildFactory.getInstance({  
     datastore,
-    scmPlugin,
+    scm,
     executor,
     uiUri
 });
@@ -280,7 +255,7 @@ factory.get({ jobId, number }).then(model => {
 const Model = require('screwdriver-models');
 const factory = Model.BuildFactory.getInstance({  
     datastore,
-    scmPlugin,
+    scm,
     executor,
     uiUri
 });
@@ -310,7 +285,7 @@ model.stream()
 const Model = require('screwdriver-models');
 const factory = Model.UserFactory.getInstance({
     datastore,
-    scmPlugin,
+    scm,
     password            // Password to seal/unseal user's token
 });
 const config = {
@@ -372,7 +347,7 @@ factory.get({ username }).then(model => {
 const Model = require('screwdriver-models');
 const factory = Model.UserFactory.getInstance({
     datastore,
-    scmPlugin,
+    scm,
     password                    // Password to seal/unseal user's token
 });
 const config = {

--- a/lib/base.js
+++ b/lib/base.js
@@ -7,7 +7,7 @@ const dirty = Symbol();
 const model = Symbol();
 const table = Symbol();
 const datastore = Symbol();
-const scmPlugin = Symbol();
+const scm = Symbol();
 
 class BaseModel {
     /**
@@ -16,13 +16,13 @@ class BaseModel {
      * @param  {String}     modelName           Name of the model to get from data-schema
      * @param  {Object}     config
      * @param  {Object}     config.datastore    Object that will perform operations on the datastore
-     * @param  {Object}     config.scmPlugin    Object that will perform operations on scm resources
+     * @param  {Object}     config.scm          Object that will perform operations on scm resources
      */
     constructor(modelName, config) {
         this[model] = schema.models[modelName];
         this[table] = this[model].tableName;
         this[datastore] = config.datastore;
-        this[scmPlugin] = config.scmPlugin;
+        this[scm] = config.scm;
         this[rowData] = {};
         this[dirty] = [];
 
@@ -44,7 +44,7 @@ class BaseModel {
     }
 
     get scm() {
-        return this[scmPlugin];
+        return this[scm];
     }
 
     /**

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -12,13 +12,13 @@ class BaseFactory {
      * @param  {String}    modelName            Name of the model to get from data-schema
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
-     * @param  {Object}    config.scmPlugin     Object that will perform operations on scm resource
+     * @param  {Object}    config.scm           Object that will perform operations on scm resource
      */
     constructor(modelName, config) {
         this.model = schema.models[modelName];
         this.table = this.model.tableName;
         this.datastore = config.datastore;
-        this.scmPlugin = config.scmPlugin;
+        this.scm = config.scm;
     }
 
     /**
@@ -72,7 +72,7 @@ class BaseFactory {
         return this.datastore.save(modelConfig)
             .then(modelData => this.createClass(hoek.applyToDefaults(config, {
                 datastore: this.datastore,
-                scmPlugin: this.scmPlugin,
+                scm: this.scm,
                 id: modelData.id
             })));
     }
@@ -108,7 +108,7 @@ class BaseFactory {
 
                 return this.createClass(hoek.applyToDefaults(data, {
                     datastore: this.datastore,
-                    scmPlugin: this.scmPlugin
+                    scm: this.scm
                 }));
             });
     }
@@ -149,7 +149,7 @@ class BaseFactory {
                 data.forEach(item => {
                     result.push(this.createClass(hoek.applyToDefaults(item, {
                         datastore: this.datastore,
-                        scmPlugin: this.scmPlugin
+                        scm: this.scm
                     })));
                 });
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -10,7 +10,7 @@ let instance;
  * @method getCommitSha
  * @param  {Object}         config
  * @param  {JobModel}       config.job                  Instance of Job Model
- * @param  {Scm}            config.scmPlugin            Instance of scmPlugin
+ * @param  {Scm}            config.scm                  Instance of SCM
  * @param  {Object}         config.modelConfig          Configuration passed to the build model
  * @param  {String}         [config.modelConfig.sha]    The sha we are ultimately looking for
  * @param  {String}         config.modelConfig.username The name of the user
@@ -44,7 +44,7 @@ function getCommitSha(config) {
         }
 
         return user.unsealToken()
-            .then(token => config.scmPlugin.getCommitSha({
+            .then(token => config.scm.getCommitSha({
                 scmUrl: pipeline.scmUrl,
                 token
             }));
@@ -124,7 +124,7 @@ class BuildFactory extends BaseFactory {
                     throw new Error('Job does not exist');
                 }
 
-                return getCommitSha({ job, scmPlugin: this.scmPlugin, modelConfig })
+                return getCommitSha({ job, scm: this.scm, modelConfig })
                     .then(sha => {
                         // TODO: support matrix jobs
                         const index = number.toString().split('.')[1] || 0;
@@ -149,7 +149,7 @@ class BuildFactory extends BaseFactory {
      * @param  {Object}     [config]            Configuration required for first call
      * @param  {Datastore}  config.datastore    Datastore instance
      * @param  {Executor}   config.executor     Executor instance
-     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @param  {Scm}        config.scm          SCM instance
      * @return {BuildFactory}
      */
     static getInstance(config) {
@@ -159,7 +159,7 @@ class BuildFactory extends BaseFactory {
         if (!instance && (!config || !config.uiUri)) {
             throw new Error('No uiUri provided to BuildFactory');
         }
-        if (!instance && (!config || !config.scmPlugin)) {
+        if (!instance && (!config || !config.scm)) {
             throw new Error('No scm plugin provided to BuildFactory');
         }
 

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -51,11 +51,11 @@ class PipelineFactory extends BaseFactory {
      * @method getInstance
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore    A datastore instance
-     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @param  {Datastore}  config.scm          A scm instance
      * @return {PipelineFactory}
      */
     static getInstance(config) {
-        if (!instance && (!config || !config.scmPlugin)) {
+        if (!instance && (!config || !config.scm)) {
             throw new Error('No scm plugin provided to PipelineFactory');
         }
         instance = BaseFactory.getInstance(PipelineFactory, instance, config);

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -65,11 +65,11 @@ class UserFactory extends BaseFactory {
      * @method getInstance
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore    A datastore instance
-     * @param  {Datastore}  config.scmPlugin    A scm plugin instance
+     * @param  {Scm}        config.scm          A scm instance
      * @return {UserFactory}
      */
     static getInstance(config) {
-        if (!instance && (!config || !config.scmPlugin)) {
+        if (!instance && (!config || !config.scm)) {
             throw new Error('No scm plugin provided to UserFactory');
         }
         instance = BaseFactory.getInstance(UserFactory, instance, config);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {
@@ -32,10 +32,10 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^1.12.0",
+    "eslint-plugin-import": "^2.0.0",
     "jenkins-mocha": "^3.0.0",
     "joi": "^9.0.4",
-    "mockery": "^1.7.0",
+    "mockery": "^2.0.0",
     "sinon": "^1.17.4",
     "sinon-as-promised": "^4.0.2"
   },

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -11,7 +11,7 @@ describe('Base Model', () => {
     let schemaMock;
     let base;
     let config;
-    let scmPlugin;
+    let scm;
 
     before(() => {
         mockery.enable({
@@ -21,7 +21,7 @@ describe('Base Model', () => {
     });
 
     beforeEach(() => {
-        scmPlugin = {
+        scm = {
             foo: 'foo'
         };
         datastore = {
@@ -46,7 +46,7 @@ describe('Base Model', () => {
 
         config = {
             datastore,
-            scmPlugin,
+            scm,
             id: 'as12345',
             foo: 'foo',
             bar: 'bar'
@@ -190,7 +190,7 @@ describe('Base Model', () => {
 
     describe('scm', () => {
         it('should have a getter for the scm plugin', () => {
-            assert.equal(base.scm, scmPlugin);
+            assert.equal(base.scm, scm);
         });
     });
 });

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 
 class Base {
     constructor(config) {
-        this.scmPlugin = config.scmPlugin;
+        this.scm = config.scm;
         this.datastore = config.datastore;
     }
 }
@@ -18,7 +18,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('Base Factory', () => {
     let BaseFactory;
     let datastore;
-    let scmPlugin;
+    let scm;
     let hashaMock;
     let factory;
     let schema;
@@ -31,7 +31,7 @@ describe('Base Factory', () => {
     });
 
     beforeEach(() => {
-        scmPlugin = {};
+        scm = {};
         datastore = {
             save: sinon.stub(),
             scan: sinon.stub(),
@@ -56,7 +56,7 @@ describe('Base Factory', () => {
         // eslint-disable-next-line global-require
         BaseFactory = require('../../lib/baseFactory');
 
-        factory = new BaseFactory('base', { datastore, scmPlugin });
+        factory = new BaseFactory('base', { datastore, scm });
     });
 
     afterEach(() => {
@@ -120,7 +120,7 @@ describe('Base Factory', () => {
                 assert.isTrue(datastore.save.calledWith(saveConfig));
                 assert.instanceOf(model, Base);
                 assert.deepEqual(model.datastore, datastore);
-                assert.deepEqual(model.scmPlugin, scmPlugin);
+                assert.deepEqual(model.scm, scm);
             });
         });
 
@@ -163,7 +163,7 @@ describe('Base Factory', () => {
                     assert.instanceOf(model, Base);
                     assert.isTrue(datastore.get.calledOnce);
                     assert.deepEqual(model.datastore, datastore);
-                    assert.deepEqual(model.scmPlugin, scmPlugin);
+                    assert.deepEqual(model.scm, scm);
                 })
         );
 
@@ -173,7 +173,7 @@ describe('Base Factory', () => {
                     assert.instanceOf(model, Base);
                     assert.isTrue(datastore.get.calledOnce);
                     assert.deepEqual(model.datastore, datastore);
-                    assert.deepEqual(model.scmPlugin, scmPlugin);
+                    assert.deepEqual(model.scm, scm);
                 })
         );
 
@@ -183,7 +183,7 @@ describe('Base Factory', () => {
                     assert.instanceOf(model, Base);
                     assert.isTrue(datastore.get.calledOnce);
                     assert.deepEqual(model.datastore, datastore);
-                    assert.deepEqual(model.scmPlugin, scmPlugin);
+                    assert.deepEqual(model.scm, scm);
                 })
         );
 
@@ -243,7 +243,7 @@ describe('Base Factory', () => {
                     arr.forEach(model => {
                         assert.instanceOf(model, Base);
                         assert.deepEqual(model.datastore, datastore);
-                        assert.deepEqual(model.scmPlugin, scmPlugin);
+                        assert.deepEqual(model.scm, scm);
                     });
                 })
         );
@@ -303,7 +303,7 @@ describe('Base Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, scmPlugin };
+            config = { datastore, scm };
         });
 
         it('should encapsulate new, and act as a singleton', () => {

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -91,7 +91,7 @@ describe('Build Model', () => {
             number: now,
             status: 'QUEUED',
             sha,
-            scmPlugin: scmMock,
+            scm: scmMock,
             apiUri,
             tokenGen,
             uiUri

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -80,7 +80,7 @@ describe('Build Factory', () => {
         // eslint-disable-next-line global-require
         BuildFactory = require('../../lib/buildFactory');
 
-        factory = new BuildFactory({ datastore, executor, scmPlugin: scmMock, uiUri });
+        factory = new BuildFactory({ datastore, executor, scm: scmMock, uiUri });
         factory.apiUri = apiUri;
         factory.tokenGen = tokenGen;
     });
@@ -276,7 +276,7 @@ describe('Build Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, executor, scmPlugin: {}, uiUri };
+            config = { datastore, executor, scm: {}, uiUri };
         });
 
         it('should utilize BaseFactory to get an instance', () => {
@@ -294,7 +294,7 @@ describe('Build Factory', () => {
                 Error, 'No executor provided to BuildFactory');
 
             assert.throw(() => {
-                BuildFactory.getInstance({ executor, scmPlugin: {}, uiUri });
+                BuildFactory.getInstance({ executor, scm: {}, uiUri });
             }, Error, 'No datastore provided to BuildFactory');
 
             assert.throw(() => {
@@ -302,7 +302,7 @@ describe('Build Factory', () => {
             }, Error, 'No scm plugin provided to BuildFactory');
 
             assert.throw(() => {
-                BuildFactory.getInstance({ executor, scmPlugin: {}, datastore });
+                BuildFactory.getInstance({ executor, scm: {}, datastore });
             }, Error, 'No uiUri provided to BuildFactory');
         });
     });

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -112,7 +112,7 @@ describe('Job Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, scmPlugin: {} };
+            config = { datastore, scm: {} };
         });
 
         it('should utilize BaseFactory to get an instance', () => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -132,7 +132,7 @@ describe('Pipeline Model', () => {
             scmUrl,
             createTime: dateNow,
             admins,
-            scmPlugin: scmMock
+            scm: scmMock
         };
 
         pipeline = new PipelineModel(pipelineConfig);

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -126,7 +126,7 @@ describe('Pipeline Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, scmPlugin: {} };
+            config = { datastore, scm: {} };
         });
 
         it('should utilize BaseFactory to get an instance', () => {
@@ -148,7 +148,7 @@ describe('Pipeline Factory', () => {
             }, Error, 'No scm plugin provided to PipelineFactory');
 
             assert.throw(() => {
-                PipelineFactory.getInstance({ scmPlugin: {} });
+                PipelineFactory.getInstance({ scm: {} });
             }, Error, 'No datastore provided to PipelineFactory');
         });
     });

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -57,7 +57,7 @@ describe('User Model', () => {
             username: 'me',
             token,
             password,
-            scmPlugin: scmMock
+            scm: scmMock
         };
         user = new UserModel(createConfig);
     });

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -99,7 +99,7 @@ describe('User Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, scmPlugin: {} };
+            config = { datastore, scm: {} };
         });
 
         it('should utilize BaseFactory to get an instance', () => {
@@ -121,7 +121,7 @@ describe('User Factory', () => {
             }, Error, 'No scm plugin provided to UserFactory');
 
             assert.throw(() => {
-                UserFactory.getInstance({ scmPlugin: {} });
+                UserFactory.getInstance({ scm: {} });
             }, Error, 'No datastore provided to UserFactory');
         });
     });


### PR DESCRIPTION
This was just annoying me.  We take `database` and `executor` without adding `Plugin` to the end of it.  Why not SCM?
