### PR TITLE
feat(371): update repo webhooks during sync operation

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -66,7 +66,7 @@ class PipelineModel extends BaseModel {
         const factory = JobFactory.getInstance();
 
         // get the pipeline configuration
-        return this.getConfiguration()
+        const syncPipeline = this.getConfiguration()
             // get list of jobs to create
             .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;
@@ -113,9 +113,25 @@ class PipelineModel extends BaseModel {
                     });
             })
             // wait until all promises have resolved
-            .then(jobs => Promise.all(jobs))
-            // return the pipeline
-            .then(() => this);
+            .then(jobs => Promise.all(jobs));
+        // Attach Screwdriver webhook to the pipeline's repository
+        const addWebhook = this.token.then(token =>
+            this.scm.addWebhook({
+                scmUri: this.scmUri,
+                token,
+                webhookUrl: 'https://api.screwdriver.cd/v4/webhooks'
+            }).catch((err) => {
+                // Disregard errors since they're non-critical
+
+                console.error('An error was encountered & discarded while updating webhooks.');
+                console.error(err);
+            })
+        );
+
+        return Promise.all([
+            syncPipeline,
+            addWebhook
+        ]).then(() => this);  // return the pipeline
     }
 
     /**


### PR DESCRIPTION
Looking for feedback on how to refactor this section. 

We discussed about how to break down this beast of a method. So this is what it boils down to:

1. There are now 2 unique operations that occur: `syncPipeline` and `addWebhook`. We want to separate those into their own methods, and shrink the `sync` function to just [the Promise.all](https://github.com/screwdriver-cd/models/compare/repoWebhooks?expand=1#diff-679e90b5b15ab1b73ddb7ed2377e7413R131). Does this structure make sense, knowing how they look like now?

1. The current implementation does not find `addWebhook` to be a critical operation. If it fails to add a webhook, we keep going as if it didn't. Is this behavior reasonable?

Related to screwdriver-cd/screwdriver#379

EDIT1: Link to working issue