### PR TITLE
WIP: fix: Refactor token model and add sealField function

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -9,7 +9,7 @@ class TokenModel extends BaseModel {
      * @param  {Object}    config
      * @param  {Object}    config.datastore         Object that will perform operations on the datastore
      * @param  {Number}    config.userId            The ID of the associated user
-     * @param  {String}    config.uuid              UUID for revoking the token
+     * @param  {String}    config.value             Hashed token value
      * @param  {String}    config.name              The token name
      * @param  {String}    config.description       The token description
      * @param  {String}    config.lastUsed          The last time the token was used (ISO String)

--- a/lib/tokenFactory.js
+++ b/lib/tokenFactory.js
@@ -31,7 +31,7 @@ class TokenFactory extends BaseFactory {
      * @method create
      * @param  {Object}     config
      * @param  {String}     config.userId            The ID of the associated user
-     * @param  {String}     config.value             The token value
+     * @param  {String}     config.value             The hashed token value
      * @param  {String}     config.name              The token name
      * @param  {String}     config.description       The token description
      * @return {Promise}

--- a/lib/user.js
+++ b/lib/user.js
@@ -80,26 +80,6 @@ class UserModel extends BaseModel {
     }
 
     /**
-     * Test if a token is valid and belongs to the user
-     * @method validateToken
-     * @param  {String}  uuid       UUID of token to validate
-     * @return {Promise}
-     */
-    validateToken(uuid) {
-        return this.tokens.then((tokens) => {
-            const token = tokens.find(t => t.uuid === uuid);
-
-            if (!token) {
-                throw new Error('Token has been revoked.');
-            }
-
-            token.lastUsed = (new Date()).toISOString();
-
-            return token.update();
-        });
-    }
-
-    /**
      * Get permissions on a specific repo
      * @method getPermissions
      * @param  {String}     scmUri          The scmUri of the repository

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -32,7 +32,7 @@ describe('Token Model', () => {
         createConfig = {
             datastore,
             userId: 12345,
-            uuid: '1a2b3c',
+            value: '1a2b3c',
             id: 6789,
             name: 'Mobile client auth token',
             description: 'For the mobile app',

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -10,7 +10,7 @@ require('sinon-as-promised');
 describe('Token Factory', () => {
     const name = 'mobile_token';
     const description = 'a token for a mobile app';
-    const uuid = 'abc123';
+    const value = 'abc123';
     const userId = 6789;
     const tokenId = 12345;
     const tokenData = {
@@ -18,7 +18,7 @@ describe('Token Factory', () => {
         userId,
         description,
         name,
-        uuid,
+        value,
         lastUsed: null
     };
     let TokenFactory;
@@ -70,7 +70,7 @@ describe('Token Factory', () => {
                 userId,
                 name,
                 description,
-                uuid,
+                value,
                 lastUsed: null
             };
 
@@ -80,7 +80,7 @@ describe('Token Factory', () => {
                 userId,
                 name,
                 description,
-                uuid
+                value
             }).then((model) => {
                 assert.isTrue(datastore.save.calledOnce);
                 assert.calledWith(datastore.save, {

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -244,23 +244,5 @@ describe('User Model', () => {
         afterEach(() => {
             sandbox.restore();
         });
-
-        it('validates a valid token and updates its lastUsed property', () =>
-            user.validateToken('110ec58a-a0f2-4ac4-8393-c866d813b8d1')
-            .then(() => {
-                assert.calledOnce(mockToken.update);
-                assert.equal(mockToken.lastUsed, '1970-01-01T00:00:00.000Z');
-            }));
-
-        it('rejects an invalid token', () => {
-            user.validateToken('a different token')
-            .then(() => {
-                assert.fail('Should not get here.');
-            })
-            .catch((err) => {
-                assert.equal(err.message, 'Token has been revoked.');
-                assert.notCalled(mockToken.update);
-            });
-        });
     });
 });


### PR DESCRIPTION
First commit:
* Added a function to seal a field on a model, since that will be reused between tokens and secrets

Second commit:
* Tokens store their value, as using a key to verify them instead would mean we couldn't rotate the key
* Iron stuff added back to tokens so the value isn't stored unencrypted

Related to https://github.com/screwdriver-cd/screwdriver/issues/532
