### PR TITLE
Determine scmUri key for scm.getFile() dynamically

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -30,12 +30,13 @@ class PipelineModel extends BaseModel {
      */
     getConfiguration(ref) {
         const uri = ref || this.scmUri;
+        const key = ref ? 'ref' : 'scmUri';
 
         return this.admin.then(user => user.unsealToken())
             // fetch the screwdriver.yaml file
             .then(token =>
                 this.scm.getFile({
-                    scmUri: uri,
+                    [key]: uri,
                     path: 'screwdriver.yaml',
                     token
                 })

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -483,7 +483,7 @@ describe('Pipeline Model', () => {
                 .then((config) => {
                     assert.equal(config, PARSED_YAML);
                     assert.calledWith(scmMock.getFile, {
-                        scmUri: 'bar',
+                        ref: 'bar',
                         path: 'screwdriver.yaml',
                         token: 'foo'
                     });


### PR DESCRIPTION
- Determine scmUri key for scm.getFile() dynamically since we have 2 sets of schema for the method now
- Related https://github.com/screwdriver-cd/data-schema/pull/78
