### PR TITLE
fix: add build createTime right before save to avoid github latency

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -53,7 +53,6 @@ class EventFactory extends BaseFactory {
                 pipelineId: config.pipelineId,
                 sha: config.sha,
                 workflow: config.workflow,
-                createTime: (new Date()).toISOString(),
                 causeMessage: config.causeMessage || `Started by ${config.username}`
             };
 
@@ -76,6 +75,7 @@ class EventFactory extends BaseFactory {
                     }))
                 .then((commit) => {
                     modelConfig.commit = commit;
+                    modelConfig.createTime = (new Date()).toISOString();
 
                     return super.create(modelConfig);
                 });

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -18,7 +18,6 @@ describe('Token Factory', () => {
         userId,
         description,
         name,
-        uuid,
         lastUsed: null
     };
     let TokenFactory;
@@ -70,7 +69,6 @@ describe('Token Factory', () => {
                 userId,
                 name,
                 description,
-                uuid,
                 lastUsed: null
             };
 


### PR DESCRIPTION
Add build createTime right before save to avoid github latency.
Need to modify the token test because of the new token schema.