### PR TITLE
fix: Fix tests + comments after changing scmUri to pipelineId in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ factory.create(config).then(model => {
 | config.description | String | Yes | Description of the template |
 | config.maintainer | Array | Yes | Maintainer's email |
 | config.config | Object | Yes | Config of the screwdriver-template.yaml |
-| config.scmUri | String | Yes | ScmUri of the template pipeline |
+| config.pipelineId | String | Yes | pipelineId of the template |
 | config.labels | Array | No | Labels attached to the template |
 
 #### Get

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -32,8 +32,8 @@ class TemplateFactory extends BaseFactory {
      * @param  {String}     config.description   Description of the template
      * @param  {String}     config.maintainer    Maintainer's email
      * @param  {Object}     config.config        Config of the screwdriver-template.yaml
-     * @param  {String}     config.scmUri        ScmUri of the template pipeline
-     * @param  {Array}      [config.labels]        Labels attached to the template
+     * @param  {String}     config.pipelineId    pipelineId of the template
+     * @param  {Array}      [config.labels]      Labels attached to the template
      * @return {Job}
      */
     createClass(config) {
@@ -50,8 +50,8 @@ class TemplateFactory extends BaseFactory {
      * @param  {String}     config.description   Description of the template
      * @param  {String}     config.maintainer    Maintainer's email
      * @param  {Object}     config.config        Config of the screwdriver-template.yaml
-     * @param  {String}     config.scmUri        ScmUri of the template pipeline
-     * @param  {Array}      [config.labels]        Labels attached to the template
+     * @param  {String}     config.pipelineId    pipelineId of the template
+     * @param  {Array}      [config.labels]      Labels attached to the template
      * @return {Promise}
      */
     create(config) {

--- a/test/lib/template.test.js
+++ b/test/lib/template.test.js
@@ -41,7 +41,7 @@ describe('Template Model', () => {
             description: 'this is a template',
             labels: ['test', 'beta'],
             config: { image: 'node:6' },
-            scmUri: 'github.com:123:master'
+            pipelineId: '123'
         };
         template = new TemplateModel(createConfig);
     });

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -13,7 +13,7 @@ describe('Template Factory', () => {
     const description = 'this is a template';
     const labels = ['test', 'beta'];
     const templateConfig = { image: 'node:6' };
-    const scmUri = 'github.com:123:master';
+    const pipelineId = '123';
     const metaData = {
         name,
         version,
@@ -21,7 +21,7 @@ describe('Template Factory', () => {
         description,
         labels,
         config: templateConfig,
-        scmUri
+        pipelineId
     };
     let TemplateFactory;
     let datastore;
@@ -80,7 +80,7 @@ describe('Template Factory', () => {
                 description,
                 labels,
                 config: templateConfig,
-                scmUri,
+                pipelineId,
                 id: generatedId
             };
         });
@@ -98,7 +98,7 @@ describe('Template Factory', () => {
                 description,
                 labels,
                 config: templateConfig,
-                scmUri
+                pipelineId
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
@@ -120,7 +120,7 @@ describe('Template Factory', () => {
                 description,
                 labels,
                 config: templateConfig,
-                scmUri
+                pipelineId
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
@@ -137,7 +137,7 @@ describe('Template Factory', () => {
                 description,
                 labels,
                 config: templateConfig,
-                scmUri,
+                pipelineId,
                 id: generatedId
             };
 
@@ -153,7 +153,7 @@ describe('Template Factory', () => {
                 description,
                 labels,
                 config: templateConfig,
-                scmUri
+                pipelineId
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {


### PR DESCRIPTION
Unit tests were failing because `scmUri` was no longer a key. It was replaced by `pipelineId` as a way of identifying which pipeline a template was associated to. 

This PR fixes tests and comments.