### PR TITLE
feat(472): configure a default docker registry for container images

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -2,6 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
+const imageParser = require('docker-parse-image');
 let instance;
 
 /**
@@ -63,18 +64,46 @@ function getCommitInfo(config) {
     });
 }
 
+/**
+ * Determines the Docker image name to use depending on if a default registry is
+ * configured.
+ *
+ * When the image name contains an explicit registry, it returns the passed-in
+ * container value. When a default registry is _not_ configured for the BuildFactory,
+ * it simply returns the passed-in container value.
+ * @method dockerImageName
+ * @param  {Object}        config
+ * @param  {String}        config.container         Docker image name to use.
+ * @param  {String}        [config.dockerRegistry]  Docker registry where the image is stored. Defaults to Docker Hub
+ * @return {String}                                 The full image name to use
+ */
+function dockerImageName({ container, dockerRegistry }) {
+    const imageInfo = imageParser(container);
+
+    // skip if no default registry or the image contains a specific registry in the name
+    if (!dockerRegistry || imageInfo.registry) {
+        return container;
+    }
+
+    const updatedName = imageParser(`${dockerRegistry}/${container}`);
+
+    return updatedName.fullname;
+}
+
 class BuildFactory extends BaseFactory {
     /**
      * Construct a JobFactory object
      * @method constructor
      * @param  {Object}    config
-     * @param  {Datastore} config.datastore     Object that will perform datastore operations
-     * @param  {Executor}  config.executor      Object that will perform compute operations
-     * @param  {Bookend}   config.bookend       Object that will calculate the setup and teardown commands
-     * @param  {String}    config.uiUri         Partial Uri including hostname and namespace for ui for git notifications
+     * @param  {Datastore} config.datastore         Object that will perform datastore operations
+     * @param  {String}    [config.dockerRegistry]  Docker Registry that the images belong to. Default is Docker Hub
+     * @param  {Executor}  config.executor          Object that will perform compute operations
+     * @param  {Bookend}   config.bookend           Object that will calculate the setup and teardown commands
+     * @param  {String}    config.uiUri             Partial Uri including hostname and namespace for ui for git notifications
      */
     constructor(config) {
         super('build', config);
+        this.dockerRegistry = config.dockerRegistry;
         this.executor = config.executor;
         this.uiUri = config.uiUri;
         this.bookend = config.bookend;
@@ -152,7 +181,10 @@ class BuildFactory extends BaseFactory {
                         modelConfig.commit = data.decoratedCommit;
                     }
 
-                    modelConfig.container = permutation.image;
+                    modelConfig.container = dockerImageName({
+                        container: permutation.image,
+                        dockerRegistry: this.dockerRegistry
+                    });
                     modelConfig.environment = permutation.environment;
                     modelConfig.steps = permutation.commands.map(command => ({
                         name: command.name,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "async": "^2.0.1",
     "base64url": "^2.0.0",
     "compare-versions": "^3.0.0",
+    "docker-parse-image": "^3.0.1",
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.6.0",

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -106,6 +106,21 @@ describe('Build Factory', () => {
         mockery.disable();
     });
 
+    describe('constructor', () => {
+        it('constructs with a designated docker registry', () => {
+            factory = new BuildFactory({
+                datastore,
+                dockerRegistry: 'registry.com:1234',
+                executor,
+                scm: scmMock,
+                uiUri,
+                bookend: bookendMock
+            });
+
+            assert.strictEqual(factory.dockerRegistry, 'registry.com:1234');
+        });
+    });
+
     describe('createClass', () => {
         it('should return a Build', () => {
             const model = factory.createClass({});
@@ -360,6 +375,29 @@ describe('Build Factory', () => {
             return factory.create({ username, jobId, eventId }).catch((err) => {
                 assert.instanceOf(err, Error);
                 assert.strictEqual(err.message, 'Pipeline does not exist');
+            });
+        });
+
+        it('creates a new build with a custom docker registry', () => {
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo })
+            };
+
+            factory = new BuildFactory({
+                datastore,
+                dockerRegistry: 'registry.com:1234',
+                executor,
+                scm: scmMock,
+                uiUri,
+                bookend: bookendMock
+            });
+
+            datastore.save.resolves({});
+            jobFactoryMock.get.resolves(jobMock);
+
+            return factory.create({ username, jobId, eventId, sha }).then((model) => {
+                assert.strictEqual(model.container, 'registry.com:1234/library/node:4');
             });
         });
     });


### PR DESCRIPTION
## Context

The typical behavior expected when a Docker image lacks an explicit registry, the default registry it uses is Docker Hub. For example, specifying `node:6` translates to `registry.hub.docker.com/library/node:6`.

This change allows for the default registry to be something other than Docker Hub (e.g., a private registry) when an image name lacks an explicit registry.

## Objective

Use a different Docker registry when the image is missing an explicit registry.

## Reference

* Related to screwdriver-cd/screwdriver#472


