### PR TITLE
feat(616): Add template tag model

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,60 @@ factory.get(config).then(model => {
 | config.version | String | Yes | Version of the template |
 | config.label | String | No | Label of the template |
 
+### Template Tag Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.TemplateTagFactory.getInstance({
+    datastore
+});
+const config = {
+    name: 'testTemplate',
+    tag: 'stable',
+    version: '1.3'
+}
+
+factory.create(config)
+    .then(model => {    // do something
+    });
+```
+
+#### Update
+Update a specific template tag
+```js
+// update template version value
+model.version = '2.4';
+
+model.update()
+```
+
+### Template Tag Factory
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with template tag model
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.name | String | Yes | The template name |
+| config.tag | String | Yes | The template tag (e.g. stable, latest, etc) |
+| config.version | String | Yes | Version of the template |
+
+#### Get
+Get a template tag based on id.
+```js
+factory.get(id).then(model => {
+    // do stuff with template model
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | String | The unique ID for the Template Tag |
+
 ### Token Factory
 #### Search
 ```js

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const JobFactory = require('./lib/jobFactory');
 const PipelineFactory = require('./lib/pipelineFactory');
 const SecretFactory = require('./lib/secretFactory');
 const TemplateFactory = require('./lib/templateFactory');
+const TemplateTagFactory = require('./lib/templateTagFactory');
 const TokenFactory = require('./lib/tokenFactory');
 const UserFactory = require('./lib/userFactory');
 
@@ -18,6 +19,7 @@ module.exports = {
     PipelineFactory,
     SecretFactory,
     TemplateFactory,
+    TemplateTagFactory,
     TokenFactory,
     UserFactory
 };

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -13,10 +13,10 @@ const PATCH_MATCH = 3;
 
 class TemplateFactory extends BaseFactory {
     /**
-     * Construct a JobFactory object
+     * Construct a TemplateFactory object
      * @method constructor
-     * @param  {Object}    config
-     * @param  {Datastore}    config.datastore         Object that will perform operations on the datastore
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore         Object that will perform operations on the datastore
      */
     constructor(config) {
         super('template', config);
@@ -34,7 +34,7 @@ class TemplateFactory extends BaseFactory {
      * @param  {Object}     config.config        Config of the screwdriver-template.yaml
      * @param  {String}     config.pipelineId    pipelineId of the template
      * @param  {Array}      [config.labels]      Labels attached to the template
-     * @return {Job}
+     * @return {Template}
      */
     createClass(config) {
         return new Template(config);

--- a/lib/templateTag.js
+++ b/lib/templateTag.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BaseModel = require('./base');
+
+class TemplateTagModel extends BaseModel {
+    /**
+     * Construct a TemplateTagModel object
+     * @method constructor
+     * @param  {Object}    config
+     * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {String}    config.name          The template name
+     * @param  {String}    config.tag           The template tag (e.g.: 'stable' or 'latest')
+     * @param  {String}    config.version       Version of the template
+     */
+    constructor(config) {
+        super('templateTag', config);
+    }
+
+}
+
+module.exports = TemplateTagModel;

--- a/lib/templateTagFactory.js
+++ b/lib/templateTagFactory.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const TemplateTag = require('./templateTag');
+let instance;
+
+class TemplateTagFactory extends BaseFactory {
+    /**
+     * Construct a TemplateTagFactory object
+     * @method constructor
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('templateTag', config);
+    }
+
+    /**
+     * Instantiate a TemplateTag class
+     * @method createClass
+     * @param  {Object}     config               Template tag data
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     * @param  {String}     config.name          The template name
+     * @param  {String}     config.tag           The template tag (e.g.: 'stable' or 'latest')
+     * @param  {String}     config.version       Version of the template
+     * @return {TemplateTag}
+     */
+    createClass(config) {
+        return new TemplateTag(config);
+    }
+
+    /**
+     * Get an instance of the TemplateTagFactory
+     * @method getInstance
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore
+     * @return {TemplateTagFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(TemplateTagFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = TemplateTagFactory;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.6.0",
-    "screwdriver-data-schema": "^16.12.1"
+    "screwdriver-data-schema": "^16.13.0"
   }
 }

--- a/test/lib/templateTag.test.js
+++ b/test/lib/templateTag.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const mockery = require('mockery');
+const schema = require('screwdriver-data-schema');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('TemplateTag Model', () => {
+    let BaseModel;
+    let TemplateTagModel;
+    let datastore;
+    let createConfig;
+    let templateTag;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            update: sinon.stub()
+        };
+
+        // eslint-disable-next-line global-require
+        BaseModel = require('../../lib/base');
+
+        // eslint-disable-next-line global-require
+        TemplateTagModel = require('../../lib/templateTag');
+
+        createConfig = {
+            datastore,
+            id: 12345,
+            name: 'testTemplateTag',
+            tag: 'latest',
+            version: '1.3'
+        };
+        templateTag = new TemplateTagModel(createConfig);
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
+        assert.instanceOf(templateTag, TemplateTagModel);
+        assert.instanceOf(templateTag, BaseModel);
+        schema.models.secret.allKeys.forEach((key) => {
+            assert.strictEqual(templateTag[key], createConfig[key]);
+        });
+    });
+});

--- a/test/lib/templateTagFactory.test.js
+++ b/test/lib/templateTagFactory.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('TemplateTag Factory', () => {
+    const name = 'testTemplateTag';
+    const version = '1.3';
+    const tag = 'latest';
+    const metaData = {
+        name,
+        tag,
+        version
+    };
+    let TemplateTagFactory;
+    let datastore;
+    let factory;
+    let TemplateTag;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            get: sinon.stub(),
+            scan: sinon.stub()
+        };
+
+        // eslint-disable-next-line global-require
+        TemplateTag = require('../../lib/templateTag');
+        // eslint-disable-next-line global-require
+        TemplateTagFactory = require('../../lib/templateTagFactory');
+
+        factory = new TemplateTagFactory({ datastore });
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a TemplateTag model', () => {
+            const model = factory.createClass(metaData);
+
+            assert.instanceOf(model, TemplateTag);
+        });
+    });
+
+    describe('create', () => {
+        const generatedId = 1234135;
+        let expected;
+
+        beforeEach(() => {
+            expected = {
+                id: generatedId,
+                name,
+                tag,
+                version
+            };
+        });
+
+        it('creates a TemplateTag given name, tag, and version', () => {
+            datastore.save.resolves(expected);
+
+            return factory.create({
+                name,
+                tag,
+                version
+            }).then((model) => {
+                assert.instanceOf(model, TemplateTag);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+        });
+
+        it('should get an instance', () => {
+            const f1 = TemplateTagFactory.getInstance(config);
+            const f2 = TemplateTagFactory.getInstance(config);
+
+            assert.instanceOf(f1, TemplateTagFactory);
+            assert.instanceOf(f2, TemplateTagFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(TemplateTagFactory.getInstance,
+                Error, 'No datastore provided to TemplateTagFactory');
+        });
+    });
+});


### PR DESCRIPTION
## Context

Users would like to tag their template versions with words such as "latest" or "stable" (much like Docker tags work).

## Objective

This PR adds a TemplateTag and TemplateTagFactory model.

## Related Links
Blocked by: https://github.com/screwdriver-cd/data-schema/pull/157
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/616
Relevant API PRs: https://github.com/screwdriver-cd/screwdriver/pull/647, https://github.com/screwdriver-cd/screwdriver/pull/646