### PR TITLE
fix: Change targetUrl to the correct value

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -50,7 +50,7 @@ class BuildModel extends BaseModel {
                 sha: this.sha,
                 buildStatus: this.status,
                 jobName: job.name,
-                url: `${this[uiUri]}/pipelines/${pipeline.id}/builds/${this.id}`
+                url: `${this[uiUri]}/pipelines/${pipeline.id}/build/${this.id}`
             };
 
             return this.scm.updateCommitStatus(config);

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -20,7 +20,7 @@ describe('Build Model', () => {
     const pipelineId = 'cf23df2207d99a74fbe169e3eba035e633b65d94';
     const scmUri = 'github.com:12345:master';
     const token = 'equivalentToOneQuarter';
-    const url = `${uiUri}/pipelines/${pipelineId}/builds/${buildId}`;
+    const url = `${uiUri}/pipelines/${pipelineId}/build/${buildId}`;
     let BuildModel;
     let datastore;
     let executorMock;


### PR DESCRIPTION
Right now it's linking to `builds`, which is 404:
https://beta.cd.screwdriver.cd/pipelines/8612abf79c08e192fd730c62ec251ac77c8c4b0c/builds/142799cabf326df7ab14dae1c24facf2965beeba