### PR TITLE
fix(399): convert string ids to numbers

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -70,13 +70,17 @@ class BaseFactory {
     get(config) {
         const params = {};
 
-        if (typeof config === 'number' || typeof config.id === 'number') {
-            params.id = config.id || config;
-        } else if (typeof config === 'object') {
+        if (typeof config === 'object' && !config.id) {
             // Reduce to unique properties
             this.model.keys.forEach((key) => {
                 params[key] = config[key];
             });
+        } else {
+            const id = parseInt(config.id || config, 10);
+
+            if (id) {
+                params.id = id;
+            }
         }
 
         const lookup = {

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -171,6 +171,16 @@ describe('Base Factory', () => {
                 })
         );
 
+        it('converts string id to a number', () =>
+            factory.get('135323')
+                .then((model) => {
+                    assert.instanceOf(model, Base);
+                    assert.isTrue(datastore.get.calledOnce);
+                    assert.deepEqual(model.datastore, datastore);
+                    assert.deepEqual(model.scm, scm);
+                })
+        );
+
         it('calls datastore get with config object and returns correct values', () =>
             factory.get({ foo: 'foo', bar: 'bar' })
                 .then((model) => {


### PR DESCRIPTION
The api pulls params as strings, and does not try to convert them. This PR has the model attempt to convert ids to a number before using them in get requests.