### PR TITLE
feat: use numeric ids instead of a hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+.nyc_output

--- a/lib/base.js
+++ b/lib/base.js
@@ -78,14 +78,11 @@ class BaseModel {
         this[dirty].forEach((key) => {
             data[key] = this[rowData][key];
         });
-        delete data.id;
+        data.id = this.id;
 
         const datastoreConfig = {
             table: this[table],
-            params: {
-                id: this.id,
-                data
-            }
+            params: data
         };
 
         // TODO: sync `this` with db response?

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const schema = require('screwdriver-data-schema');
-const hashr = require('screwdriver-hashr');
 const hoek = require('hoek');
 const PAGINATE_PAGE = 1;
 const PAGINATE_COUNT = 50;
@@ -32,41 +31,21 @@ class BaseFactory {
     }
 
     /**
-     * Generate the id for the model
-     * @method generateId
-     * @param  {Object}   config Object to generate a hashed ID for
-     * @return {String}          SHA1 unique ID
-     */
-    generateId(config) {
-        const hashObject = {};
-
-        this.model.keys.forEach((keyName) => {
-            hashObject[keyName] = hoek.reach(config, keyName);
-        });
-
-        return hashr.sha1(hashObject);
-    }
-
-    /**
      * Create a Model
      * @method create
      * @param  {Object}    config               Config object
      * @return {Promise}
      */
     create(config) {
-        const id = this.generateId(config);
         const modelConfig = {
             table: this.table,
-            params: {
-                id,
-                data: {}
-            }
+            params: {}
         };
 
         // Filter for valid keys
         this.model.allKeys.forEach((key) => {
             if (config[key] !== undefined) {
-                modelConfig.params.data[key] = config[key];
+                modelConfig.params[key] = config[key];
             }
         });
 
@@ -89,19 +68,20 @@ class BaseFactory {
      * @return {Promise}
      */
     get(config) {
-        let id = config;
+        const params = {};
 
-        if (typeof config === 'object' && config.id) {
-            id = config.id;
+        if (typeof config === 'number' || typeof config.id === 'number') {
+            params.id = config.id || config;
         } else if (typeof config === 'object') {
-            id = this.generateId(config);
+            // Reduce to unique properties
+            this.model.keys.forEach((key) => {
+                params[key] = config[key];
+            });
         }
 
         const lookup = {
             table: this.table,
-            params: {
-                id
-            }
+            params
         };
 
         return this.datastore.get(lookup)

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -120,11 +120,8 @@ class PipelineModel extends BaseModel {
                 scmUri: this.scmUri,
                 token,
                 webhookUrl: 'https://api.screwdriver.cd/v4/webhooks'
-            }).catch((err) => {
-                // Disregard errors since they're non-critical
-
-                console.error('An error was encountered & discarded while updating webhooks.');
-                console.error(err);
+            }).catch(() => {
+                // ignore errors since they're non-critical
             })
         );
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.0.1",
-    "screwdriver-data-schema": "^15.4.0",
-    "screwdriver-hashr": "^1.0.30"
+    "screwdriver-data-schema": "^16.0.0"
   }
 }

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -48,7 +48,7 @@ describe('Base Model', () => {
         config = {
             datastore,
             scm,
-            id: 'as12345',
+            id: 12345,
             foo: 'foo',
             bar: 'bar'
         };
@@ -104,10 +104,8 @@ describe('Base Model', () => {
                     assert.isTrue(datastore.update.calledWith({
                         table: 'base',
                         params: {
-                            id: 'as12345',
-                            data: {
-                                foo: 'banana'
-                            }
+                            id: 12345,
+                            foo: 'banana'
                         }
                     }));
                 });
@@ -134,7 +132,7 @@ describe('Base Model', () => {
         const params = {
             table: 'base',
             params: {
-                id: 'as12345'
+                id: 12345
             }
         };
 
@@ -179,13 +177,13 @@ describe('Base Model', () => {
 
     describe('toString', () => {
         it('should give a string representation of the model', () => {
-            assert.strictEqual(base.toString(), '{"id":"as12345","foo":"foo","bar":"bar"}');
+            assert.strictEqual(base.toString(), '{"id":12345,"foo":"foo","bar":"bar"}');
         });
     });
 
     describe('toJson', () => {
         it('should give an object representation of the model data', () => {
-            assert.deepEqual(base.toJson(), { id: 'as12345', foo: 'foo', bar: 'bar' });
+            assert.deepEqual(base.toJson(), { id: 12345, foo: 'foo', bar: 'bar' });
         });
     });
 

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -29,7 +29,6 @@ describe('Build Factory', () => {
     let BuildFactory;
     let datastore;
     let executor;
-    let hashaMock;
     let jobFactoryMock;
     let userFactoryMock;
     let scmMock;
@@ -56,9 +55,6 @@ describe('Build Factory', () => {
             save: sinon.stub(),
             scan: sinon.stub()
         };
-        hashaMock = {
-            sha1: sinon.stub()
-        };
         jobFactoryMock = {
             get: sinon.stub()
         };
@@ -81,7 +77,6 @@ describe('Build Factory', () => {
 
         mockery.registerMock('screwdriver-build-bookend', bookendMock);
 
-        mockery.registerMock('screwdriver-hashr', hashaMock);
         mockery.registerMock('./jobFactory', jobFactory);
         mockery.registerMock('./userFactory', {
             getInstance: sinon.stub().returns(userFactoryMock)
@@ -126,9 +121,8 @@ describe('Build Factory', () => {
 
     describe('create', () => {
         let sandbox;
-        const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
-        const jobId = '62089f642bbfd1886623964b4cff12db59869e5d';
-        const eventId = '12345f642bbfd1886623964b4cff12db59869e5d';
+        const jobId = 12345;
+        const eventId = 123456;
         const sha = 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f';
         const scmUri = 'github.com:12345:master';
         const scmRepo = {
@@ -184,8 +178,6 @@ describe('Build Factory', () => {
             });
             sandbox.useFakeTimers(dateNow);
 
-            hashaMock.sha1.returns(testId);
-
             jobFactoryMock.get.resolves({
                 permutations
             });
@@ -204,20 +196,17 @@ describe('Build Factory', () => {
             saveConfig = {
                 table: 'builds',
                 params: {
-                    id: testId,
-                    data: {
-                        eventId,
-                        cause: 'Started by user i_made_the_request',
-                        commit,
-                        createTime: isoTime,
-                        number: dateNow,
-                        status: 'QUEUED',
-                        container,
-                        environment,
-                        steps,
-                        jobId,
-                        sha
-                    }
+                    eventId,
+                    cause: 'Started by user i_made_the_request',
+                    commit,
+                    createTime: isoTime,
+                    number: dateNow,
+                    status: 'QUEUED',
+                    container,
+                    environment,
+                    steps,
+                    jobId,
+                    sha
                 }
             };
         });
@@ -240,7 +229,7 @@ describe('Build Factory', () => {
 
             jobFactoryMock.get.resolves(jobMock);
             userFactoryMock.get.resolves(user);
-            delete saveConfig.params.data.commit;
+            delete saveConfig.params.commit;
 
             return factory.create({ garbage, username, jobId, eventId, sha }).then(() => {
                 assert.calledWith(datastore.save, saveConfig);
@@ -331,7 +320,7 @@ describe('Build Factory', () => {
             };
 
             jobFactoryMock.get.resolves(jobMock);
-            delete saveConfig.params.data.commit;
+            delete saveConfig.params.commit;
 
             return factory.create({ username, jobId, eventId, sha }).then((model) => {
                 assert.calledWith(datastore.save, saveConfig);

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -12,7 +12,6 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('Job Factory', () => {
     let JobFactory;
     let datastore;
-    let hashaMock;
     let factory;
 
     before(() => {
@@ -28,14 +27,10 @@ describe('Job Factory', () => {
             scan: sinon.stub(),
             get: sinon.stub()
         };
-        hashaMock = {
-            sha1: sinon.stub()
-        };
 
         // Fixing mockery issue with duplicate file names
         // by re-registering data-schema with its own implementation
         mockery.registerMock('screwdriver-data-schema', schema);
-        mockery.registerMock('screwdriver-hashr', hashaMock);
         mockery.registerMock('./job', Job);
 
         // eslint-disable-next-line global-require
@@ -74,19 +69,12 @@ describe('Job Factory', () => {
         const saveConfig = {
             table: 'jobs',
             params: {
-                id: jobId,
-                data: {
-                    name,
-                    pipelineId,
-                    state: 'ENABLED',
-                    archived: false
-                }
+                name,
+                pipelineId,
+                state: 'ENABLED',
+                archived: false
             }
         };
-
-        beforeEach(() => {
-            hashaMock.sha1.returns(jobId);
-        });
 
         it('creates a new job in the datastore', () => {
             const expected = {

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -12,7 +12,6 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('Pipeline Factory', () => {
     let PipelineFactory;
     let datastore;
-    let hashaMock;
     let scm;
     let factory;
     let userFactoryMock;
@@ -41,9 +40,6 @@ describe('Pipeline Factory', () => {
             scan: sinon.stub(),
             get: sinon.stub()
         };
-        hashaMock = {
-            sha1: sinon.stub()
-        };
         scm = {
             decorateUrl: sinon.stub()
         };
@@ -54,7 +50,6 @@ describe('Pipeline Factory', () => {
         // Fixing mockery issue with duplicate file names
         // by re-registering data-schema with its own implementation
         mockery.registerMock('screwdriver-data-schema', schema);
-        mockery.registerMock('screwdriver-hashr', hashaMock);
         mockery.registerMock('./pipeline', Pipeline);
         mockery.registerMock('./userFactory', {
             getInstance: sinon.stub().returns(userFactoryMock)
@@ -98,13 +93,10 @@ describe('Pipeline Factory', () => {
         const saveConfig = {
             table: 'pipelines',
             params: {
-                id: testId,
-                data: {
-                    admins,
-                    createTime: nowTime,
-                    scmUri,
-                    scmRepo
-                }
+                admins,
+                createTime: nowTime,
+                scmUri,
+                scmRepo
             }
         };
 
@@ -113,8 +105,6 @@ describe('Pipeline Factory', () => {
                 useFakeTimers: false
             });
             sandbox.useFakeTimers(dateNow);
-
-            hashaMock.sha1.returns(testId);
         });
 
         afterEach(() => {

--- a/test/lib/secret.test.js
+++ b/test/lib/secret.test.js
@@ -43,8 +43,8 @@ describe('Secret Model', () => {
 
         createConfig = {
             datastore,
-            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
-            pipelineId: 'e124fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+            id: 12345,
+            pipelineId: 54321,
             name: 'secret',
             value: 'batman',
             allowInPR: true,
@@ -87,10 +87,8 @@ describe('Secret Model', () => {
                     assert.isTrue(datastore.update.calledWith({
                         table: 'secrets',
                         params: {
-                            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
-                            data: {
-                                value: 'sealedspiderman'
-                            }
+                            id: 12345,
+                            value: 'sealedspiderman'
                         }
                     }));
                 });

--- a/test/lib/secretFactory.test.js
+++ b/test/lib/secretFactory.test.js
@@ -8,13 +8,13 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('Secret Factory', () => {
     const password = 'totallySecurePassword';
-    const pipelineId = 'pipeline1';
+    const pipelineId = 4321;
     const allowInPR = true;
     const name = 'npm_token';
     const sealed = 'erwijx342';
     const unsealed = 'batman';
     const secretData = {
-        id: 'abc123',
+        id: 12345,
         pipelineId,
         name,
         value: sealed,
@@ -22,7 +22,6 @@ describe('Secret Factory', () => {
     };
     let SecretFactory;
     let datastore;
-    let hashaMock;
     let ironMock;
     let factory;
     let Secret;
@@ -40,16 +39,12 @@ describe('Secret Factory', () => {
             scan: sinon.stub(),
             get: sinon.stub()
         };
-        hashaMock = {
-            sha1: sinon.stub()
-        };
         ironMock = {
             seal: sinon.stub(),
             unseal: sinon.stub(),
             defaults: 'defaults'
         };
 
-        mockery.registerMock('screwdriver-hashr', hashaMock);
         mockery.registerMock('iron', ironMock);
 
         // eslint-disable-next-line global-require
@@ -80,7 +75,7 @@ describe('Secret Factory', () => {
 
     describe('create', () => {
         it('should create a Secret', () => {
-            const generatedId = 'aabbccdd';
+            const generatedId = 1234135;
             const expected = {
                 pipelineId,
                 name,
@@ -90,7 +85,6 @@ describe('Secret Factory', () => {
             };
 
             ironMock.seal.yieldsAsync(null, sealed);
-            hashaMock.sha1.returns(generatedId);
             datastore.save.resolves(expected);
 
             return factory.create({
@@ -109,7 +103,7 @@ describe('Secret Factory', () => {
     });
 
     describe('get', () => {
-        const id = 'abc123';
+        const id = 12345;
         const expected = {
             pipelineId,
             name,
@@ -125,7 +119,13 @@ describe('Secret Factory', () => {
                     id
                 }
             }).resolves(secretData);
-            hashaMock.sha1.returns(id);
+            datastore.get.withArgs({
+                table: 'secrets',
+                params: {
+                    pipelineId,
+                    name
+                }
+            }).resolves(secretData);
             ironMock.unseal.yieldsAsync(null, unsealed);
         });
 
@@ -173,7 +173,7 @@ describe('Secret Factory', () => {
                 }
             }).resolves(null);
 
-            return factory.get({ pipelineId, name })
+            return factory.get(id)
                 .then((model) => {
                     assert.isTrue(datastore.get.calledOnce);
                     assert.notCalled(ironMock.unseal);
@@ -188,28 +188,28 @@ describe('Secret Factory', () => {
             count: 2
         };
         const datastoreReturnValue = [{
-            id: '151c9b11e4a9a27e9e374daca6e59df37d8cf00f',
-            pipelineId: 'pipeline1',
+            id: 1234512,
+            pipelineId: 4321,
             name: 'secret1',
             value: 'sealedsecret1value',
             allowInPR: true
         }, {
-            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
-            pipelineId: 'pipeline1',
+            id: 5315423,
+            pipelineId: 4321,
             name: 'secret2',
             value: 'sealedsecret2value',
             allowInPR: false
         }];
 
         const returnValue = [{
-            id: '151c9b11e4a9a27e9e374daca6e59df37d8cf00f',
-            pipelineId: 'pipeline1',
+            id: 1234512,
+            pipelineId: 4321,
             name: 'secret1',
             value: 'batman',
             allowInPR: true
         }, {
-            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
-            pipelineId: 'pipeline1',
+            id: 5315423,
+            pipelineId: 4321,
             name: 'secret2',
             value: 'superman',
             allowInPR: false


### PR DESCRIPTION
BREAKING CHANGE: removes hash based unique keys in favor of numeric ids. No longer generates hashes based on unique properties.

Related Epic: screwdriver-cd/screwdriver#399
Blocked By: screwdriver-cd/data-schema#98