### PR TITLE
fix(tokens): Convert buffer directly to base64url

### DIFF
--- a/lib/generateToken.js
+++ b/lib/generateToken.js
@@ -13,7 +13,7 @@ const TOKEN_LENGTH = 256; // Measured in bits
  */
 function generateValue() {
     return nodeify.withContext(crypto, 'randomBytes', [TOKEN_LENGTH / 8])
-        .then(buffer => base64url(buffer.toString()));
+        .then(base64url);
 }
 
 /**

--- a/test/lib/generateToken.test.js
+++ b/test/lib/generateToken.test.js
@@ -17,7 +17,7 @@ describe('generateToken', () => {
             .then((value) => {
                 firstValue = value;
                 // Check that it's a base64 value of the right length
-                assert.match(value, /[a-zA-Z0-9_-]{43}/);
+                assert.match(value, /^[a-zA-Z0-9_-]{43}$/);
             }));
 
     it('generates a different value on a second call', () => {


### PR DESCRIPTION
## Context
I realized in my testing that I was getting wildly different lengths of strings as tokens. It turns out that calling `toString` on the buffer of random bytes was sometimes giving me strings of length between 29 and 32. Fortunately, `base64url` can be called directly from buffers (which I missed on the first pass), and it does not seem to have this problem.

## Objective
Have all tokens (and token hashes) be the same length so they can be reliably filtered from logs

## References
Related to https://github.com/screwdriver-cd/screwdriver/pull/642