### PR TITLE
feat(470): Add version bumping to template creation

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -3,7 +3,13 @@
 const BaseFactory = require('./baseFactory');
 const Template = require('./template');
 const compareVersions = require('compare-versions');
+const schema = require('screwdriver-data-schema');
 let instance;
+
+const VERSION_REGEX = schema.config.regex.VERSION;
+const MAJOR_MATCH = 1;
+const MINOR_MATCH = 2;
+const PATCH_MATCH = 3;
 
 class TemplateFactory extends BaseFactory {
     /**
@@ -35,7 +41,7 @@ class TemplateFactory extends BaseFactory {
     }
 
     /**
-     * Create a new template (See schema definition)
+     * Create a new template of the correct version (See schema definition)
      * @method create
      * @param  {Object}     config               Config object
      * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
@@ -49,7 +55,28 @@ class TemplateFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        return super.create(config);
+        const match = VERSION_REGEX.exec(config.version);
+        const major = match[MAJOR_MATCH];
+        const minor = match[MINOR_MATCH];
+        const searchVersion = minor ? `${major}${minor}` : major;
+
+        return this.getTemplate({
+            name: config.name,
+            version: searchVersion
+        }).then((latest) => {
+            if (!latest) {
+                config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
+            } else {
+                const latestMatch = VERSION_REGEX.exec(latest.version);
+                const latestMajor = latestMatch[MAJOR_MATCH];
+                const latestMinor = latestMatch[MINOR_MATCH];
+                const patch = parseInt(latestMatch[PATCH_MATCH].slice(1), 10) + 1;
+
+                config.version = `${latestMajor}${latestMinor}.${patch}`;
+            }
+
+            return super.create(config);
+        });
     }
 
     /**


### PR DESCRIPTION
Move auto-bumping of template version from API to models.

Related: https://github.com/screwdriver-cd/screwdriver/pull/497

**Pasted from Above PR:**

Auto bump version:
For example, if latest version is 1.7.3

If template.yaml says 1, it will create 1.7.4
If template.yaml says 1.7, it will create 1.7.4
If template.yaml says 1.7.3, it will create 1.7.4 (does not matter what the patch is)
If template.yaml says 1.8, it will create 1.8.0
If template.yaml says 2, it will create 2.0.0

Related: https://github.com/screwdriver-cd/screwdriver/issues/470