### PR TITLE
fix(tokens): lastUsed defaults to empty string instead of null

### DIFF
--- a/lib/tokenFactory.js
+++ b/lib/tokenFactory.js
@@ -43,7 +43,7 @@ class TokenFactory extends BaseFactory {
             .then((bytes) => {
                 value = bytes;
                 config.hash = generateToken.hashValue(bytes);
-                config.lastUsed = null;
+                config.lastUsed = '';
 
                 return super.create(config);
             }).then((model) => {

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -19,14 +19,14 @@ describe('Token Factory', () => {
         description,
         name,
         hash,
-        lastUsed: null
+        lastUsed: ''
     };
     const expected = {
         userId,
         name,
         description,
         hash,
-        lastUsed: null
+        lastUsed: ''
     };
     let TokenFactory;
     let datastore;


### PR DESCRIPTION
The datastore wasn't validating tokens that hadn't been used, because the `.allow(null)` was being ignored by the datastore-sequelize plugin. Now using empty strings instead of `null`.

Related to https://github.com/screwdriver-cd/screwdriver/issues/532