### PR TITLE
feat: Add syncPRs() for pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -50,6 +50,99 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Get a list of PR jobs to create or update
+     * @method _checkPRState
+     * @param  {Array}    existingJobs      List pipeline's existing jobs
+     * @param  {Array}    openedPRs         List of opened PRs coming from SCM
+     * @return {Promise}                    Resolves to the list of jobs to archive, unarchive and create
+     * Note: toArchive and toUnarchive is an array of job objects; toCreate is an array of objects with name and ref.
+     */
+    _checkPRState(existingJobs, openedPRs) {
+        const jobList = {
+            toCreate: [],
+            toArchive: [],
+            toUnarchive: []
+        };
+        const existingPRs = existingJobs.filter(j => j.isPR());   // list of PRs according to SD
+        const existingPRsNames = existingPRs.map(j => j.name);
+        const openedPRsNames = openedPRs.map(j => j.name);
+        const openedPRsRef = openedPRs.map(j => j.ref);
+
+        existingPRs.forEach((job) => {
+            // if PR is closed, add it to archive list
+            if (openedPRsNames.indexOf(job.name) < 0 && job.archived === false) {
+                jobList.toArchive.push(job);
+            }
+        });
+
+        openedPRsNames.forEach((name, i) => {
+            const index = existingPRsNames.indexOf(name);
+
+            if (index < 0) {
+                // if opened PR is not in the list of existingPRs, create it
+                jobList.toCreate.push({ name, ref: openedPRsRef[i] });
+            } else {
+                const job = existingPRs[index];
+
+                // if opened PR was previously archived, unarchive it
+                if (job.archived) {
+                    jobList.toUnarchive.push(existingPRs[index]);
+                }
+            }
+        });
+
+        return jobList;
+    }
+
+    /**
+     * Go through the job list and archive/unarchive it
+     * @method _updateJobArchive
+     * @param  {Array}        jobList     List of job objects
+     * @param  {boolean}      archived    Archived value to update to
+     * @return {Promise}
+     */
+    _updateJobArchive(jobList, archived) {
+        const jobsToUpdate = [];
+
+        jobList.forEach((j) => {
+            j.archived = archived;
+            jobsToUpdate.push(j.update());
+        });
+
+        return Promise.all(jobsToUpdate);
+    }
+
+    /**
+     * Go through the list of job names and create it
+     * @method _createJob
+     * @param  {Array}      jobList         Array of job names and refs
+     * @param  {Number}     pipelineId      Pipeline id that the job belongs to
+     * @return {Promise}
+     */
+    _createJob(jobList) {
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const JobFactory = require('./jobFactory');
+        /* eslint-enable global-require */
+
+        const factory = JobFactory.getInstance();
+
+        const jobsToCreate = jobList.map(j =>
+            this.getConfiguration(j.ref).then((config) => {
+                const jobConfig = {
+                    pipelineId: this.id,
+                    name: j.name,
+                    permutations: config.jobs.main
+                };
+
+                return factory.create(jobConfig);
+            }));
+
+        return Promise.all(jobsToCreate);
+    }
+
+    /**
      * Attach Screwdriver webhook to the pipeline's repository
      * @param   webhookUrl    The webhook to be added
      * @method  addWebhook
@@ -64,6 +157,34 @@ class PipelineModel extends BaseModel {
             })
       );
     }
+
+    /**
+     * Sync the pull requests by checking against SCM
+     * Create or update PR jobs if necessary
+     * @method syncPRs
+     * @return {Promise}
+     */
+    syncPRs() {
+        /* eslint-disable no-underscore-dangle */
+        return this.token.then(token =>
+            Promise.all([
+                this.jobs,
+                this.scm.getOpenedPRs({
+                    scmUri: this.scmUri,
+                    token
+                })
+            ]).then(([existingJobs, openedPRs]) => {
+                const jobList = this._checkPRState(existingJobs, openedPRs);
+
+                return Promise.all([
+                    this._createJob(jobList.toCreate),
+                    this._updateJobArchive(jobList.toArchive, true),
+                    this._updateJobArchive(jobList.toUnarchive, false)
+                ]);
+            }));
+          /* eslint-enable no-understore-dangle */
+    }
+
     /**
      * Sync the pipeline by looking up screwdriver.yaml
      * Create, update, or disable jobs if necessary.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "20.0.0",
+  "version": "21.2.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There are 3 cases:
- `PR-1` is closed, but it's still in the current list of jobs, so archive it. Related: https://github.com/screwdriver-cd/screwdriver/issues/389
- `PR-1` is opened, but it's not in the current list of jobs, so create it. 
- `PR-1` is opened, it's in the current list of jobs, but it was archived, so update it. 

Mocking `this.scm.getOpenedPRs`. This should return the list of opened PR jobs, for example: `['PR-12', PR-20']`

This is a major version bump. The `this.scm` passed in needs to be the newest version which has `getOpenedPRs` implemented. Otherwise this will break. 

Related Epic https://github.com/screwdriver-cd/screwdriver/issues/417