### PR TITLE
feat(244): syncPR so it can restart PR from the API

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -152,7 +152,7 @@ class PipelineModel extends BaseModel {
 
     /**
      * Attach Screwdriver webhook to the pipeline's repository
-     * @param   webhookUrl    The webhook to be added
+     * @param   {String}    webhookUrl    The webhook to be added
      * @method  addWebhook
      * @return  {Promise}
      */
@@ -191,6 +191,41 @@ class PipelineModel extends BaseModel {
                 ]);
             }));
           /* eslint-enable no-understore-dangle */
+    }
+
+    /**
+     * Sync PR by looking up the PR's screwdriver.yaml
+     * Update the permutations to be correct
+     * @param   {Integer}   prNum        PR Number
+     * @method syncPR
+     * @return {Promise}
+     */
+    syncPR(prNum) {
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const JobFactory = require('./jobFactory');
+        /* eslint-enable global-require */
+
+        const jobFactory = JobFactory.getInstance();
+
+        return this.admin
+            .then(user => user.unsealToken())
+            .then(token => this.scm.getPrInfo({
+                scmUri: this.scmUri,
+                token,
+                prNum
+            }))
+            .then(prInfo => Promise.all([
+                this.getConfiguration(prInfo.ref),
+                jobFactory.get({ pipelineId: this.id, name: `PR-${prNum}` })
+            ]))
+            .then(([parsedConfig, job]) => {
+                job.permutations = parsedConfig.jobs.main;
+
+                return job.update();
+            })
+            .then(() => this);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "21.2.0",
+  "version": "22.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously, when a build for PR is created, it will go through `pipeline.sync`, which gets the configuration from `master`. This new function aims to read the configuration from the PR branch instead. It's done by passing in `prRef` to `this.getConfiguration`.

API will call this function like this: https://github.com/screwdriver-cd/screwdriver/pull/546
Blocked by: 
- https://github.com/screwdriver-cd/scm-base/pull/39/files
- https://github.com/screwdriver-cd/scm-github/pull/58
- https://github.com/screwdriver-cd/scm-bitbucket/pull/38

Related: https://github.com/screwdriver-cd/screwdriver/issues/244