### PR TITLE
Short circuit getting commit info when build is triggered by Screwdriver

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -16,6 +16,12 @@ let instance;
  * @return {Promise}
  */
 function getCommitInfo(config) {
+    if (config.modelConfig.sha) {
+        return Promise.resolve({
+            sha: config.modelConfig.sha
+        });
+    }
+
     // Lazy load factory dependency to prevent circular dependency issues
     // https://nodejs.org/api/modules.html#modules_cycles
     /* eslint-disable global-require */
@@ -136,7 +142,11 @@ class BuildFactory extends BaseFactory {
                         const permutation = job.permutations[index];
 
                         modelConfig.sha = data.sha;
-                        modelConfig.commit = data.decoratedCommit;
+
+                        if (data.decoratedCommit) {
+                            modelConfig.commit = data.decoratedCommit;
+                        }
+
                         modelConfig.container = permutation.image;
                         modelConfig.steps = permutation.commands.map(command => ({
                             name: command.name


### PR DESCRIPTION
This is currently breaking functional tests in Screwdriver: getting a "User does not exist" error message when trying to update the status for a build that is triggered by Screwdriver.
