### PR TITLE
feat(379): move addWebhook out of sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ factory.get({ scmUri }).then(model => {
 })
 ```
 
+#### Add Screwdriver webhook
+Attach Screwdriver webhook to the pipeline's repository
+```js
+model.addWebhook(webhookUrl)
+```
+
+| Parameter        | Type  | Description |
+| :-------------   | :---- | :--------|
+| webhookUrl        | String | The webhook url to be added |
+
+
 #### Sync
 Sync the pipeline. Look up the configuration in the repo to create and delete jobs if necessary.
 ```js
@@ -108,8 +119,8 @@ model.getConfiguration(config)
 ```
 
 | Parameter        | Type  | Required | Description |
-| :-------------   | :---- | : --- | :--- | :-------------|
-| ref        | String | No | | Reference to the branch or PR |
+| :-------------   | :---- | :--- | :--------|
+| ref        | String | No | Reference to the branch or PR |
 
 
 #### Get Jobs
@@ -119,7 +130,7 @@ model.getJobs(config)
 ```
 
 | Parameter        | Type  | Required | Default | Description |
-| :-------------   | :---- | : --- | :--- | :-------------|
+| :-------------   | :---- | :--- | :--- | :-------------|
 | config        | Object | No | | Configuration Object |
 | config.params | Object | No | | Fields to search on |
 | config.params.sort | Boolean | No | false| Sorting by createTime |
@@ -132,7 +143,7 @@ model.getEvents(config)
 ```
 
 | Parameter        | Type  | Required | Default | Description |
-| :-------------   | :---- | : --- | :--- | :-------------|
+| :-------------   | :---- | :--- | :--- | :-------------|
 | config        | Object | No | | Config Object |
 | config.type | Number | No | `pipeline` | Type of event: `pipeline` or `pr` |
 | config.sort | Number | No | `descending`| Sorting by createTime |

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -50,6 +50,21 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Attach Screwdriver webhook to the pipeline's repository
+     * @param   webhookUrl    The webhook to be added
+     * @method  addWebhook
+     * @return  {Promise}
+     */
+    addWebhook(webhookUrl) {
+        return this.token.then(token =>
+            this.scm.addWebhook({
+                scmUri: this.scmUri,
+                token,
+                webhookUrl
+            })
+      );
+    }
+    /**
      * Sync the pipeline by looking up screwdriver.yaml
      * Create, update, or disable jobs if necessary.
      * Store/update the pipeline workflow
@@ -66,7 +81,7 @@ class PipelineModel extends BaseModel {
         const factory = JobFactory.getInstance();
 
         // get the pipeline configuration
-        const syncPipeline = this.getConfiguration()
+        return this.getConfiguration()
             // get list of jobs to create
             .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;
@@ -113,22 +128,8 @@ class PipelineModel extends BaseModel {
                     });
             })
             // wait until all promises have resolved
-            .then(jobs => Promise.all(jobs));
-        // Attach Screwdriver webhook to the pipeline's repository
-        const addWebhook = this.token.then(token =>
-            this.scm.addWebhook({
-                scmUri: this.scmUri,
-                token,
-                webhookUrl: 'https://api.screwdriver.cd/v4/webhooks'
-            }).catch(() => {
-                // ignore errors since they're non-critical
-            })
-        );
-
-        return Promise.all([
-            syncPipeline,
-            addWebhook
-        ]).then(() => this);  // return the pipeline
+            .then(jobs => Promise.all(jobs))
+            .then(() => this);
     }
 
     /**


### PR DESCRIPTION
Move addWebhook outside of `sync()` to reduce overhead since this method is called many times at different places. We can call `pipeline.addWebhook()` once inside `create` right before `sync`: https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/pipelines/create.js#L92

We can also add another endpoint inside `api` for correcting webhooks if needed.

Related: https://github.com/screwdriver-cd/screwdriver/issues/379