### PR TITLE
feat(473): Add alwaysRun flag to steps in builds

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -157,7 +157,8 @@ class BuildFactory extends BaseFactory {
                     modelConfig.environment = permutation.environment;
                     modelConfig.steps = permutation.commands.map(command => ({
                         name: command.name,
-                        command: command.command
+                        command: command.command,
+                        alwaysRun: command.alwaysRun || false
                     }));
 
                     const bookendConfig = { pipeline, job, build: modelConfig };
@@ -168,7 +169,7 @@ class BuildFactory extends BaseFactory {
                     ]).then(([setup, teardown]) => {
                         modelConfig.steps = setup.concat(modelConfig.steps, teardown);
                         // Launcher is hardcoded to do some business in sd-setup-launcher
-                        modelConfig.steps.unshift({ name: 'sd-setup-launcher' });
+                        modelConfig.steps.unshift({ name: 'sd-setup-launcher', alwaysRun: true });
 
                         return super.create(modelConfig);
                     });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -134,30 +134,30 @@ describe('Build Factory', () => {
         const isoTime = (new Date(dateNow)).toISOString();
         const container = 'node:4';
         const steps = [
-            { name: 'sd-setup-launcher' },
-            { name: 'sd-setup-scm', command: 'git clone' },
-            { command: 'npm install', name: 'init' },
-            { command: 'npm test', name: 'test' }
+            { name: 'sd-setup-launcher', alwaysRun: true },
+            { name: 'sd-setup-scm', command: 'git clone', alwaysRun: true },
+            { command: 'npm install', name: 'init', alwaysRun: false },
+            { command: 'npm test', name: 'test', alwaysRun: false }
         ];
         const environment = { NODE_ENV: 'test', NODE_VERSION: '4' };
         const permutations = [{
             commands: [
-                { command: 'npm install', name: 'init' },
-                { command: 'npm test', name: 'test' }
+                { command: 'npm install', name: 'init', alwaysRun: false },
+                { command: 'npm test', name: 'test', alwaysRun: false }
             ],
             environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
             image: 'node:4'
         }, {
             commands: [
-                { command: 'npm install', name: 'init' },
-                { command: 'npm test', name: 'test' }
+                { command: 'npm install', name: 'init', alwaysRun: false },
+                { command: 'npm test', name: 'test', alwaysRun: false }
             ],
             environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
             image: 'node:5'
         }, {
             commands: [
-                { command: 'npm install', name: 'init' },
-                { command: 'npm test', name: 'test' }
+                { command: 'npm install', name: 'init', alwaysRun: false },
+                { command: 'npm test', name: 'test', alwaysRun: false }
             ],
             environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
             image: 'node:6'


### PR DESCRIPTION
Allows users to define a step verbosely in their `screwdriver.yaml`, to make it possible for an `alwaysRun` flag to exist:

```yaml
jobs:
    main:
        steps:
            - name: hello
               command: echo hello
               alwaysRun: true
```

Related to: https://github.com/screwdriver-cd/screwdriver/issues/473