### PR TITLE
fix: move build createTime closer to datastore save

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -122,7 +122,6 @@ class BuildFactory extends BaseFactory {
         const modelConfig = config;
 
         modelConfig.cause = `Started by user ${config.username}`;
-        modelConfig.createTime = (new Date(number)).toISOString();
         modelConfig.number = number;
         modelConfig.status = 'QUEUED';
 
@@ -169,6 +168,7 @@ class BuildFactory extends BaseFactory {
                         modelConfig.steps = setup.concat(modelConfig.steps, teardown);
                         // Launcher is hardcoded to do some business in sd-setup-launcher
                         modelConfig.steps.unshift({ name: 'sd-setup-launcher' });
+                        modelConfig.createTime = (new Date(number)).toISOString();
 
                         return super.create(modelConfig);
                     });


### PR DESCRIPTION
Seeing some weird data where createTime is after startTime. 
This does not address that problem but moving it closer to datastore save to be more accurate. 