### PR TITLE
fix: Tokens store hash value

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,15 @@ model.getPermissions(scmUri)
 | :-------------   | :---- | :-------------|
 | scmUri | String | The scmUri of the repo |
 
+#### Tokens
+Get the user's access tokens
+```js
+model.tokens
+    .then((tokens) => {
+        // do stuff with tokens
+    });
+```
+
 
 ### Secret Factory
 #### Search
@@ -773,6 +782,100 @@ factory.get(config).then(model => {
 | config.name | String | Yes | The template name |
 | config.version | String | Yes | Version of the template |
 | config.label | String | No | Label of the template |
+
+### Token Factory
+#### Search
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.TokenFactory.getInstance({
+    datastore
+});
+const config = {
+    params: {
+        userId: 12345
+    },
+    paginate {
+        page: 1,
+        count: 3
+    }
+}
+
+factory.list(config).then(tokens => {
+    // Do stuff with list of tokens
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Config Object |
+| config.paginate.page | Number | The page for pagination |
+| config.paginate.count | Number | The count for pagination |
+| config.params | Object | fields to search on |
+
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with token model
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.userId | Number | Yes | User that this token belongs to |
+| config.name | String | Yes | Token name |
+| config.description | String | No | Description of the token |
+
+#### Get
+Get a token based on id. Can pass the generatedId for the token, or the token value, and the id will be determined automatically.
+```js
+factory.get(id).then(model => {
+    // do stuff with token model
+});
+
+factory.get({ value }).then(model => {
+    // do stuff with token model
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | Number | The unique ID for the token |
+| config.value | String | The value of the token |
+
+
+### Token Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.TokenFactory.getInstance({
+    datastore,
+});
+const config = {
+    userId: 12345,
+    name: 'NPM_TOKEN',
+    description: 'A token for use by npm'
+}
+
+factory.create(config)
+    .then(model => // do something
+    });
+```
+
+#### Update
+Update a specific token
+```js
+model.update()
+```
+
+#### Regenerate
+Regenerate a token's value while preserving its other metadata. Attaches a temporary "value" field to the model
+```js
+token.regenerate()
+    .then(model => // do something with the new model.value
+    });
+```
 
 ## Testing
 

--- a/lib/generateToken.js
+++ b/lib/generateToken.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const nodeify = require('./nodeify');
+const crypto = require('crypto');
+const ALGORITHM = 'sha256';
+const ENCODING = 'base64';
+const TOKEN_LENGTH = 256; // Measured in bits
+
+/**
+ * Create a token value with crypto
+ * @method generateValue
+ * @return {Promise}
+ */
+function generateValue() {
+    return nodeify.withContext(crypto, 'randomBytes', [TOKEN_LENGTH / 8])
+        .then(buffer => buffer.toString(ENCODING));
+}
+
+/**
+ * Use crypto to hash a token value
+ * @param  {String} value   Token to hash
+ * @return {String}         Hashed value
+ */
+function hashValue(value) {
+    return crypto.createHash(ALGORITHM).update(value).digest(ENCODING);
+}
+
+module.exports = {
+    generateValue,
+    hashValue
+};

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseModel = require('./base');
+const generateToken = require('./generateToken');
 
 class TokenModel extends BaseModel {
     /**
@@ -9,13 +10,34 @@ class TokenModel extends BaseModel {
      * @param  {Object}    config
      * @param  {Object}    config.datastore         Object that will perform operations on the datastore
      * @param  {Number}    config.userId            The ID of the associated user
-     * @param  {String}    config.uuid              UUID for revoking the token
+     * @param  {String}    config.hash              Hashed token value
      * @param  {String}    config.name              The token name
      * @param  {String}    config.description       The token description
      * @param  {String}    config.lastUsed          The last time the token was used (ISO String)
      */
     constructor(config) {
         super('token', config);
+    }
+
+    /**
+     * Regenerate a token value, and return the value once
+     * @method regenerate
+     * @return {Promise}
+     */
+    regenerate() {
+        let value;
+
+        return generateToken.generateValue()
+            .then((bytes) => {
+                value = bytes;
+                this.hash = generateToken.hashValue(bytes);
+
+                return this.update();
+            }).then((model) => {
+                model.value = value;
+
+                return model;
+            });
     }
 }
 

--- a/lib/tokenFactory.js
+++ b/lib/tokenFactory.js
@@ -2,6 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Token = require('./token');
+const generateToken = require('./generateToken');
 
 let instance;
 
@@ -27,19 +28,45 @@ class TokenFactory extends BaseFactory {
     }
 
     /**
-     * Create a token model
+     * Create a token model, returning the model including the unhashed value
      * @method create
      * @param  {Object}     config
      * @param  {String}     config.userId            The ID of the associated user
-     * @param  {String}     config.value             The token value
      * @param  {String}     config.name              The token name
      * @param  {String}     config.description       The token description
      * @return {Promise}
      */
     create(config) {
-        config.lastUsed = null;
+        let value;
 
-        return super.create(config);
+        return generateToken.generateValue()
+            .then((bytes) => {
+                value = bytes;
+                config.hash = generateToken.hashValue(bytes);
+                config.lastUsed = null;
+
+                return super.create(config);
+            }).then((model) => {
+                model.value = value;
+
+                return model;
+            });
+    }
+
+    /**
+     * Get a token
+     * @method get
+     * @param  {Mixed}     config
+     * @param  {String}    [config.value]    (Un-hashed) value of token to look for
+     * @return {Promise}
+     */
+    get(config) {
+        if (config && config.value) {
+            config.hash = generateToken.hashValue(config.value);
+            delete config.value;
+        }
+
+        return super.get(config);
     }
 
     /**

--- a/lib/user.js
+++ b/lib/user.js
@@ -80,26 +80,6 @@ class UserModel extends BaseModel {
     }
 
     /**
-     * Test if a token is valid and belongs to the user
-     * @method validateToken
-     * @param  {String}  uuid       UUID of token to validate
-     * @return {Promise}
-     */
-    validateToken(uuid) {
-        return this.tokens.then((tokens) => {
-            const token = tokens.find(t => t.uuid === uuid);
-
-            if (!token) {
-                throw new Error('Token has been revoked.');
-            }
-
-            token.lastUsed = (new Date()).toISOString();
-
-            return token.update();
-        });
-    }
-
-    /**
      * Get permissions on a specific repo
      * @method getPermissions
      * @param  {String}     scmUri          The scmUri of the repository

--- a/test/lib/generateToken.test.js
+++ b/test/lib/generateToken.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const generateToken = require('../../lib/generateToken');
+
+sinon.assert.expose(assert, { prefix: '' });
+require('sinon-as-promised');
+
+describe('generateToken', () => {
+    const RANDOM_BYTES = 'some random bytes';
+    // Result of passing 'some random bytes' through a sha256 hash, in base64
+    const HASH = 'mF0EvjvxWMrVz5ZGJcnbe0ZPooUlv/DAB9VrV6bmZmg=';
+    let firstValue;
+
+    it('generates a value', () =>
+        generateToken.generateValue()
+            .then((value) => {
+                firstValue = value;
+                // Check that it's a base64 value of the right length
+                assert.match(value, /[a-zA-Z0-9+/]{43}=/);
+            }));
+
+    it('generates a different value on a second call', () => {
+        generateToken.generateValue()
+            .then((value) => {
+                assert.notEqual(value, firstValue);
+            });
+    });
+
+    it('hashes a value', () => {
+        assert.strictEqual(generateToken.hashValue(RANDOM_BYTES), HASH);
+    });
+
+    it('hashes a different value to a different hash', () => {
+        assert.notEqual(generateToken.hashValue('some different bytes'), HASH);
+    });
+});

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -10,18 +10,28 @@ require('sinon-as-promised');
 describe('Token Factory', () => {
     const name = 'mobile_token';
     const description = 'a token for a mobile app';
-    const uuid = 'abc123';
     const userId = 6789;
     const tokenId = 12345;
+    const randomBytes = 'some random bytes';
+    const hash = 'abc123';
     const tokenData = {
         id: tokenId,
         userId,
         description,
         name,
+        hash,
+        lastUsed: null
+    };
+    const expected = {
+        userId,
+        name,
+        description,
+        hash,
         lastUsed: null
     };
     let TokenFactory;
     let datastore;
+    let generateTokenMock;
     let factory;
     let Token;
 
@@ -30,11 +40,21 @@ describe('Token Factory', () => {
             useCleanCache: true,
             warnOnUnregistered: false
         });
+        generateTokenMock = {
+            generateValue: sinon.stub(),
+            hashValue: sinon.stub()
+        };
+
+        generateTokenMock.generateValue.resolves(randomBytes);
+        generateTokenMock.hashValue.returns(hash);
+
+        mockery.registerMock('./generateToken', generateTokenMock);
     });
 
     beforeEach(() => {
         datastore = {
-            save: sinon.stub()
+            save: sinon.stub(),
+            get: sinon.stub()
         };
 
         /* eslint-disable global-require */
@@ -46,12 +66,11 @@ describe('Token Factory', () => {
     });
 
     afterEach(() => {
-        datastore = null;
-        mockery.deregisterAll();
         mockery.resetCache();
     });
 
     after(() => {
+        mockery.deregisterAll();
         mockery.disable();
     });
 
@@ -65,22 +84,17 @@ describe('Token Factory', () => {
 
     describe('create', () => {
         it('should create a Token', () => {
-            const expected = {
-                userId,
-                name,
-                description,
-                lastUsed: null
-            };
-
             datastore.save.resolves(tokenData);
 
             return factory.create({
                 userId,
                 name,
                 description,
-                uuid
+                hash
             }).then((model) => {
                 assert.isTrue(datastore.save.calledOnce);
+                assert.calledOnce(generateTokenMock.generateValue);
+                assert.calledWith(generateTokenMock.hashValue, randomBytes);
                 assert.calledWith(datastore.save, {
                     params: expected,
                     table: 'tokens'
@@ -89,7 +103,52 @@ describe('Token Factory', () => {
                 Object.keys(tokenData).forEach((key) => {
                     assert.strictEqual(model[key], tokenData[key]);
                 });
+                assert.strictEqual(model.value, randomBytes);
             });
+        });
+    });
+
+    describe('get', () => {
+        beforeEach(() => {
+            datastore.get.resolves(tokenData);
+        });
+
+        it('should get a token by ID', () =>
+            Promise.all([factory.get(tokenId), factory.get({ id: tokenId })])
+                .then(([token1, token2]) => {
+                    Object.keys(token1).forEach((key) => {
+                        assert.strictEqual(token1[key], tokenData[key]);
+                        assert.strictEqual(token2[key], tokenData[key]);
+                    });
+                }));
+
+        it('should get a token by value', () =>
+            factory.get({ value: randomBytes })
+                .then((token) => {
+                    Object.keys(token).forEach((key) => {
+                        assert.strictEqual(token[key], tokenData[key]);
+                    });
+                    assert.calledWith(datastore.get, {
+                        params: {
+                            hash
+                        },
+                        table: 'tokens'
+                    });
+                }));
+
+        it('should return null when trying to get a token by value', () => {
+            datastore.get.resolves(null);
+
+            return factory.get({ value: randomBytes })
+                .then((token) => {
+                    assert.isNull(token);
+                    assert.calledWith(datastore.get, {
+                        params: {
+                            hash
+                        },
+                        table: 'tokens'
+                    });
+                });
         });
     });
 
@@ -98,6 +157,10 @@ describe('Token Factory', () => {
 
         beforeEach(() => {
             config = { datastore };
+
+            /* eslint-disable global-require */
+            TokenFactory = require('../../lib/tokenFactory');
+            /* eslint-enable global-require */
         });
 
         it('should get an instance', () => {

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -219,48 +219,4 @@ describe('User Model', () => {
             assert.calledOnce(tokenFactoryMock.list);
         });
     });
-
-    describe('validateToken', () => {
-        let sandbox;
-        let mockToken;
-
-        beforeEach(() => {
-            sandbox = sinon.sandbox.create();
-            sandbox.useFakeTimers(0);
-
-            mockToken = {
-                id: 123,
-                uuid: '110ec58a-a0f2-4ac4-8393-c866d813b8d1',
-                userId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
-                name: 'token1',
-                description: 'token number 1',
-                lastUsed: null,
-                update: sinon.stub()
-            };
-
-            tokenFactoryMock.list.resolves([mockToken]);
-        });
-
-        afterEach(() => {
-            sandbox.restore();
-        });
-
-        it('validates a valid token and updates its lastUsed property', () =>
-            user.validateToken('110ec58a-a0f2-4ac4-8393-c866d813b8d1')
-            .then(() => {
-                assert.calledOnce(mockToken.update);
-                assert.equal(mockToken.lastUsed, '1970-01-01T00:00:00.000Z');
-            }));
-
-        it('rejects an invalid token', () => {
-            user.validateToken('a different token')
-            .then(() => {
-                assert.fail('Should not get here.');
-            })
-            .catch((err) => {
-                assert.equal(err.message, 'Token has been revoked.');
-                assert.notCalled(mockToken.update);
-            });
-        });
-    });
 });


### PR DESCRIPTION
* Use sha256 to hash a token value, and store the hash
* When generating (or regenerating) a token, the first time the model is returned it will have a "value" field.
* Can `get` a token by value, and the factory will hash it so the api doesn't have to worry about it

Related to https://github.com/screwdriver-cd/screwdriver/issues/532