### PR TITLE
refactor: build model uses pipeline.getToken()

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -40,22 +40,21 @@ class BuildModel extends BaseModel {
      * @return {Promise}
      */
     updateCommitStatus(pipeline) {
-        return this.job
-            .then(job => pipeline.admin
-                .then(admin => admin.unsealToken())
-                // update github
-                .then((token) => {
-                    const config = {
-                        token,
-                        scmUri: pipeline.scmUri,
-                        sha: this.sha,
-                        buildStatus: this.status,
-                        jobName: job.name,
-                        url: `${this[uiUri]}/builds/${this.id}`
-                    };
+        return Promise.all([
+            this.job,
+            pipeline.getToken()
+        ]).then(([job, token]) => {
+            const config = {
+                token,
+                scmUri: pipeline.scmUri,
+                sha: this.sha,
+                buildStatus: this.status,
+                jobName: job.name,
+                url: `${this[uiUri]}/pipelines/${pipeline.id}/builds/${this.id}`
+            };
 
-                    return this.scm.updateCommitStatus(config);
-                }));
+            return this.scm.updateCommitStatus(config);
+        });
     }
 
     /**


### PR DESCRIPTION
* Change url for build page sent to github
* Use `pipeline.getToken()` when updating commit status