### PR TITLE
fix(tokens): Update tokens to be URL-safe

### DIFF
--- a/lib/generateToken.js
+++ b/lib/generateToken.js
@@ -3,7 +3,7 @@
 const nodeify = require('./nodeify');
 const crypto = require('crypto');
 const ALGORITHM = 'sha256';
-const ENCODING = 'base64';
+const ENCODING = 'hex';
 const TOKEN_LENGTH = 256; // Measured in bits
 
 /**

--- a/test/lib/generateToken.test.js
+++ b/test/lib/generateToken.test.js
@@ -8,16 +8,16 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('generateToken', () => {
     const RANDOM_BYTES = 'some random bytes';
-    // Result of passing 'some random bytes' through a sha256 hash, in base64
-    const HASH = 'mF0EvjvxWMrVz5ZGJcnbe0ZPooUlv/DAB9VrV6bmZmg=';
+    // Result of passing 'some random bytes' through a sha256 hash, in hex
+    const HASH = '985d04be3bf158cad5cf964625c9db7b464fa28525bff0c007d56b57a6e66668';
     let firstValue;
 
     it('generates a value', () =>
         generateToken.generateValue()
             .then((value) => {
                 firstValue = value;
-                // Check that it's a base64 value of the right length
-                assert.match(value, /[a-zA-Z0-9+/]{43}=/);
+                // Check that it's a hex value of the right length
+                assert.match(value, /[a-f0-9]{64}/);
             }));
 
     it('generates a different value on a second call', () => {


### PR DESCRIPTION
* The endpoint for auth takes tokens through query string, or a bearer header
* Bearer headers are used for JWT's. We could try to pattern match and handle tokens differently based on if they're user tokens or JWT's, but that seems suspect
* Currently tokens are encoded in base64, which is not URL-safe
* This PR switches to using hex, which *is* URL-safe

Related to https://github.com/screwdriver-cd/screwdriver/issues/532
More discussion at https://github.com/screwdriver-cd/data-schema/pull/139