### PR TITLE
Refactor models to use new scm-base functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const factory = Model.PipelineFactory.getInstance({
 });
 const config = {
     params: {
-        scmUrl: 'banana'
+        scmUri: 'github.com:12345:banana'
     },
     paginate {
         page: 2,
@@ -52,7 +52,7 @@ factory.create(config).then(model => {
 | :-------------   | :---- | :---- | :-------------|
 | config        | Object | Yes | Configuration Object |
 | config.admins | Object | Yes | Admins for this pipeline, e.g { batman: true } |
-| config.scmUrl | String | Yes | Source Code URL for the application |
+| config.scmUri | String | Yes | Source Code URI for the application |
 
 #### Get
 Get a pipeline based on id. Can pass the generatedId for the pipeline, or the unique keys for the model, and the id will be determined automatically.
@@ -61,7 +61,7 @@ factory.get(id).then(model => {
     // do stuff with pipeline model
 });
 
-factory.get({ scmUrl }).then(model => {
+factory.get({ scmUri }).then(model => {
     // do stuff with pipeline model
 });
 ```
@@ -69,7 +69,7 @@ factory.get({ scmUrl }).then(model => {
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
 | id | String | The unique ID for the pipeline |
-| config.scmUrl | String | Source Code URL for the application |
+| config.scmUri | String | Source Code URI for the application |
 
 
 ### Pipeline Model
@@ -88,9 +88,9 @@ const factory = Model.PipelineFactory.getInstance({
     datastore,
     scm
 });
-const scmUrl = 'git@git.corp.yahoo.com:foo/BAR.git';
-factory.get({ scmUrl }).then(model => {
-    model.scmUrl = 'git@git.corp.yahoo.com:foo/bar.git#master';
+const scmUri = 'github.com:12345:master';
+factory.get({ scmUri }).then(model => {
+    model.scmUri = 'github.com:12345:foo';
     return model.update();
 })
 ```
@@ -226,7 +226,7 @@ factory.create(config).then(model => {
 | :-------------   | :---- | :-------------|  :-------------|
 | config        | Object | Yes | Configuration Object |
 | config.apiUri | String | Yes | URI back to the API |
-| config.tokenGen | FUnction | Yes | Generator for building tokens |
+| config.tokenGen | Function | Yes | Generator for building tokens |
 | config.username | String | Yes | User who made the change to kick off the build |
 | config.container | String | No | Container for the build to run in |
 | config.sha | String | No | SHA used to kick off the build |
@@ -357,7 +357,7 @@ const config = {
 }
 
 factory.create(config)
-    .then(user => user.getPermissions(scmUrl))
+    .then(user => user.getPermissions(scmUri))
     .then(permissions => {
         // do stuff here
     });
@@ -389,12 +389,12 @@ model.unsealToken()
 #### Get User's Permissions For a Repo
 Get user's permissions for a specific repo
 ```
-model.getPermissions(scmUrl)
+model.getPermissions(scmUri)
 ```
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| scmUrl | String | The scmUrl of the repo |
+| scmUri | String | The scmUri of the repo |
 
 
 ### Secret Factory

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const BuildFactory = require('./lib/buildFactory');
 const JobFactory = require('./lib/jobFactory');
 const PipelineFactory = require('./lib/pipelineFactory');

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,13 +1,14 @@
 'use strict';
+
 const schema = require('screwdriver-data-schema');
 const nodeify = require('./nodeify');
 // Get symbols for private fields
-const rowData = Symbol();
-const dirty = Symbol();
-const model = Symbol();
-const table = Symbol();
-const datastore = Symbol();
-const scm = Symbol();
+const rowData = Symbol('row data');
+const dirty = Symbol('dirty variable');
+const model = Symbol('model');
+const table = Symbol('table');
+const datastore = Symbol('datastore');
+const scm = Symbol('scm');
 
 class BaseModel {
     /**
@@ -30,9 +31,9 @@ class BaseModel {
             this[rowData][key] = val;
             this[dirty].push(key);
         };
-        const getter = (key) => this[rowData][key];
+        const getter = key => this[rowData][key];
 
-        this[model].allKeys.forEach(key => {
+        this[model].allKeys.forEach((key) => {
             this[rowData][key] = config[key];
 
             Object.defineProperty(this, key, {
@@ -74,7 +75,7 @@ class BaseModel {
         }
 
         // only update dirty fields
-        this[dirty].forEach(key => {
+        this[dirty].forEach((key) => {
             data[key] = this[rowData][key];
         });
         delete data.id;

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const schema = require('screwdriver-data-schema');
 const hashr = require('screwdriver-hashr');
 const hoek = require('hoek');
@@ -70,7 +71,7 @@ class BaseFactory {
         });
 
         return this.datastore.save(modelConfig)
-            .then(modelData => {
+            .then((modelData) => {
                 const c = config;
 
                 c.datastore = this.datastore;
@@ -104,7 +105,7 @@ class BaseFactory {
         };
 
         return this.datastore.get(lookup)
-            .then(data => {
+            .then((data) => {
                 // datastore miss
                 if (!data) {
                     return data;
@@ -143,14 +144,14 @@ class BaseFactory {
         }
 
         return this.datastore.scan(scanConfig)
-            .then(data => {
+            .then((data) => {
                 if (!Array.isArray(data)) {
                     throw new Error('Unexpected response from datastore, ' +
                         `expected Array, got ${typeof data}`);
                 }
                 const result = [];
 
-                data.forEach(item => {
+                data.forEach((item) => {
                     item.datastore = this.datastore;
                     item.scm = this.scm;
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const BaseModel = require('./base');
 
 // Symbols for private members
@@ -7,17 +8,6 @@ const apiUri = Symbol('apiUri');
 const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
 const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
-
-/**
- * Update status to SCM
- * @method updateSCM
- * @param  {Object}  config
- * @param  {String}  conFig.scmUrl      Url for the repoInfo
- * @param  {String}  config.sha         Sha for the commit
- * @param  {String}  config.state       Build status
- * @param  {User}    config.user        Owner of the repo
- * @return {Promise}
- */
 
 class BuildModel extends BaseModel {
     /**
@@ -54,10 +44,10 @@ class BuildModel extends BaseModel {
             .then(job => pipeline.admin
                 .then(admin => admin.unsealToken())
                 // update github
-                .then(githubToken => {
+                .then((token) => {
                     const config = {
-                        token: githubToken,
-                        scmUrl: pipeline.scmUrl,
+                        token,
+                        scmUri: pipeline.scmUri,
                         sha: this.sha,
                         buildStatus: this.status,
                         jobName: job.name,
@@ -130,12 +120,12 @@ class BuildModel extends BaseModel {
     get pipeline() {
         delete this.pipeline;
 
-        const pipeline = this.job.then(job => {
+        const pipeline = this.job.then((job) => {
             if (!job) {
                 throw new Error('Job does not exist');
             }
 
-            return job.pipeline.then(p => {
+            return job.pipeline.then((p) => {
                 if (!p) {
                     throw new Error('Pipeline does not exist');
                 }
@@ -163,7 +153,7 @@ class BuildModel extends BaseModel {
     get secrets() {
         delete this.secrets;
 
-        const secrets = this.job.then(job => {
+        const secrets = this.job.then((job) => {
             if (!job) {
                 throw new Error('Job does not exist');
             }
@@ -217,7 +207,7 @@ class BuildModel extends BaseModel {
         const now = (new Date()).toISOString();
 
         // Fail any running steps
-        this.steps = this.steps.map(step => {
+        this.steps = this.steps.map((step) => {
             if (step.startTime && !step.endTime) {
                 step.endTime = now;
                 step.code = ABORT_CODE;

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -6,7 +6,7 @@ let instance;
 
 /**
  * Gathers a sha for the build
- * @method getCommitSha
+ * @method getCommitInfo
  * @param  {Object}         config
  * @param  {JobModel}       config.job                  Instance of Job Model
  * @param  {Scm}            config.scm                  Instance of SCM
@@ -15,12 +15,7 @@ let instance;
  * @param  {String}         config.modelConfig.username The name of the user
  * @return {Promise}
  */
-function getCommitSha(config) {
-    // Short circuit if sha already defined
-    if (config.modelConfig.sha) {
-        return Promise.resolve(config.modelConfig.sha);
-    }
-
+function getCommitInfo(config) {
     // Lazy load factory dependency to prevent circular dependency issues
     // https://nodejs.org/api/modules.html#modules_cycles
     /* eslint-disable global-require */
@@ -44,9 +39,21 @@ function getCommitSha(config) {
 
         return user.unsealToken()
             .then(token => config.scm.getCommitSha({
-                scmUrl: pipeline.scmUrl,
+                scmUri: pipeline.scmUri,
                 token
-            }));
+            })
+            .then(sha =>
+                config.scm.decorateCommit({
+                    scmUri: pipeline.scmUri,
+                    sha,
+                    token
+                })
+                .then(decoratedCommit => Promise.resolve({
+                    sha,
+                    decoratedCommit
+                }))
+            )
+        );
     });
 }
 
@@ -117,20 +124,21 @@ class BuildFactory extends BaseFactory {
         const factory = JobFactory.getInstance();
 
         return factory.get(config.jobId)
-            .then(job => {
+            .then((job) => {
                 if (!job) {
                     throw new Error('Job does not exist');
                 }
 
-                return getCommitSha({ job, scm: this.scm, modelConfig })
-                    .then(sha => {
+                return getCommitInfo({ job, scm: this.scm, modelConfig })
+                    .then((data) => {
                         // TODO: support matrix jobs
                         const index = number.toString().split('.')[1] || 0;
                         const permutation = job.permutations[index];
 
-                        modelConfig.sha = sha;
+                        modelConfig.sha = data.sha;
+                        modelConfig.commit = data.decoratedCommit;
                         modelConfig.container = permutation.image;
-                        modelConfig.steps = permutation.commands.map((command) => ({
+                        modelConfig.steps = permutation.commands.map(command => ({
                             name: command.name
                         }));
                         modelConfig.steps.unshift({ name: 'sd-setup' });

--- a/lib/job.js
+++ b/lib/job.js
@@ -55,13 +55,13 @@ class Job extends BaseModel {
         delete this.secrets;
 
         const secretNames = hoek.reach(this.permutations, '0.secrets', { default: [] });
-        const secretList = this.pipeline.then(pipeline => {
+        const secretList = this.pipeline.then((pipeline) => {
             if (!pipeline) {
                 throw new Error('Pipeline does not exist');
             }
 
             return pipeline.secrets.then(secrets =>
-                secrets.filter((secret) =>
+                secrets.filter(secret =>
                     // Only allow secrets that are called in the config AND are allowed (if a PR)
                     secretNames.includes(secret.name) && (secret.allowInPR || !this.isPR()))
             );
@@ -161,7 +161,7 @@ class Job extends BaseModel {
     remove() {
         const removeBuilds = (() =>
             // Iterate through the builds and remove them
-            this.getBuilds().then(builds => {
+            this.getBuilds().then((builds) => {
                 if (builds.length === 0) {
                     // Done removing builds
                     return null;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,5 +1,7 @@
 /* eslint no-param-reassign: ["error", { "props": false }] */
+
 'use strict';
+
 const BaseModel = require('./base');
 const parser = require('screwdriver-config-parser');
 const nodeify = require('./nodeify');
@@ -14,7 +16,7 @@ class PipelineModel extends BaseModel {
      * @param  {Object}   config                Config object to create the pipeline with
      * @param  {Object}   config.datastore      Object that will perform operations on the datastore
      * @param  {Object}   config.admins         The admins of this repository
-     * @param  {String}   config.scmUrl         The scmUrl for the application
+     * @param  {String}   config.scmUri         The scmUri for the application
      * @param  {String}   config.createTime     The time the pipeline was created
      */
     constructor(config) {
@@ -42,7 +44,7 @@ class PipelineModel extends BaseModel {
             // get the pipeline configuration
             .then(() => this.getConfiguration())
             // get list of jobs to create
-            .then(parsedConfig => {
+            .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;
 
                 return this.update()
@@ -54,7 +56,7 @@ class PipelineModel extends BaseModel {
                         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
 
                         // Loop through all existing jobs
-                        existingJobs.forEach(job => {
+                        existingJobs.forEach((job) => {
                             // if it's in the yaml, update it
                             if (parsedConfigJobNames.includes(job.name)) {
                                 job.permutations = parsedConfig.jobs[job.name];
@@ -70,7 +72,7 @@ class PipelineModel extends BaseModel {
                         });
 
                         // Loop through all defined jobs in the yaml
-                        Object.keys(parsedConfig.jobs).forEach(jobName => {
+                        Object.keys(parsedConfig.jobs).forEach((jobName) => {
                             const jobConfig = {
                                 pipelineId: this.id,
                                 name: jobName,
@@ -256,17 +258,17 @@ class PipelineModel extends BaseModel {
     /**
      * Get the screwdriver configuration for the pipeline at the given ref
      * @method getConfiguration
-     * @param  {String}  [ref=scmUrl]   Reference to the repo
+     * @param  {String}  [ref=scmUri]   Reference to the repo
      * @return {Promise}                Resolves to parsed and flattened configuration
      */
     getConfiguration(ref) {
-        const url = ref || this.scmUrl;
+        const uri = ref || this.scmUri;
 
         return this.admin.then(user => user.unsealToken())
             // fetch the screwdriver.yaml file
             .then(token =>
                 this.scm.getFile({
-                    scmUrl: url,
+                    scmUri: uri,
                     path: 'screwdriver.yaml',
                     token
                 })
@@ -276,31 +278,36 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Update the SCM Repo based on the SCM URL
+     * Update the SCM Repo based on the SCM URI
      * @method refreshScmRepo
      * @return {Promise}
      */
     refreshScmRepo() {
         // Skip if no changes
-        if (!this.isDirty('scmUrl') && this.scmRepo) {
+        if (!this.isDirty('checkoutUrl') && this.scmRepo) {
             return Promise.resolve();
         }
 
-        // get the admin of the pipeline
-        return this.admin
-            // and their token
-            .then(user => user.unsealToken())
+        return Promise.all([
+            this.admin,                          // get the admin of the pipeline
+            this.scm.parseUrl(this.checkoutUrl)  // get the scmUri
+        ]).then(([user, scmUri]) => {
+            this.scmUri = scmUri;
+
+            // get the user token
+            return user.unsealToken()
             // get the expanded repo information
             .then(token =>
-                this.scm.getRepoId({
-                    scmUrl: this.scmUrl,
+                this.scm.decorateUrl({
+                    scmUri: this.scmUri,
                     token
                 })
             )
             // and store it
-            .then(scmRepo => {
+            .then((scmRepo) => {
                 this.scmRepo = scmRepo;
             });
+        });
     }
 
     /**
@@ -308,12 +315,12 @@ class PipelineModel extends BaseModel {
      * @return {Promise}        Resolves to null if remove successfully
      */
     remove() {
-        const removeJobs = ((archived) =>
+        const removeJobs = (archived =>
             this.getJobs({
                 params: {
                     archived
                 }
-            }).then(jobs => {
+            }).then((jobs) => {
                 if (jobs.length === 0) {
                     return null;
                 }

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -20,9 +20,9 @@ class PipelineFactory extends BaseFactory {
      * @method createClass
      * @param  {Object}    config               Pipeline data
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
-     * @param  {String}    config.id            unique id
-     * @param  {Object}    config.admins        hash of admin usernames
-     * @param  {String}    config.scmUrl        url of source
+     * @param  {String}    config.id            Unique id
+     * @param  {Object}    config.admins        Hash of admin usernames
+     * @param  {String}    config.scmUri        Uri of source
      * @return {Pipeline}
      */
     createClass(config) {
@@ -34,15 +34,21 @@ class PipelineFactory extends BaseFactory {
      * @method create
      * @param  {Object}   config                Config object
      * @param  {Object}   config.admins         The admins of this repository
-     * @param  {String}   config.scmUrl         The scmUrl for the application
+     * @param  {String}   config.checkoutUrl    The checkoutUrl for the application
      * @return {Promise}
      */
     create(config) {
-        const modelConfig = config;
+        return this.scm.parseUrl(config.checkoutUrl)
+        .then((scmUri) => {
+            const modelConfig = {
+                admins: config.admins,
+                scmUri
+            };
 
-        modelConfig.createTime = (new Date()).toISOString();
+            modelConfig.createTime = (new Date()).toISOString();
 
-        return super.create(modelConfig);
+            return super.create(modelConfig);
+        });
     }
 
     /**

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -1,9 +1,10 @@
 'use strict';
+
 const BaseModel = require('./base');
 const nodeify = require('./nodeify');
 const iron = require('iron');
 // Get symbols for private fields
-const password = Symbol();
+const password = Symbol('password');
 
 class SecretModel extends BaseModel {
 
@@ -30,7 +31,7 @@ class SecretModel extends BaseModel {
      */
     update() {
         return nodeify.withContext(iron, 'seal', [this.value, this[password], iron.defaults])
-            .then(sealed => {
+            .then((sealed) => {
                 this.value = sealed;
 
                 return super.update();

--- a/lib/secretFactory.js
+++ b/lib/secretFactory.js
@@ -28,7 +28,7 @@ function sealSecret(secretvalue, pw) {
  */
 function unsealSecret(secret, pw) {
     return nodeify.withContext(iron, 'unseal', [secret.value, pw, iron.defaults])
-        .then(unsealed => {
+        .then((unsealed) => {
             secret.value = unsealed;
 
             return secret;
@@ -75,7 +75,7 @@ class SecretFactory extends BaseFactory {
      */
     create(config) {
         return sealSecret(config.value, this[password])
-            .then(sealed => {
+            .then((sealed) => {
                 config.value = sealed;
 
                 return super.create(config);
@@ -89,7 +89,7 @@ class SecretFactory extends BaseFactory {
      * @return {Promise}
      */
     get(config) {
-        return super.get(config).then(secret => {
+        return super.get(config).then((secret) => {
             if (!secret) {
                 return secret;
             }

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,9 +1,10 @@
 'use strict';
+
 const BaseModel = require('./base');
 const iron = require('iron');
 const nodeify = require('./nodeify');
 // Get symbols for private fields
-const password = Symbol();
+const password = Symbol('password');
 
 class UserModel extends BaseModel {
 
@@ -45,15 +46,15 @@ class UserModel extends BaseModel {
     /**
      * Get permissions on a specific repo
      * @method getPermissions
-     * @param  {String}     scmUrl          The scmUrl of the repository
+     * @param  {String}     scmUri          The scmUri of the repository
      * @return {Promise}                    Contains the permissions for [admin, push, pull]
      *                                      Example: {admin: false, push: true, pull: true}
      */
-    getPermissions(scmUrl) {
+    getPermissions(scmUri) {
         return this.unsealToken()
             .then(token => this.scm.getPermissions({
                 token,
-                scmUrl
+                scmUri
             }));
     }
 }

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -54,7 +54,7 @@ class UserFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        return sealToken(config.token, this[password]).then(token => {
+        return sealToken(config.token, this[password]).then((token) => {
             const modelConfig = config;
 
             modelConfig.token = token;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "15.0.0",
+  "version": "16.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {
@@ -44,7 +44,7 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^2.0.0",
-    "screwdriver-data-schema": "^13.0.0",
+    "screwdriver-data-schema": "^14.0.0",
     "screwdriver-hashr": "^1.0.30"
   }
 }

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -68,7 +69,7 @@ describe('Base Model', () => {
     describe('constructor', () => {
         it('constructs properly', () => {
             assert.instanceOf(base, BaseModel);
-            schemaMock.models.base.allKeys.forEach(key => {
+            schemaMock.models.base.allKeys.forEach((key) => {
                 assert.strictEqual(base[key], config[key]);
             });
             // datastore is private
@@ -84,7 +85,7 @@ describe('Base Model', () => {
         it('is a noop if no fields changed', () => {
             assert.isFalse(base.isDirty());
 
-            return base.update().then(model => {
+            return base.update().then((model) => {
                 assert.isFalse(model.isDirty());
                 assert.notCalled(datastore.update);
             });
@@ -97,7 +98,7 @@ describe('Base Model', () => {
             assert.isTrue(base.isDirty());
 
             return base.update(config)
-                .then(model => {
+                .then((model) => {
                     assert.deepEqual(model, base);
                     assert.isFalse(model.isDirty());
                     assert.isTrue(datastore.update.calledWith({

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -11,7 +12,7 @@ class Base {
 }
 class BF {}
 const baseId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
-const createMock = (c) => new Base(c);
+const createMock = c => new Base(c);
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -116,7 +117,7 @@ describe('Base Factory', () => {
                     notkey: 'bar'
                 },
                 bar: false
-            }).then(model => {
+            }).then((model) => {
                 assert.isTrue(datastore.save.calledWith(saveConfig));
                 assert.instanceOf(model, Base);
                 assert.deepEqual(model.datastore, datastore);
@@ -159,7 +160,7 @@ describe('Base Factory', () => {
 
         it('calls datastore get with id and returns correct values', () =>
             factory.get(baseData.id)
-                .then(model => {
+                .then((model) => {
                     assert.instanceOf(model, Base);
                     assert.isTrue(datastore.get.calledOnce);
                     assert.deepEqual(model.datastore, datastore);
@@ -169,7 +170,7 @@ describe('Base Factory', () => {
 
         it('calls datastore get with config.id and returns correct values', () =>
             factory.get(baseData)
-                .then(model => {
+                .then((model) => {
                     assert.instanceOf(model, Base);
                     assert.isTrue(datastore.get.calledOnce);
                     assert.deepEqual(model.datastore, datastore);
@@ -179,7 +180,7 @@ describe('Base Factory', () => {
 
         it('calls datastore get with id generated from config and returns correct values', () =>
             factory.get({ foo: 'foo', bar: 'bar' })
-                .then(model => {
+                .then((model) => {
                     assert.instanceOf(model, Base);
                     assert.isTrue(datastore.get.calledOnce);
                     assert.deepEqual(model.datastore, datastore);
@@ -196,7 +197,7 @@ describe('Base Factory', () => {
             }).resolves(null);
 
             return factory.get(baseData.id)
-                .then(model => {
+                .then((model) => {
                     assert.isNull(model);
                 });
         });
@@ -237,10 +238,10 @@ describe('Base Factory', () => {
 
         it('calls datastore scan and returns correct values', () =>
             factory.list({ paginate })
-                .then(arr => {
+                .then((arr) => {
                     assert.isArray(arr);
                     assert.equal(arr.length, 2);
-                    arr.forEach(model => {
+                    arr.forEach((model) => {
                         assert.instanceOf(model, Base);
                         assert.deepEqual(model.datastore, datastore);
                         assert.deepEqual(model.scm, scm);
@@ -278,7 +279,7 @@ describe('Base Factory', () => {
             datastore.scan.resolves(null);
 
             return factory.list({ paginate })
-                .catch(err => {
+                .catch((err) => {
                     assert.strictEqual(err.message, 'Unexpected response from datastore, ' +
                         'expected Array, got object');
                 });

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -17,7 +18,7 @@ describe('Build Model', () => {
     const container = 'node:4';
     const adminUser = { username: 'batman', unsealToken: sinon.stub().resolves('foo') };
     const pipelineId = 'cf23df2207d99a74fbe169e3eba035e633b65d94';
-    const scmUrl = 'git@github.com:screwdriver-cd/models.git#master';
+    const scmUri = 'github.com:12345:master';
     const token = 'equivalentToOneQuarter';
     const url = `${uiUri}/builds/${buildId}`;
     let BuildModel;
@@ -114,7 +115,7 @@ describe('Build Model', () => {
         assert.isFunction(build.start);
         assert.isFunction(build.stop);
 
-        schema.models.build.allKeys.forEach(key => {
+        schema.models.build.allKeys.forEach((key) => {
             assert.strictEqual(build[key], config[key]);
         });
 
@@ -136,12 +137,12 @@ describe('Build Model', () => {
                 name: 'main',
                 pipeline: Promise.resolve({
                     id: pipelineId,
-                    scmUrl,
+                    scmUri,
                     admin: Promise.resolve(adminUser)
                 })
             });
             pipeline = {
-                scmUrl,
+                scmUri,
                 admin: Promise.resolve(adminUser)
             };
         });
@@ -151,7 +152,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
-                        scmUrl,
+                        scmUri,
                         sha,
                         jobName: 'main',
                         buildStatus: 'QUEUED',
@@ -185,7 +186,7 @@ describe('Build Model', () => {
                 name: 'main',
                 pipeline: Promise.resolve({
                     id: pipelineId,
-                    scmUrl,
+                    scmUri,
                     admin: Promise.resolve(adminUser)
                 })
             });
@@ -211,7 +212,7 @@ describe('Build Model', () => {
 
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
-                        scmUrl,
+                        scmUri,
                         sha,
                         jobName: 'main',
                         buildStatus: 'FAILURE',
@@ -239,7 +240,7 @@ describe('Build Model', () => {
 
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
-                        scmUrl,
+                        scmUri,
                         sha,
                         jobName: 'main',
                         buildStatus: 'ABORTED',
@@ -263,7 +264,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
-                        scmUrl,
+                        scmUri,
                         sha,
                         jobName: 'main',
                         buildStatus: 'RUNNING',
@@ -328,7 +329,7 @@ describe('Build Model', () => {
                 name: 'main',
                 pipeline: Promise.resolve({
                     id: pipelineId,
-                    scmUrl,
+                    scmUri,
                     admin: Promise.resolve(adminUser)
                 }),
                 isPR: () => false
@@ -353,7 +354,7 @@ describe('Build Model', () => {
 
                 assert.calledWith(scmMock.updateCommitStatus, {
                     token: 'foo',
-                    scmUrl,
+                    scmUri,
                     sha,
                     jobName: 'main',
                     buildStatus: 'QUEUED',
@@ -405,7 +406,7 @@ describe('Build Model', () => {
 
             return build.secrets.then(() => {
                 assert.fail('nope');
-            }).catch(err => {
+            }).catch((err) => {
                 assert.equal('Job does not exist', err.message);
             });
         });
@@ -473,7 +474,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.fail('should not get here');
                 })
-                .catch(err => {
+                .catch((err) => {
                     assert.instanceOf(err, Error);
                     assert.strictEqual(err.message, 'Pipeline does not exist');
                 });
@@ -486,7 +487,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.fail('should not get here');
                 })
-                .catch(err => {
+                .catch((err) => {
                     assert.instanceOf(err, Error);
                     assert.strictEqual(err.message, 'Job does not exist');
                 });

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -126,7 +127,7 @@ describe('Job Model', () => {
         assert.instanceOf(job, BaseModel);
         assert.isFunction(job.update);
 
-        schema.models.job.allKeys.forEach(key => {
+        schema.models.job.allKeys.forEach((key) => {
             assert.strictEqual(job[key], config[key]);
         });
     });
@@ -156,7 +157,7 @@ describe('Job Model', () => {
 
         return job.secrets.then(() => {
             assert.fail('nope');
-        }).catch(err => {
+        }).catch((err) => {
             assert.equal('Pipeline does not exist', err.message);
         });
     });
@@ -289,7 +290,7 @@ describe('Job Model', () => {
         it('remove builds recursively', () => {
             let i;
 
-            for (i = 0; i < 4; i++) {
+            for (i = 0; i < 4; i += 1) {
                 buildFactoryMock.list.onCall(i).resolves([build1, build2]);
             }
 
@@ -308,7 +309,7 @@ describe('Job Model', () => {
 
             return job.remove().then(() => {
                 assert.fail('should not get here');
-            }).catch(err => {
+            }).catch((err) => {
                 assert.isOk(err);
                 assert.equal(err.message, 'error');
             });
@@ -320,7 +321,7 @@ describe('Job Model', () => {
 
             return job.remove().then(() => {
                 assert.fail('should not get here');
-            }).catch(err => {
+            }).catch((err) => {
                 assert.isOk(err);
                 assert.equal(err.message, 'error removing build');
             });

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -101,7 +102,7 @@ describe('Job Factory', () => {
             return factory.create({
                 pipelineId,
                 name
-            }).then(model => {
+            }).then((model) => {
                 assert.calledWith(datastore.save, saveConfig);
                 assert.instanceOf(model, Job);
             });

--- a/test/lib/nodeify.test.js
+++ b/test/lib/nodeify.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const nodeify = require('../../lib/nodeify');
 const sinon = require('sinon');

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -12,10 +13,12 @@ describe('Pipeline Factory', () => {
     let PipelineFactory;
     let datastore;
     let hashaMock;
+    let scm;
     let factory;
     const dateNow = 1111111111;
     const nowTime = (new Date(dateNow)).toISOString();
-    const scmUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
+    const checkoutUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
+    const scmUri = 'github.com:12345:master';
     const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
     const admins = ['me'];
     let pipelineConfig;
@@ -36,6 +39,9 @@ describe('Pipeline Factory', () => {
         hashaMock = {
             sha1: sinon.stub()
         };
+        scm = {
+            parseUrl: sinon.stub()
+        };
 
         // Fixing mockery issue with duplicate file names
         // by re-registering data-schema with its own implementation
@@ -48,8 +54,9 @@ describe('Pipeline Factory', () => {
 
         pipelineConfig = {
             datastore,
+            scm,
             id: testId,
-            scmUrl,
+            scmUri,
             createTime: nowTime,
             admins
         };
@@ -84,7 +91,7 @@ describe('Pipeline Factory', () => {
                 data: {
                     admins,
                     createTime: nowTime,
-                    scmUrl
+                    scmUri
                 }
             }
         };
@@ -107,15 +114,16 @@ describe('Pipeline Factory', () => {
                 id: testId,
                 admins,
                 createTime: nowTime,
-                scmUrl
+                scmUri
             };
 
             datastore.save.resolves(expected);
+            scm.parseUrl.resolves(scmUri);
 
             return factory.create({
-                scmUrl,
+                checkoutUrl,
                 admins
-            }).then(model => {
+            }).then((model) => {
                 assert.calledWith(datastore.save, saveConfig);
                 assert.instanceOf(model, Pipeline);
             });

--- a/test/lib/secret.test.js
+++ b/test/lib/secret.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const sinon = require('sinon');
 const mockery = require('mockery');
@@ -65,7 +66,7 @@ describe('Secret Model', () => {
     it('is constructed properly', () => {
         assert.instanceOf(secret, SecretModel);
         assert.instanceOf(secret, BaseModel);
-        schema.models.secret.allKeys.forEach(key => {
+        schema.models.secret.allKeys.forEach((key) => {
             assert.strictEqual(secret[key], createConfig[key]);
         });
     });

--- a/test/lib/secretFactory.test.js
+++ b/test/lib/secretFactory.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -97,10 +98,10 @@ describe('Secret Factory', () => {
                 name,
                 value: unsealed,
                 allowInPR
-            }).then(model => {
+            }).then((model) => {
                 assert.calledWith(ironMock.seal, unsealed, password, 'defaults');
                 assert.instanceOf(model, Secret);
-                Object.keys(expected).forEach(key => {
+                Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);
                 });
             });
@@ -130,11 +131,11 @@ describe('Secret Factory', () => {
 
         it('calls datastore get with id and returns correct values', () =>
             factory.get(id)
-                .then(model => {
+                .then((model) => {
                     assert.calledWith(ironMock.unseal, sealed, password, 'defaults');
                     assert.instanceOf(model, Secret);
                     assert.isTrue(datastore.get.calledOnce);
-                    Object.keys(expected).forEach(key => {
+                    Object.keys(expected).forEach((key) => {
                         assert.strictEqual(model[key], expected[key]);
                     });
                 })
@@ -142,11 +143,11 @@ describe('Secret Factory', () => {
 
         it('calls datastore get with config.id and returns correct values', () =>
             factory.get({ id })
-                .then(model => {
+                .then((model) => {
                     assert.calledWith(ironMock.unseal, sealed, password, 'defaults');
                     assert.instanceOf(model, Secret);
                     assert.isTrue(datastore.get.calledOnce);
-                    Object.keys(expected).forEach(key => {
+                    Object.keys(expected).forEach((key) => {
                         assert.strictEqual(model[key], expected[key]);
                     });
                 })
@@ -154,11 +155,11 @@ describe('Secret Factory', () => {
 
         it('calls datastore get with id generated from config and returns correct values', () =>
             factory.get({ pipelineId, name })
-                .then(model => {
+                .then((model) => {
                     assert.calledWith(ironMock.unseal, sealed, password, 'defaults');
                     assert.instanceOf(model, Secret);
                     assert.isTrue(datastore.get.calledOnce);
-                    Object.keys(expected).forEach(key => {
+                    Object.keys(expected).forEach((key) => {
                         assert.strictEqual(model[key], expected[key]);
                     });
                 })
@@ -173,7 +174,7 @@ describe('Secret Factory', () => {
             }).resolves(null);
 
             return factory.get({ pipelineId, name })
-                .then(model => {
+                .then((model) => {
                     assert.isTrue(datastore.get.calledOnce);
                     assert.notCalled(ironMock.unseal);
                     assert.isNull(model);
@@ -220,11 +221,11 @@ describe('Secret Factory', () => {
             ironMock.unseal.withArgs('sealedsecret2value', password).yieldsAsync(null, 'superman');
 
             return factory.list({ paginate })
-                .then(arr => {
+                .then((arr) => {
                     assert.isArray(arr);
                     assert.equal(arr.length, 2);
                     assert.deepEqual(arr, returnValue);
-                    arr.forEach(model => {
+                    arr.forEach((model) => {
                         assert.instanceOf(model, Secret);
                     });
                 });

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -75,7 +76,7 @@ describe('User Model', () => {
     it('is constructed properly', () => {
         assert.instanceOf(user, UserModel);
         assert.instanceOf(user, BaseModel);
-        schema.models.user.allKeys.forEach(key => {
+        schema.models.user.allKeys.forEach((key) => {
             assert.strictEqual(user[key], createConfig[key]);
         });
         // password is private
@@ -146,7 +147,7 @@ describe('User Model', () => {
     });
 
     describe('getPermissions', () => {
-        const scmUrl = 'git@github.com:screwdriver-cd/models.git';
+        const scmUri = 'github.com:12345:master';
         const repo = {
             permissions: {
                 admin: true,
@@ -161,11 +162,11 @@ describe('User Model', () => {
         });
 
         it('promises to get permissions', () =>
-            user.getPermissions(scmUrl)
-                .then(data => {
+            user.getPermissions(scmUri)
+                .then((data) => {
                     assert.calledWith(scmMock.getPermissions, {
                         token: '12345',
-                        scmUrl
+                        scmUri
                     });
                     assert.deepEqual(data, repo.permissions);
                 })
@@ -176,11 +177,11 @@ describe('User Model', () => {
 
             scmMock.getPermissions.rejects(expectedError);
 
-            return user.getPermissions(scmUrl)
+            return user.getPermissions(scmUri)
                 .then(() => {
                     assert.fail('This should not fail the test');
                 })
-                .catch(err => {
+                .catch((err) => {
                     assert.deepEqual(err, expectedError);
                 });
         });

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -85,10 +86,10 @@ describe('User Factory', () => {
             return factory.create({
                 username: 'batman',
                 token: 'hero'
-            }).then(model => {
+            }).then((model) => {
                 assert.calledWith(ironMock.seal, 'hero', password, 'defaults');
                 assert.instanceOf(model, User);
-                Object.keys(expected).forEach(key => {
+                Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);
                 });
             });


### PR DESCRIPTION
- Use `scmUri` over `scmUrl`
- Call `parseUrl` to get `scmUri`
- Call `decorateCommit`
- Make changes to conform to new eslint rules
- Bump data-schema version to 14.0.0
- Bump models version to 16.0.0

Based on changes made in https://github.com/screwdriver-cd/scm-base/pull/11
Related to https://github.com/screwdriver-cd/screwdriver/issues/160
