### PR TITLE
feat: Add token models and tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const PipelineFactory = require('./lib/pipelineFactory');
 const SecretFactory = require('./lib/secretFactory');
 const UserFactory = require('./lib/userFactory');
 const TemplateFactory = require('./lib/templateFactory');
+const TokenFactory = require('./lib/tokenFactory');
 
 module.exports = {
     BuildFactory,
@@ -15,5 +16,6 @@ module.exports = {
     PipelineFactory,
     SecretFactory,
     UserFactory,
-    TemplateFactory
+    TemplateFactory,
+    TokenFactory
 };

--- a/lib/library.js
+++ b/lib/library.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const iron = require('iron');
+const nodeify = require('./nodeify');
+
+/**
+ * Seal token value
+ * @method sealToken
+ * @param  {String}         value          Value to seal
+ * @param  {String}         pw             Password to seal with
+ * @return {Promise}
+ */
+function sealValue(value, pw) {
+    return nodeify.withContext(iron, 'seal', [value, pw, iron.defaults]);
+}
+
+/**
+ * Unseal token value and return the token with the unsealed value
+ * @param  {Model}              model   Model to unseal
+ * @param  {String}             pw      Password to unseal with
+ * @return {Promise}
+ */
+function unsealValue(model, pw) {
+    return nodeify.withContext(iron, 'unseal', [model.value, pw, iron.defaults])
+        .then((unsealed) => {
+            model.value = unsealed;
+
+            return model;
+        });
+}
+
+module.exports = {
+    sealValue,
+    unsealValue
+};

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const BaseModel = require('./base');
+const nodeify = require('./nodeify');
+const iron = require('iron');
+
+// Symbols for private members
+const password = Symbol('password');
+
+class TokenModel extends BaseModel {
+    /**
+     * Construct a TokenModel object
+     * @method constructor
+     * @param  {Object}    config
+     * @param  {Object}    config.datastore         Object that will perform operations on the datastore
+     * @param  {Number}    config.userId            The ID of the associated user
+     * @param  {String}    config.value             The token value
+     * @param  {String}    config.tokenId           The token ID
+     * @param  {String}    config.name              The token name
+     * @param  {String}    config.description       The token description
+     * @param  {Date}      config.lastUsed          The last time the token was accessed
+     * @param  {String}    config.password          The encryption password
+     */
+    constructor(config) {
+        super('token', config);
+        this[password] = config.password;
+    }
+
+    /**
+     * Update a token with sealed token value
+     * @method update
+     * @return {Promise}
+     */
+    update() {
+        return nodeify.withContext(iron, 'seal', [this.value, this[password], iron.defaults])
+            .then((sealed) => {
+                this.value = sealed;
+
+                return super.update();
+            });
+    }
+}
+
+module.exports = TokenModel;

--- a/lib/tokenFactory.js
+++ b/lib/tokenFactory.js
@@ -1,78 +1,63 @@
 'use strict';
 
 const BaseFactory = require('./baseFactory');
-const Secret = require('./secret');
+const Token = require('./token');
 const Lib = require('./library');
-// Get symbols for private fields
+// Symbols for private fields
 const password = Symbol('password');
 
 let instance;
 
-class SecretFactory extends BaseFactory {
+class TokenFactory extends BaseFactory {
     /**
-     * Construct a SecretFactory object
+     * Construct a TokenFactory object
      * @method constructor
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
      * @param  {String}    config.password      Password for encryption operations
      */
     constructor(config) {
-        super('secret', config);
+        super('token', config);
         this[password] = config.password;
     }
 
     /**
-     * Instantiate a Secret class
+     * Instantiate a Token class
      * @method createClass
      * @param  config
-     * @return {Secret}
+     * @return {Token}
      */
     createClass(config) {
         const c = config;
 
         c.password = this[password];
 
-        return new Secret(c);
+        return new Token(c);
     }
 
     /**
-     * Create a secret model
-     * Need to seal the secret before saving
+     * Create a token model
+     * Need to seal the token before saving
      * @method create
      * @param  {Object}     config
-     * @param  {String}     config.pipelineId      Pipeline Id
-     * @param  {String}     config.name            Secret name
-     * @param  {String}     config.value           Secret value
-     * @param  {Boolean}    config.allowInPR       Whether this secret can be shown in PR builds
+     * @param  {String}     config.userId            The ID of the associated user
+     * @param  {String}     config.value             The token value
+     * @param  {String}     config.name              The token name
+     * @param  {String}     config.description       The token description
      * @return {Promise}
      */
     create(config) {
         return Lib.sealValue(config.value, this[password])
             .then((sealed) => {
                 config.value = sealed;
+                config.lastUsed = null;
 
                 return super.create(config);
             });
     }
 
     /**
-     * Get a secret based on id
-     * @method get
-     * @param  {Mixed}   config    The configuration from which an id is generated or the actual id
-     * @return {Promise}
-     */
-    get(config) {
-        return super.get(config).then((secret) => {
-            if (!secret) {
-                return secret;
-            }
-
-            return Lib.unsealValue(secret, this[password]);
-        });
-    }
-
-    /**
-     * List secrets with pagination and filter options
+     * List tokens with pagination and filter options
      * @method list
      * @param  {Object}   config                  Config object
      * @param  {Object}   config.params           Parameters to filter on
@@ -82,23 +67,23 @@ class SecretFactory extends BaseFactory {
      * @return {Promise}
      */
     list(config) {
-        return super.list(config).then(secrets =>
-            Promise.all(secrets.map(secret => Lib.unsealValue(secret, this[password]))));
+        return super.list(config).then(tokens =>
+            Promise.all(tokens.map(token => Lib.unsealValue(token, this[password]))));
     }
 
     /**
-     * Get an instance of the SecretFactory
+     * Get an instance of the TokenFactory
      * @method getInstance
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore    A datastore instance
      * @param  {String}     config.password     Password for encryption operations
-     * @return {SecretFactory}
+     * @return {TokenFactory}
      */
     static getInstance(config) {
-        instance = BaseFactory.getInstance(SecretFactory, instance, config);
+        instance = BaseFactory.getInstance(TokenFactory, instance, config);
 
         return instance;
     }
 }
 
-module.exports = SecretFactory;
+module.exports = TokenFactory;

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -328,6 +328,10 @@ describe('Build Model', () => {
             });
         });
 
+        afterEach(() => {
+            sandbox.restore();
+        });
+
         it('promises to start a build', () =>
             build.start()
             .then(() => {

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const mockery = require('mockery');
+const schema = require('screwdriver-data-schema');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Token Model', () => {
+    const password = 'password';
+    let BaseModel;
+    let TokenModel;
+    let ironMock;
+    let datastore;
+    let createConfig;
+    let token;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            update: sinon.stub()
+        };
+        datastore.update.resolves({});
+
+        ironMock = {
+            seal: sinon.stub(),
+            unseal: sinon.stub(),
+            defaults: {}
+        };
+        mockery.registerMock('iron', ironMock);
+
+        /* eslint-disable global-require */
+        BaseModel = require('../../lib/base');
+        TokenModel = require('../../lib/token');
+        /* eslint-enable global-require */
+
+        createConfig = {
+            datastore,
+            userId: 12345,
+            value: 'A_SECRET_TOKEN_VALUE',
+            id: 6789,
+            name: 'Mobile client auth token',
+            description: 'For the mobile app',
+            lastUsed: '2017-05-10T01:49:59.327Z',
+            password
+        };
+        token = new TokenModel(createConfig);
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
+        assert.instanceOf(token, TokenModel);
+        assert.instanceOf(token, BaseModel);
+        schema.models.token.allKeys.forEach((key) => {
+            assert.strictEqual(token[key], createConfig[key]);
+        });
+    });
+
+    describe('update', () => {
+        beforeEach(() => {
+            ironMock.seal.yieldsAsync(null, 'sealed');
+        });
+
+        it('promises to update a token and seal the value before datastore saves it', () => {
+            const newTimestamp = '2017-05-13T02:01:17.588Z';
+
+            token.value = 'unsealed';
+            token.lastUsed = newTimestamp;
+
+            return token.update()
+                .then(() => {
+                    assert.calledWith(ironMock.seal, 'unsealed', password, ironMock.defaults);
+
+                    assert.isTrue(datastore.update.calledWith({
+                        table: 'tokens',
+                        params: {
+                            id: 6789,
+                            value: 'sealed',
+                            lastUsed: newTimestamp
+                        }
+                    }));
+                });
+        });
+    });
+});

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Token Factory', () => {
+    const password = 'super_secure_password';
+    const name = 'mobile_token';
+    const description = 'a token for a mobile app';
+    const sealed = 'abcd';
+    const unsealed = 'efgh';
+    const userId = 6789;
+    const tokenId = 12345;
+    const tokenData = {
+        id: tokenId,
+        userId,
+        description,
+        name,
+        value: sealed,
+        lastUsed: null
+    };
+    let TokenFactory;
+    let datastore;
+    let ironMock;
+    let factory;
+    let Token;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            scan: sinon.stub(),
+            get: sinon.stub()
+        };
+        ironMock = {
+            seal: sinon.stub(),
+            unseal: sinon.stub(),
+            defaults: 'defaults'
+        };
+
+        mockery.registerMock('iron', ironMock);
+
+        /* eslint-disable global-require */
+        Token = require('../../lib/token');
+        TokenFactory = require('../../lib/tokenFactory');
+        /* eslint-enable global-require */
+
+        factory = new TokenFactory({ datastore, password });
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a Token', () => {
+            const model = factory.createClass(tokenData);
+
+            assert.instanceOf(model, Token);
+        });
+    });
+
+    describe('create', () => {
+        it('should create a Token', () => {
+            const generatedId = 1234135;
+            const expected = {
+                id: generatedId,
+                userId,
+                name,
+                description,
+                value: sealed,
+                lastUsed: null
+            };
+
+            ironMock.seal.yieldsAsync(null, sealed);
+            datastore.save.resolves(expected);
+
+            return factory.create({
+                value: unsealed,
+                userId,
+                name,
+                description
+            }).then((model) => {
+                assert.calledWith(ironMock.seal, unsealed, password, 'defaults');
+                assert.isTrue(datastore.save.calledOnce);
+                assert.instanceOf(model, Token);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+    });
+
+    describe('list', () => {
+        const paginate = {
+            page: 1,
+            count: 3
+        };
+        const params = {
+            userId: 4321
+        };
+        const datastoreReturnValue = [{
+            id: 123,
+            userId: 4321,
+            name: 'token1',
+            description: 'token number 1',
+            value: 'sealedToken1',
+            lastUsed: null
+        }, {
+            id: 456,
+            userId: 4321,
+            name: 'token2',
+            description: 'token number 2',
+            value: 'sealedToken2',
+            lastUsed: '2017-05-11T22:48:16.827Z'
+        }];
+
+        const returnValue = [{
+            id: 123,
+            userId: 4321,
+            name: 'token1',
+            description: 'token number 1',
+            value: 'unsealedToken1',
+            lastUsed: null
+        }, {
+            id: 456,
+            userId: 4321,
+            name: 'token2',
+            description: 'token number 2',
+            value: 'unsealedToken2',
+            lastUsed: '2017-05-11T22:48:16.827Z'
+        }];
+
+        it('calls datastore scan and returns correct values', () => {
+            datastore.scan.resolves(datastoreReturnValue);
+            ironMock.unseal.withArgs('sealedToken1', password).yieldsAsync(null, 'unsealedToken1');
+            ironMock.unseal.withArgs('sealedToken2', password).yieldsAsync(null, 'unsealedToken2');
+
+            return factory.list({ paginate, params })
+                .then((arr) => {
+                    assert.isTrue(datastore.scan.calledOnce);
+                    assert.isArray(arr);
+                    assert.equal(arr.length, 2);
+                    assert.deepEqual(arr, returnValue);
+                    arr.forEach((model) => {
+                        assert.instanceOf(model, Token);
+                    });
+                });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+        });
+
+        it('should get an instance', () => {
+            const f1 = TokenFactory.getInstance(config);
+            const f2 = TokenFactory.getInstance(config);
+
+            assert.instanceOf(f1, TokenFactory);
+            assert.instanceOf(f2, TokenFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw an error when config not supplied', () => {
+            assert.throw(TokenFactory.getInstance,
+                Error, 'No datastore provided to TokenFactory');
+        });
+    });
+});


### PR DESCRIPTION
* add Token and TokenFactory models
* add tests for those models

Notably with the current plan for authenticating, we don't actually need to be able to get a single token, just getting a list of the tokens associated with a user. It'd be pretty easy to implement though.

Related to https://github.com/screwdriver-cd/screwdriver/issues/532