### PR TITLE
Fix missing screwdriver config breaks pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+ci/
+.editorconfig
+eslint*
+CONTRIBUTING.md
+screwdriver.yaml
+test/
+features/

--- a/lib/job.js
+++ b/lib/job.js
@@ -83,7 +83,7 @@ class Job extends BaseModel {
      * @return {Boolean}
      */
     isPR() {
-        return /^PR\-/.test(this.name);
+        return /^PR-/.test(this.name);
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -42,7 +42,8 @@ class PipelineModel extends BaseModel {
                     config.ref = ref;
                 }
 
-                return this.scm.getFile(config);
+                return this.scm.getFile(config)
+                    .catch(() => '');
             })
             // parse the content of the yaml file
             .then(parser);


### PR DESCRIPTION
If scm.getFile rejects, than we parse an empty string instead. Fixes https://github.com/screwdriver-cd/screwdriver/issues/297

Added missing .editorconfig and .npmignore
