### PR TITLE
Remove hoek.applyToDefaults on complex objects

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -70,11 +70,15 @@ class BaseFactory {
         });
 
         return this.datastore.save(modelConfig)
-            .then(modelData => this.createClass(hoek.applyToDefaults(config, {
-                datastore: this.datastore,
-                scm: this.scm,
-                id: modelData.id
-            })));
+            .then(modelData => {
+                const c = config;
+
+                c.datastore = this.datastore;
+                c.scm = this.scm;
+                c.id = modelData.id;
+
+                return this.createClass(c);
+            });
     }
 
     /**
@@ -101,15 +105,15 @@ class BaseFactory {
 
         return this.datastore.get(lookup)
             .then(data => {
-                // datastore miss, can not applyToDefaults on null
+                // datastore miss
                 if (!data) {
                     return data;
                 }
 
-                return this.createClass(hoek.applyToDefaults(data, {
-                    datastore: this.datastore,
-                    scm: this.scm
-                }));
+                data.datastore = this.datastore;
+                data.scm = this.scm;
+
+                return this.createClass(data);
             });
     }
 
@@ -147,10 +151,10 @@ class BaseFactory {
                 const result = [];
 
                 data.forEach(item => {
-                    result.push(this.createClass(hoek.applyToDefaults(item, {
-                        datastore: this.datastore,
-                        scm: this.scm
-                    })));
+                    item.datastore = this.datastore;
+                    item.scm = this.scm;
+
+                    result.push(this.createClass(item));
                 });
 
                 return result;

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -2,7 +2,6 @@
 
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
-const hoek = require('hoek');
 let instance;
 
 /**
@@ -82,12 +81,12 @@ class BuildFactory extends BaseFactory {
      */
     createClass(config) {
         // add executor to config
-        const c = hoek.applyToDefaults(config, {
-            executor: this.executor,
-            apiUri: this.apiUri,
-            tokenGen: this.tokenGen,
-            uiUri: this.uiUri
-        });
+        const c = config;
+
+        c.executor = this.executor;
+        c.apiUri = this.apiUri;
+        c.tokenGen = this.tokenGen;
+        c.uiUri = this.uiUri;
 
         return new Build(c);
     }
@@ -103,13 +102,12 @@ class BuildFactory extends BaseFactory {
      */
     create(config) {
         const number = Date.now();
-        const createTime = (new Date(number)).toISOString();
-        const modelConfig = hoek.applyToDefaults(config, {
-            cause: `Started by user ${config.username}`,
-            createTime,
-            number,
-            status: 'QUEUED'
-        });
+        const modelConfig = config;
+
+        modelConfig.cause = `Started by user ${config.username}`;
+        modelConfig.createTime = (new Date(number)).toISOString();
+        modelConfig.number = number;
+        modelConfig.status = 'QUEUED';
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -2,7 +2,6 @@
 
 const BaseFactory = require('./baseFactory');
 const Job = require('./job');
-const hoek = require('hoek');
 let instance;
 
 class JobFactory extends BaseFactory {
@@ -43,7 +42,10 @@ class JobFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        const c = hoek.applyToDefaults(config, { state: 'ENABLED', archived: false });
+        const c = config;
+
+        c.state = 'ENABLED';
+        c.archived = false;
 
         return super.create(c);
     }

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -2,7 +2,6 @@
 
 const BaseFactory = require('./baseFactory');
 const Pipeline = require('./pipeline');
-const hoek = require('hoek');
 let instance;
 
 class PipelineFactory extends BaseFactory {
@@ -39,9 +38,9 @@ class PipelineFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        const modelConfig = hoek.applyToDefaults({
-            createTime: (new Date()).toISOString()
-        }, config);
+        const modelConfig = config;
+
+        modelConfig.createTime = (new Date()).toISOString();
 
         return super.create(modelConfig);
     }

--- a/lib/secretFactory.js
+++ b/lib/secretFactory.js
@@ -4,9 +4,8 @@ const BaseFactory = require('./baseFactory');
 const Secret = require('./secret');
 const iron = require('iron');
 const nodeify = require('./nodeify');
-const hoek = require('hoek');
 // Get symbols for private fields
-const password = Symbol();
+const password = Symbol('password');
 
 let instance;
 
@@ -56,7 +55,9 @@ class SecretFactory extends BaseFactory {
      * @return {Secret}
      */
     createClass(config) {
-        const c = hoek.applyToDefaults(config, { password: this[password] });
+        const c = config;
+
+        c.password = this[password];
 
         return new Secret(c);
     }
@@ -74,7 +75,11 @@ class SecretFactory extends BaseFactory {
      */
     create(config) {
         return sealSecret(config.value, this[password])
-            .then(sealed => super.create(hoek.applyToDefaults(config, { value: sealed })));
+            .then(sealed => {
+                config.value = sealed;
+
+                return super.create(config);
+            });
     }
 
     /**

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -4,9 +4,8 @@ const BaseFactory = require('./baseFactory');
 const User = require('./user');
 const iron = require('iron');
 const nodeify = require('./nodeify');
-const hoek = require('hoek');
 // Get symbols for private fields
-const password = Symbol();
+const password = Symbol('password');
 
 let instance;
 /**
@@ -38,7 +37,9 @@ class UserFactory extends BaseFactory {
      * @return {User}
      */
     createClass(config) {
-        const c = hoek.applyToDefaults(config, { password: this[password] });
+        const c = config;
+
+        c.password = this[password];
 
         return new User(c);
     }
@@ -54,7 +55,10 @@ class UserFactory extends BaseFactory {
      */
     create(config) {
         return sealToken(config.token, this[password]).then(token => {
-            const modelConfig = hoek.applyToDefaults(config, { token, password: this[password] });
+            const modelConfig = config;
+
+            modelConfig.token = token;
+            modelConfig.password = this[password];
 
             return super.create(modelConfig);
         });


### PR DESCRIPTION
`hoek.applyToDefaults` does numerous clones of input objects over the course of merging into a single output. This has negative effects when dealing with the sequalize module as an SCM ORM. This PR removes the use of that method for all complex objects.
