### PR TITLE
fix(580): add annotations to pipeline model during sync

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -249,6 +249,7 @@ class PipelineModel extends BaseModel {
             // get list of jobs to create
             .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;
+                this.annotations = parsedConfig.annotations;
 
                 return this.update()
                     .then(() => this.jobs)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "compare-versions": "^3.0.0",
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
-    "screwdriver-config-parser": "^3.0.1",
-    "screwdriver-data-schema": "^16.8.2"
+    "screwdriver-config-parser": "^3.6.0",
+    "screwdriver-data-schema": "^16.10.1"
   }
 }

--- a/test/data/parser.json
+++ b/test/data/parser.json
@@ -80,5 +80,8 @@
     "workflow": [
         "main",
         "publish"
-    ]
+    ],
+    "annotations": {
+        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
+    }
 }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -257,7 +257,7 @@ describe('Pipeline Model', () => {
             };
         });
 
-        it('store workflow to pipeline', () => {
+        it('stores workflow to pipeline', () => {
             jobs = [];
             jobFactoryMock.list.resolves(jobs);
             jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
@@ -265,6 +265,19 @@ describe('Pipeline Model', () => {
 
             return pipeline.sync().then(() => {
                 assert.deepEqual(pipeline.workflow, ['main', 'publish']);
+            });
+        });
+
+        it('stores annotations to pipeline', () => {
+            jobs = [];
+            jobFactoryMock.list.resolves(jobs);
+            jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
+            jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
+
+            return pipeline.sync().then(() => {
+                assert.deepEqual(pipeline.annotations, {
+                    'beta.screwdriver.cd/executor': 'screwdriver-executor-vm'
+                });
             });
         });
 


### PR DESCRIPTION
add annotations to pipeline model during pipeline.sync()

Related to https://github.com/screwdriver-cd/screwdriver/issues/580

Blocked by https://github.com/screwdriver-cd/data-schema/pull/147