### PR TITLE
Add scmRepo when create pipeline and remove refreshScmRepo

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -23,6 +23,28 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Get the screwdriver configuration for the pipeline at the given ref
+     * @method getConfiguration
+     * @param  {String}  [ref=scmUri]   Reference to the repo
+     * @return {Promise}                Resolves to parsed and flattened configuration
+     */
+    getConfiguration(ref) {
+        const uri = ref || this.scmUri;
+
+        return this.admin.then(user => user.unsealToken())
+            // fetch the screwdriver.yaml file
+            .then(token =>
+                this.scm.getFile({
+                    scmUri: uri,
+                    path: 'screwdriver.yaml',
+                    token
+                })
+            )
+            // parse the content of the yaml file
+            .then(parser);
+    }
+
+    /**
      * Sync the pipeline by looking up screwdriver.yaml
      * Create, update, or disable jobs if necessary.
      * Store/update the pipeline workflow
@@ -38,10 +60,8 @@ class PipelineModel extends BaseModel {
 
         const factory = JobFactory.getInstance();
 
-        // update the generated scm repo
-        return this.refreshScmRepo()
-            // get the pipeline configuration
-            .then(() => this.getConfiguration())
+        // get the pipeline configuration
+        return this.getConfiguration()
             // get list of jobs to create
             .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;
@@ -252,61 +272,6 @@ class PipelineModel extends BaseModel {
 
                 return workflowJobs.concat(prJobs);
             });
-    }
-
-    /**
-     * Get the screwdriver configuration for the pipeline at the given ref
-     * @method getConfiguration
-     * @param  {String}  [ref=scmUri]   Reference to the repo
-     * @return {Promise}                Resolves to parsed and flattened configuration
-     */
-    getConfiguration(ref) {
-        const uri = ref || this.scmUri;
-
-        return this.admin.then(user => user.unsealToken())
-            // fetch the screwdriver.yaml file
-            .then(token =>
-                this.scm.getFile({
-                    scmUri: uri,
-                    path: 'screwdriver.yaml',
-                    token
-                })
-            )
-            // parse the content of the yaml file
-            .then(parser);
-    }
-
-    /**
-     * Update the SCM Repo based on the SCM URI
-     * @method refreshScmRepo
-     * @return {Promise}
-     */
-    refreshScmRepo() {
-        // Skip if no changes
-        if (!this.isDirty('checkoutUrl') && this.scmRepo) {
-            return Promise.resolve();
-        }
-
-        return Promise.all([
-            this.admin,                          // get the admin of the pipeline
-            this.scm.parseUrl(this.checkoutUrl)  // get the scmUri
-        ]).then(([user, scmUri]) => {
-            this.scmUri = scmUri;
-
-            // get the user token
-            return user.unsealToken()
-            // get the expanded repo information
-            .then(token =>
-                this.scm.decorateUrl({
-                    scmUri: this.scmUri,
-                    token
-                })
-            )
-            // and store it
-            .then((scmRepo) => {
-                this.scmRepo = scmRepo;
-            });
-        });
     }
 
     /**

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -34,21 +34,29 @@ class PipelineFactory extends BaseFactory {
      * @method create
      * @param  {Object}   config                Config object
      * @param  {Object}   config.admins         The admins of this repository
-     * @param  {String}   config.checkoutUrl    The checkoutUrl for the application
+     * @param  {String}   config.scmUri         The scmUri for the application
      * @return {Promise}
      */
     create(config) {
-        return this.scm.parseUrl(config.checkoutUrl)
-        .then((scmUri) => {
-            const modelConfig = {
-                admins: config.admins,
-                scmUri
-            };
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const UserFactory = require('./userFactory');
+        /* eslint-enable global-require */
 
-            modelConfig.createTime = (new Date()).toISOString();
+        const userFactory = UserFactory.getInstance();
+        const modelConfig = config;
 
-            return super.create(modelConfig);
-        });
+        modelConfig.createTime = (new Date()).toISOString();
+
+        return userFactory.get({ username: Object.keys(config.admins)[0] })
+            .then(user => user.unsealToken())
+            .then(token => this.scm.decorateUrl({ scmUri: config.scmUri, token }))
+            .then((scmRepo) => {
+                modelConfig.scmRepo = scmRepo;
+
+                return super.create(modelConfig);
+            });
     }
 
     /**

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -106,8 +106,7 @@ describe('Pipeline Model', () => {
         };
         scmMock = {
             getFile: sinon.stub(),
-            decorateUrl: sinon.stub(),
-            parseUrl: sinon.stub()
+            decorateUrl: sinon.stub()
         };
         parserMock = sinon.stub();
 
@@ -159,39 +158,6 @@ describe('Pipeline Model', () => {
         });
     });
 
-    describe('refreshScmRepo', () => {
-        beforeEach(() => {
-            scmMock.decorateUrl.resolves({ name: 'foo' });
-            userFactoryMock.get.withArgs({ username: 'batman' }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-            scmMock.parseUrl.resolves('bar');
-        });
-
-        it('stores scmRepo to pipeline', () => {
-            const newCheckoutUrl = 'git@github.com:screwdriver-cd/data-model.git#foobar';
-
-            pipeline.checkoutUrl = newCheckoutUrl;
-
-            return pipeline.refreshScmRepo().then(() => {
-                assert.calledWith(scmMock.decorateUrl, {
-                    scmUri: 'bar',
-                    token: 'foo'
-                });
-                assert.deepEqual(pipeline.scmRepo, { name: 'foo' });
-            });
-        });
-
-        it('skips storing scmRepo to pipeline if no changes', () => {
-            pipeline.scmRepo = { name: 'bar' };
-
-            return pipeline.refreshScmRepo().then(() => {
-                assert.notCalled(scmMock.decorateUrl);
-                assert.deepEqual(pipeline.scmRepo, { name: 'bar' });
-            });
-        });
-    });
-
     describe('sync', () => {
         let publishMock;
         let mainMock;
@@ -199,12 +165,10 @@ describe('Pipeline Model', () => {
         beforeEach(() => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
-            scmMock.decorateUrl.resolves({ name: 'foo' });
             parserMock.withArgs('superyamlcontent').resolves(PARSED_YAML);
             userFactoryMock.get.withArgs({ username: 'batman' }).resolves({
                 unsealToken: sinon.stub().resolves('foo')
             });
-            scmMock.parseUrl.resolves('bar');
 
             publishMock = {
                 pipelineId: testId,
@@ -258,33 +222,6 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('store scmRepo to pipeline', () => {
-            jobs = [];
-            jobFactoryMock.list.resolves(jobs);
-            jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
-            jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
-
-            return pipeline.sync().then(() => {
-                assert.calledWith(scmMock.decorateUrl, {
-                    scmUri: 'bar',
-                    token: 'foo'
-                });
-                assert.deepEqual(pipeline.scmRepo, { name: 'foo' });
-            });
-        });
-
-        it('skips storing scmRepo to pipeline if no changes', () => {
-            jobs = [];
-            jobFactoryMock.list.resolves(jobs);
-            jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
-            jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
-            pipeline.scmRepo = { name: 'bar' };
-
-            return pipeline.sync().then(() => {
-                assert.notCalled(scmMock.decorateUrl);
-            });
-        });
-
         it('creates new jobs', () => {
             jobs = [];
             jobFactoryMock.list.resolves(jobs);
@@ -295,7 +232,7 @@ describe('Pipeline Model', () => {
                 .then((p) => {
                     assert.equal(p.id, testId);
                     assert.calledWith(scmMock.getFile, {
-                        scmUri: 'bar',
+                        scmUri,
                         path: 'screwdriver.yaml',
                         token: 'foo'
                     });


### PR DESCRIPTION
- Add `scmRepo` blob when creating pipeline
- Remove `refreshScmRepo`  in `sync` 
- Because we do not have`scmUri` update endpoint now, no need to refresh the `scmRepo`
