### PR TITLE
feat: Get a user by token value

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ factory.create(config).then(model => {
 
 #### Get
 Get a user based on id. Can pass the generatedId for the user, or the username, and the id will be determined automatically.
+Can also pass a Screwdriver access token, and will get the user associated with that token.
 ```js
 factory.get(id).then(model => {
     // do stuff with user model
@@ -425,12 +426,17 @@ factory.get(id).then(model => {
 factory.get({ username }).then(model => {
     // do stuff with user model
 });
+
+factory.get({ token }).then(model => {
+    // do stuff with user model
+});
 ```
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
 | id | String | The unique ID for the build |
 | config.username | String | User name |
+| config.accessToken | String | A user access token value |
 
 ### User Model
 ```js

--- a/lib/tokenFactory.js
+++ b/lib/tokenFactory.js
@@ -61,7 +61,7 @@ class TokenFactory extends BaseFactory {
      * @return {Promise}
      */
     get(config) {
-        if (config && config.value) {
+        if (config.value) {
             config.hash = generateToken.hashValue(config.value);
             delete config.value;
         }

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -65,6 +65,38 @@ class UserFactory extends BaseFactory {
     }
 
     /**
+     * Get a user model by name, id, or personal access token
+     * @method get
+     * @param   {Mixed}     config
+     * @param   {String}    [config.username]       Username of the user to look up
+     * @param   {String}    [config.accessToken]    Access token of the user to look up
+     * @return  {Promise}
+     */
+    get(config) {
+        if (!config.accessToken) {
+            return super.get(config);
+        }
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const TokenFactory = require('./tokenFactory');
+        /* eslint-enable global-require */
+        const tokenFactory = TokenFactory.getInstance();
+
+        return tokenFactory.get({ value: config.accessToken })
+            .then((token) => {
+                if (!token) {
+                    return token;
+                }
+
+                token.lastUsed = (new Date()).toISOString();
+
+                return token.update().then(() => this.get(token.userId));
+            });
+    }
+
+    /**
      * Get an instance of the UserFactory
      * @method getInstance
      * @param  {Object}     config


### PR DESCRIPTION
* Can call userFactory.get with an unhashed token value in `token`
* Getting a user this way update's the token's "last used" property

Related to https://github.com/screwdriver-cd/screwdriver/issues/532