### PR TITLE
fix(562): Update pipelines with new repo and branch

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -497,6 +497,34 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Update the repository and branch
+     * @method update
+     * @return {Promise}
+     */
+    update() {
+        if (this.isDirty('scmUri')) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const UserFactory = require('./userFactory');
+            /* eslint-enable global-require */
+
+            const userFactory = UserFactory.getInstance();
+
+            return userFactory.get({ username: Object.keys(this.admins)[0] })
+                .then(user => user.unsealToken())
+                .then(token => this.scm.decorateUrl({ scmUri: this.scmUri, token }))
+                .then((scmRepo) => {
+                    this.scmRepo = scmRepo;
+
+                    return super.update();
+                });
+        }
+
+        return super.update();
+    }
+
+    /**
      * Remove all jobs & builds associated with this pipeline and the pipeline itself
      * @return {Promise}        Resolves to null if remove successfully
      */

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -775,6 +775,73 @@ describe('Pipeline Model', () => {
         });
     });
 
+    describe('update', () => {
+        const scmRepo = {
+            name: 'foo/bar',
+            branch: 'master',
+            url: 'https://github.com/foo/bar/tree/master'
+        };
+
+        it('updates a pipeline with a different scm repository and branch', () => {
+            const expected = {
+                params: {
+                    admins: { d2lam: true },
+                    id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    scmRepo: {
+                        branch: 'master',
+                        name: 'foo/bar',
+                        url: 'https://github.com/foo/bar/tree/master'
+                    },
+                    scmUri: 'github.com:12345:master'
+                },
+                table: 'pipelines'
+            };
+
+            scmMock.decorateUrl.resolves(scmRepo);
+            userFactoryMock.get.withArgs({ username: 'd2lam' }).resolves({
+                unsealToken: sinon.stub().resolves('foo')
+            });
+            datastore.update.resolves({});
+
+            pipeline.scmUri = 'github.com:12345:master';
+            pipeline.admins = {
+                d2lam: true
+            };
+
+            return pipeline.update().then((p) => {
+                assert.calledWith(scmMock.decorateUrl, { scmUri, token: 'foo' });
+                assert.calledWith(datastore.update, expected);
+                assert.ok(p);
+            });
+        });
+
+        it('updates a pipeline without updating scmUri when it has not changes', () => {
+            const expected = {
+                params: {
+                    admins: { d2lam: true },
+                    id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c'
+                },
+                table: 'pipelines'
+            };
+
+            scmMock.decorateUrl.resolves(scmRepo);
+            userFactoryMock.get.withArgs({ username: 'd2lam' }).resolves({
+                unsealToken: sinon.stub().resolves('foo')
+            });
+            datastore.update.resolves({});
+
+            pipeline.admins = {
+                d2lam: true
+            };
+
+            return pipeline.update().then((p) => {
+                assert.notCalled(scmMock.decorateUrl);
+                assert.calledWith(datastore.update, expected);
+                assert.ok(p);
+            });
+        });
+    });
+
     describe('remove', () => {
         let archived;
         let prType;


### PR DESCRIPTION
## Context
Users currently cannot update the repo/branch for their pipeline. It would be nice if users could update that information without having to create a new pipeline (and lose their pipeline ID).

## Objective
This PR adds a method for updating a pipeline. It will check if the `scmUri` value is dirty. If so, it will get a user token, decorate the URL to create an `scmRepo` object, and update the pipeline with the new information.

`scmRepo` object: 
```
"scmRepo": {
"branch": "master",
"name": "screwdriver-cd/screwdriver",
"url": "https://github.com/screwdriver-cd/screwdriver/tree/master"
}
```

## References
Data-schema PR: https://github.com/screwdriver-cd/data-schema/pull/148
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/562