### PR TITLE
refactor(tests): Upgrade to Sinon V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "jenkins-mocha": "^4.0.0",
     "joi": "^10.0.5",
     "mockery": "^2.0.0",
-    "sinon": "^1.17.4",
-    "sinon-as-promised": "^4.0.2"
+    "sinon": "^2.3.1"
   },
   "dependencies": {
     "async": "^2.0.1",

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
-require('sinon-as-promised');
 
 describe('Build Model', () => {
     const apiUri = 'https://notify.com/some/endpoint';

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -6,7 +6,6 @@ const schema = require('screwdriver-data-schema');
 const sinon = require('sinon');
 let startStub;
 
-require('sinon-as-promised');
 sinon.assert.expose(assert, { prefix: '' });
 
 class Build {

--- a/test/lib/generateToken.test.js
+++ b/test/lib/generateToken.test.js
@@ -5,7 +5,6 @@ const sinon = require('sinon');
 const generateToken = require('../../lib/generateToken');
 
 sinon.assert.expose(assert, { prefix: '' });
-require('sinon-as-promised');
 
 describe('generateToken', () => {
     const RANDOM_BYTES = 'some random bytes';

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -7,7 +7,6 @@ const schema = require('screwdriver-data-schema');
 const hoek = require('hoek');
 
 sinon.assert.expose(assert, { prefix: '' });
-require('sinon-as-promised');
 
 describe('Job Model', () => {
     let pipelineFactoryMock;
@@ -305,7 +304,7 @@ describe('Job Model', () => {
         });
 
         it('fail if getBuilds returns error', () => {
-            buildFactoryMock.list.rejects('error');
+            buildFactoryMock.list.rejects(new Error('error'));
 
             return job.remove().then(() => {
                 assert.fail('should not get here');
@@ -316,7 +315,7 @@ describe('Job Model', () => {
         });
 
         it('fail if build.remove returns error', () => {
-            build1.remove.rejects('error removing build');
+            build1.remove.rejects(new Error('error removing build'));
             buildFactoryMock.list.resolves([build1, build2]);
 
             return job.remove().then(() => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 const hoek = require('hoek');
 const schema = require('screwdriver-data-schema');
 
-require('sinon-as-promised');
 sinon.assert.expose(assert, { prefix: '' });
 const PARSED_YAML = require('../data/parser');
 
@@ -851,7 +850,7 @@ describe('Pipeline Model', () => {
         });
 
         it('fail if getJobs returns error', () => {
-            jobFactoryMock.list.rejects('error');
+            jobFactoryMock.list.rejects(new Error('error'));
 
             return pipeline.remove().then(() => {
                 assert.fail('should not get here');
@@ -862,7 +861,7 @@ describe('Pipeline Model', () => {
         });
 
         it('fail if job.remove returns error', () => {
-            publishJob.remove.rejects('error removing job');
+            publishJob.remove.rejects(new Error('error removing job'));
             jobFactoryMock.list.resolves([publishJob, mainJob]);
 
             return pipeline.remove().then(() => {
@@ -901,7 +900,7 @@ describe('Pipeline Model', () => {
         });
 
         it('fail if getEvents returns error', () => {
-            eventFactoryMock.list.rejects('error');
+            eventFactoryMock.list.rejects(new Error('error'));
 
             return pipeline.remove().then(() => {
                 assert.fail('should not get here');
@@ -912,7 +911,7 @@ describe('Pipeline Model', () => {
         });
 
         it('fail if event.remove returns error', () => {
-            testEvent.remove.rejects('error removing event');
+            testEvent.remove.rejects(new Error('error removing event'));
             eventFactoryMock.list.resolves([testEvent]);
 
             return pipeline.remove().then(() => {
@@ -924,7 +923,7 @@ describe('Pipeline Model', () => {
         });
 
         it('fail if secret.remove returns error', () => {
-            secret.remove.rejects('error removing secret');
+            secret.remove.rejects(new Error('error removing secret'));
 
             return pipeline.remove().then(() => {
                 assert.fail('should not get here');

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -6,7 +6,6 @@ const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
-require('sinon-as-promised');
 
 describe('Token Model', () => {
     const password = 'password';

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -5,7 +5,6 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
-require('sinon-as-promised');
 
 describe('Token Factory', () => {
     const name = 'mobile_token';

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
-require('sinon-as-promised');
 
 describe('User Model', () => {
     const password = 'password';

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -5,7 +5,6 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
-require('sinon-as-promised');
 
 describe('User Factory', () => {
     const password = 'totallySecurePassword';


### PR DESCRIPTION
* Sinon version 2 supports promises, so we no longer need `sinon-as-promised`