### PR TITLE
fix(tokens): Use URL-safe values, add toJson

### DIFF
--- a/lib/generateToken.js
+++ b/lib/generateToken.js
@@ -2,8 +2,8 @@
 
 const nodeify = require('./nodeify');
 const crypto = require('crypto');
+const base64url = require('base64url');
 const ALGORITHM = 'sha256';
-const ENCODING = 'base64';
 const TOKEN_LENGTH = 256; // Measured in bits
 
 /**
@@ -13,7 +13,7 @@ const TOKEN_LENGTH = 256; // Measured in bits
  */
 function generateValue() {
     return nodeify.withContext(crypto, 'randomBytes', [TOKEN_LENGTH / 8])
-        .then(buffer => buffer.toString(ENCODING));
+        .then(buffer => base64url(buffer.toString()));
 }
 
 /**
@@ -22,7 +22,7 @@ function generateValue() {
  * @return {String}         Hashed value
  */
 function hashValue(value) {
-    return crypto.createHash(ALGORITHM).update(value).digest(ENCODING);
+    return base64url(crypto.createHash(ALGORITHM).update(value).digest());
 }
 
 module.exports = {

--- a/lib/token.js
+++ b/lib/token.js
@@ -39,6 +39,23 @@ class TokenModel extends BaseModel {
                 return model;
             });
     }
+
+    /**
+     * Get the token as JSON, including value if it exists
+     * @method toJson
+     * @return {Object}
+     */
+    toJson() {
+        const output = super.toJson();
+
+        if (this.value) {
+            output.value = this.value;
+        }
+
+        delete output.hash;
+
+        return output;
+    }
 }
 
 module.exports = TokenModel;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "async": "^2.0.1",
+    "base64url": "^2.0.0",
     "compare-versions": "^3.0.0",
     "hoek": "^4.0.1",
     "iron": "^4.0.1",

--- a/test/lib/generateToken.test.js
+++ b/test/lib/generateToken.test.js
@@ -9,7 +9,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('generateToken', () => {
     const RANDOM_BYTES = 'some random bytes';
     // Result of passing 'some random bytes' through a sha256 hash, in base64
-    const HASH = 'mF0EvjvxWMrVz5ZGJcnbe0ZPooUlv/DAB9VrV6bmZmg=';
+    const HASH = 'mF0EvjvxWMrVz5ZGJcnbe0ZPooUlv_DAB9VrV6bmZmg';
     let firstValue;
 
     it('generates a value', () =>
@@ -17,7 +17,7 @@ describe('generateToken', () => {
             .then((value) => {
                 firstValue = value;
                 // Check that it's a base64 value of the right length
-                assert.match(value, /[a-zA-Z0-9+/]{43}=/);
+                assert.match(value, /[a-zA-Z0-9_-]{43}/);
             }));
 
     it('generates a different value on a second call', () => {

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -8,7 +8,6 @@ const schema = require('screwdriver-data-schema');
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('Token Model', () => {
-    const password = 'password';
     let datastore;
     let generateTokenMock;
     let BaseModel;
@@ -47,8 +46,7 @@ describe('Token Model', () => {
             id: 6789,
             name: 'Mobile client auth token',
             description: 'For the mobile app',
-            lastUsed: '2017-05-10T01:49:59.327Z',
-            password
+            lastUsed: '2017-05-10T01:49:59.327Z'
         };
         token = new TokenModel(createConfig);
     });
@@ -100,6 +98,29 @@ describe('Token Model', () => {
                     assert.strictEqual(model.value, newValue);
                     assert.strictEqual(model.hash, newHash);
                 });
+        });
+    });
+
+    describe('toJson', () => {
+        const expected = {
+            userId: 12345,
+            id: 6789,
+            name: 'Mobile client auth token',
+            description: 'For the mobile app',
+            lastUsed: '2017-05-10T01:49:59.327Z'
+        };
+        const value = 'tokenValue';
+
+        it('functions normally if no value is present', () => {
+            const output = token.toJson();
+
+            assert.deepEqual(output, expected);
+        });
+
+        it('adds the value field if present', () => {
+            token.value = value;
+
+            assert.deepEqual(token.toJson(), Object.assign({}, expected, { value }));
         });
     });
 });


### PR DESCRIPTION
* add `toJson` to hide the hash value, since the only time the API ever even knows a hash value exists is to delete it before returning the token, and so that `value` doesn't have to be added manually by the API
* switch base64 encoding to be URL-safe.
    - Could use a library like `base64url`, but the same thing can be accomplished by a small function in one file, which doesn't add a new dependency.
    - If adding the dependency for increased code-cleanliness is preferred I can switch to doing that.
* test still had `password` in it, we no longer use that in tokens

Related to https://github.com/screwdriver-cd/screwdriver/issues/532