### PR TITLE
feat(595): consume executor from job annotations

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -183,6 +183,7 @@ class BuildModel extends BaseModel {
             .then(job =>
                 job.pipeline.then(pipeline =>
                     this[executor].start({
+                        annotations: job.permutations[0].annotations,
                         apiUri: this[apiUri],
                         buildId: this.id,
                         container: this.container,
@@ -247,7 +248,11 @@ class BuildModel extends BaseModel {
      * @return {Promise}
      */
     stop() {
-        return this[executor].stop({ buildId: this.id })
+        return this.job
+            .then(job => this[executor].stop({
+                annotations: job.permutations[0].annotations,
+                buildId: this.id
+            }))
             .then(() => this);
     }
 


### PR DESCRIPTION
- consume executor from job annotations

Related to https://github.com/screwdriver-cd/screwdriver/issues/595