### PR TITLE
feat(523): Add collection model and factory with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,92 @@ token.refresh()
     });
 ```
 
+### Collection Factory
+#### Search
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.CollectionFactory.getInstance({
+    datastore
+});
+const config = {
+    params: {
+        userId: 12345
+    }
+};
+
+factory.list(config).then(collections => {
+    // Do stuff with list of collections
+});
+```
+
+| Parameter     | Type   | Description         |
+| :-------------| :------| :-------------------|
+| config        | Object | Config object       |
+| config.params | Object | Fields to search on |
+
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with collection model
+});
+```
+
+| Parameter          | Type   | Required | Description                                              |
+| :------------------| :------| :--------| :--------------------------------------------------------|
+| config             | Object | Yes      | Configuration Object                                     |
+| config.userId      | Number | Yes      | User that this collection belongs to                     |
+| config.name        | String | Yes      | Collection name                                          |
+| config.description | String | No       | Collection description                                   |
+| config.pipelineIds | Array  | No       | List of ids of pipelines associated with this collection |
+
+#### Get
+Get a collection based on unique id of collection. Can also pass in a combination of userId and collection name, and the id will be determined automatically.
+```js
+factory.get(id).then(model => {
+    // do stuff with collection model
+});
+
+factory.get({ userId, name }).then(model => {
+    // do stuff with collection model
+})
+```
+
+| Parameter | Type   | Description                      |
+| :---------| :------| :--------------------------------|
+| id        | Number | The unique id for the collection |
+
+### Collection Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.CollectionFactory.getInstance({
+    datastore
+});
+const config = {
+    userId: 12345,
+    name: 'Screwdriver',
+    description: 'Collection of screwdriver pipelines'
+};
+
+factory.create(config)
+    .then(model => {
+        // do something with model
+    });
+```
+
+#### Update
+Update a specific collection
+```js
+model.update()
+```
+
+#### Remove
+Remove a specific collection
+```js
+model.remove()
+```
+
 ## Testing
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -1,21 +1,23 @@
 'use strict';
 
 const BuildFactory = require('./lib/buildFactory');
+const CollectionFactory = require('./lib/collectionFactory');
 const EventFactory = require('./lib/eventFactory');
 const JobFactory = require('./lib/jobFactory');
 const PipelineFactory = require('./lib/pipelineFactory');
 const SecretFactory = require('./lib/secretFactory');
-const UserFactory = require('./lib/userFactory');
 const TemplateFactory = require('./lib/templateFactory');
 const TokenFactory = require('./lib/tokenFactory');
+const UserFactory = require('./lib/userFactory');
 
 module.exports = {
     BuildFactory,
+    CollectionFactory,
     EventFactory,
     JobFactory,
     PipelineFactory,
     SecretFactory,
-    UserFactory,
     TemplateFactory,
-    TokenFactory
+    TokenFactory,
+    UserFactory
 };

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BaseModel = require('./base');
+
+class CollectionModel extends BaseModel {
+    /**
+     * Construct a CollectionModel object
+     * @method constructor
+     * @param {Object} config
+     * @param {Object} config.datastore       Object that will perform operations on the datastore
+     * @param {Number} config.userId          The ID of the associated user
+     * @param {String} config.name            The collection name
+     * @param {String} [config.description]   The collection description (Optional)
+     * @param {Array}  config.pipelineIds     The ids of the pipelines associated with this collection
+     */
+    constructor(config) {
+        super('collection', config);
+    }
+}
+
+module.exports = CollectionModel;

--- a/lib/collectionFactory.js
+++ b/lib/collectionFactory.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const Collection = require('./collection');
+
+let instance;
+
+class CollectionFactory extends BaseFactory {
+    /**
+     * Construct a CollectionFactory object
+     * @method constructor
+     * @param {Object} config
+     * @param {Object} config.datastore     Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('collection', config);
+    }
+
+    /**
+     * Instantiate a Collection class
+     * @method createClass
+     * @param {Object} config
+     * @return {Collection}
+     */
+    createClass(config) {
+        return new Collection(config);
+    }
+
+    /**
+     * Create a Collection model
+     * @param {Object} config
+     * @param {Number} config.userId         The ID of the associated user
+     * @param {String} config.name           The collection name
+     * @param {String} [config.description]  The collection description (Optional)
+     * @param {Array}  [config.pipelineIds]  The ids of the pipelines associated with this collection
+     * @memberof CollectionFactory
+     */
+    create(config) {
+        if (!config.pipelineIds) {
+            config.pipelineIds = [];
+        }
+
+        return super.create(config);
+    }
+
+    /**
+     * Get an instance of CollectionFactory
+     * @method getInstance
+     * @param {Object} config
+     * @param {DataStore} config.datastore    A datastore instance
+     * @return {CollectionFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(CollectionFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = CollectionFactory;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.6.0",
-    "screwdriver-data-schema": "^16.10.1"
+    "screwdriver-data-schema": "^16.12.1"
   }
 }

--- a/test/lib/collection.test.js
+++ b/test/lib/collection.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const mockery = require('mockery');
+const schema = require('screwdriver-data-schema');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Collection Model', () => {
+    let datastore;
+    let BaseModel;
+    let CollectionModel;
+    let createConfig;
+    let collection;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+        datastore = {
+            update: sinon.stub(),
+            remove: sinon.stub().resolves(null)
+        };
+
+        /* eslint-disable global-require */
+        BaseModel = require('../../lib/base');
+        CollectionModel = require('../../lib/collection');
+        /* eslint-enable global-require */
+    });
+
+    beforeEach(() => {
+        datastore.update.resolves({});
+
+        createConfig = {
+            datastore,
+            userId: 12345,
+            id: 654,
+            name: 'Screwdriver',
+            description: 'Pipelines for screwdriver',
+            pipelineIds: [12, 34, 56]
+        };
+        collection = new CollectionModel(createConfig);
+    });
+
+    after(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
+        assert.instanceOf(collection, CollectionModel);
+        assert.instanceOf(collection, BaseModel);
+        schema.models.collection.allKeys.forEach((key) => {
+            assert.strictEqual(collection[key], createConfig[key]);
+        });
+    });
+
+    describe('update', () => {
+        it('promises to update a collection', () => {
+            const newPipelineIds = [12, 34, 56, 78];
+
+            collection.pipelineIds = newPipelineIds;
+
+            return collection.update()
+                .then(() => {
+                    assert.calledWith(datastore.update, {
+                        table: 'collections',
+                        params: {
+                            id: 654,
+                            pipelineIds: [12, 34, 56, 78]
+                        }
+                    });
+                });
+        });
+    });
+
+    describe('remove', () => {
+        it('removes a collection', () =>
+            collection.remove()
+                .then(() => {
+                    assert.calledWith(datastore.remove, {
+                        table: 'collections',
+                        params: {
+                            id: 654
+                        }
+                    });
+                }));
+    });
+});

--- a/test/lib/collectionFactory.test.js
+++ b/test/lib/collectionFactory.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Collection Factory', () => {
+    const name = 'Favorites';
+    const description = 'Collection of favorite pipelines';
+    const userId = 1;
+    const collectionId = 123;
+    const pipelineIds = [12, 34, 56];
+    const collectionData = {
+        id: collectionId,
+        userId,
+        name,
+        description,
+        pipelineIds
+    };
+    const expected = {
+        userId,
+        name,
+        description,
+        pipelineIds
+    };
+
+    let CollectionFactory;
+    let datastore;
+    let factory;
+    let Collection;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            get: sinon.stub()
+        };
+
+        /* eslint-disable global-require */
+        Collection = require('../../lib/collection');
+        CollectionFactory = require('../../lib/collectionFactory');
+        /* eslint-disable global-require */
+
+        factory = new CollectionFactory({ datastore });
+    });
+
+    afterEach(() => {
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a Collection', () => {
+            const model = factory.createClass(collectionData);
+
+            assert.instanceOf(model, Collection);
+        });
+    });
+
+    describe('create', () => {
+        it('should create a Collection', () => {
+            datastore.save.resolves(collectionData);
+
+            return factory.create({
+                userId,
+                name,
+                description,
+                pipelineIds
+            }).then((model) => {
+                assert.isTrue(datastore.save.calledOnce);
+                assert.calledWith(datastore.save, {
+                    params: expected,
+                    table: 'collections'
+                });
+                assert.instanceOf(model, Collection);
+                Object.keys(collectionData).forEach((key) => {
+                    assert.strictEqual(model[key], collectionData[key]);
+                });
+            });
+        });
+    });
+
+    describe('get', () => {
+        it('should get a collection by ID', () => {
+            datastore.get.resolves(collectionData);
+
+            Promise.all([factory.get(collectionId), factory.get({ id: collectionId })])
+                .then(([collection1, collection2]) => {
+                    Object.keys(collection1).forEach((key) => {
+                        assert.strictEqual(collection1[key], collectionData[key]);
+                        assert.strictEqual(collection2[key], collectionData[key]);
+                    });
+                });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+
+            /* eslint-disable global-require */
+            CollectionFactory = require('../../lib/collectionFactory');
+            /* eslint-enable global-require */
+        });
+
+        it('should get an instance', () => {
+            const f1 = CollectionFactory.getInstance(config);
+            const f2 = CollectionFactory.getInstance(config);
+
+            assert.instanceOf(f1, CollectionFactory);
+            assert.instanceOf(f2, CollectionFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw an error when config not supplied', () => {
+            assert.throw(CollectionFactory.getInstance,
+                Error, 'No datastore provided to CollectionFactory');
+        });
+    });
+});


### PR DESCRIPTION
# Context

To be able to perform CRUD operations for collections, we need a CollectionModel and CollectionFactory to interface with the datastore.

# Objective

This PR adds a CollectionModel and CollectionFactory along with some tests

# References

issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)

This is the first pass for the CollectionModel and CollectionFactory so it will change when I start working on adding / updating / removing pipelines from Collections.