### PR TITLE
feat(616): Configure getTemplate to take in a full template name with version or tag [1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,19 +775,16 @@ factory.get(id).then(model => {
 | id | String | The unique ID for the Template |
 
 #### Get Template
-Get the latest template by name, version with/without label. The version can be in any valid version format. It can can be only major, or major.minor, or major.minor.patch. If label is specified, then the latest version with that label will be resolved. If no match found, the function will resolve undefined.
+Get the latest template by name or get a specific template using name and version or name and tag. The version can be in any valid version format: either major, major.minor, or major.minor.patch. If no version is specified, the function will resolve with the latest version published. If no match is found, the function will resolve null.
 ```js
-factory.get(config).then(model => {
+factory.getTemplate(fullTemplateName).then(model => {
     // do stuff with template model
 });
 ```
 
-| Parameter        | Type  |  Required | Description |
-| :-------------   | :---- | :-------------|  :-------------|
-| config        | Object | Yes | Configuration Object |
-| config.name | String | Yes | The template name |
-| config.version | String | Yes | Version of the template |
-| config.label | String | No | Label of the template |
+| Parameter        | Type   |  Required | Description |
+| :-------------   | :----- | :-------------|  :-------------|
+| fullTemplateName | String | Yes | Name of the template and the version or tag (e.g. chef/publish@1.2.3 or chef/publish@latest). Can also be just name of the template (e.g. chef/publish) |
 
 ### Template Tag Model
 ```js

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -6,10 +6,9 @@ const compareVersions = require('compare-versions');
 const schema = require('screwdriver-data-schema');
 let instance;
 
+const TEMPLATE_NAME_REGEX = schema.config.regex.FULL_TEMPLATE_NAME;
+const EXACT_VERSION_REGEX = schema.config.regex.EXACT_VERSION;
 const VERSION_REGEX = schema.config.regex.VERSION;
-const MAJOR_MATCH = 1;
-const MINOR_MATCH = 2;
-const PATCH_MATCH = 3;
 
 class TemplateFactory extends BaseFactory {
     /**
@@ -55,22 +54,17 @@ class TemplateFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        const match = VERSION_REGEX.exec(config.version);
-        const major = match[MAJOR_MATCH];
-        const minor = match[MINOR_MATCH];
+        const [, major, minor] = VERSION_REGEX.exec(config.version);
         const searchVersion = minor ? `${major}${minor}` : major;
 
-        return this.getTemplate({
-            name: config.name,
-            version: searchVersion
-        }).then((latest) => {
+        return this.getTemplate(`${config.name}@${searchVersion}`)
+        .then((latest) => {
             if (!latest) {
                 config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
             } else {
-                const latestMatch = VERSION_REGEX.exec(latest.version);
-                const latestMajor = latestMatch[MAJOR_MATCH];
-                const latestMinor = latestMatch[MINOR_MATCH];
-                const patch = parseInt(latestMatch[PATCH_MATCH].slice(1), 10) + 1;
+                // eslint-disable-next-line max-len
+                const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latest.version);
+                const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
                 config.version = `${latestMajor}${latestMinor}.${patch}`;
             }
@@ -80,32 +74,67 @@ class TemplateFactory extends BaseFactory {
     }
 
     /**
-     * Get a the latest template by config
+     * Get a the latest template by config using the full template name
      * @method getTemplate
-     * @param  {Object}     config               Config object
-     * @param  {String}     config.name          The template name
-     * @param  {String}     config.version       Version of the template
-     * @param  {String}     [config.label]       Label of template
-     * @return {Promise}                         Resolves template model or undefined if not found
+     * @param  {String}     fullTemplateName    Name of the template and the version or tag (e.g. chef/publish@1.2.3)
+     * @return {Promise}                        Resolves template model or null if not found
      */
-    getTemplate(config) {
-        // get all templates with the same name
-        return super.list({ params: { name: config.name } })
+    getTemplate(fullTemplateName) {
+        const [, templateName, versionOrTag] = TEMPLATE_NAME_REGEX.exec(fullTemplateName);
+        const isExactVersion = EXACT_VERSION_REGEX.exec(versionOrTag);
+        const isVersion = VERSION_REGEX.exec(versionOrTag);
+
+        if (isExactVersion) {
+            // Get a template using the exact template version
+            return super.get({
+                name: templateName,
+                version: versionOrTag
+            });
+        }
+
+        // If tag is passed in, get the version from the tag
+        if (versionOrTag && !isVersion) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // eslint-disable-next-line global-require
+            const TemplateTagFactory = require('./templateTagFactory');
+            const templateTagFactory = TemplateTagFactory.getInstance();
+
+            // Get a template tag
+            return templateTagFactory.get({
+                name: templateName,
+                tag: versionOrTag
+            })
+            .then((templateTag) => {
+                // Return null if no template tag exists
+                if (!templateTag) {
+                    return null;
+                }
+
+                // Get a template using the exact template version
+                return super.get({
+                    name: templateName,
+                    version: templateTag.version
+                });
+            });
+        }
+
+        // Get all templates with the same name
+        return super.list({ params: { name: templateName } })
             .then((templates) => {
-                // get templates that have version prefix as config.version
+                // If no version provided, return the most recently published template
+                if (!versionOrTag) {
+                    return templates[0];
+                }
+
+                // Get templates that have versions beginning with the version given
                 const filtered = templates.filter(template =>
-                    template.version.startsWith(config.version));
+                    template.version.startsWith(versionOrTag));
 
                 // Sort templates by descending order
                 filtered.sort((a, b) => compareVersions(b.version, a.version));
 
-                // If no config.label, return latest one
-                if (filtered.length > 0 && !config.label) {
-                    return filtered[0];
-                }
-
-                // Loop through filtered to find the first match for config.label
-                return filtered.find(template => template.labels.includes(config.label));
+                // Return first filtered template or null if none
+                return filtered[0] || null;
             });
     }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.6.0",
-    "screwdriver-data-schema": "^16.13.0"
+    "screwdriver-data-schema": "^16.14.7"
   }
 }


### PR DESCRIPTION
## Context
Moving logic to `models`. Since the same logic needs to be used by `config-parser`. (https://github.com/screwdriver-cd/config-parser/pull/41)

## Objective
This PR determines if a full template name contains a version or tag. If there's a tag, it'll get the version by getting a template tag. The `getTemplate` will return a template with the corresponding version or the latest published template if no version is provided. If no template tag is found, the method will return undefined.

Also refactored version regex matching in the same file.

## Related Links
Issue: https://github.com/screwdriver-cd/screwdriver/issues/616#issuecomment-314568245
Related PRs: https://github.com/screwdriver-cd/data-schema/pull/166, https://github.com/screwdriver-cd/screwdriver/pull/657, https://github.com/screwdriver-cd/config-parser/pull/41