### PR TITLE
fix(616): Pull in new version of config parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "docker-parse-image": "^3.0.1",
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
-    "screwdriver-config-parser": "^3.6.0",
+    "screwdriver-config-parser": "^3.10.0",
     "screwdriver-data-schema": "^16.14.7"
   }
 }


### PR DESCRIPTION
Need to pull in the new version of config-parser for template tag changes

Related to: https://github.com/screwdriver-cd/config-parser/pull/41
Issue: https://github.com/screwdriver-cd/screwdriver/issues/616#issuecomment-314568245