### PR TITLE
test(collections): Improve code coverage of collectionFactory

### DIFF
--- a/test/lib/collectionFactory.test.js
+++ b/test/lib/collectionFactory.test.js
@@ -90,6 +90,32 @@ describe('Collection Factory', () => {
                 });
             });
         });
+
+        it('should create a Collection without pipelineIds', () => {
+            const dataWithoutPipelineIds = Object.assign({}, collectionData);
+
+            dataWithoutPipelineIds.pipelineIds = [];
+            datastore.save.resolves(dataWithoutPipelineIds);
+
+            return factory.create({
+                userId,
+                name,
+                description
+            }).then((model) => {
+                assert.isTrue(datastore.save.calledOnce);
+                assert.calledWith(datastore.save, {
+                    params: {
+                        userId,
+                        name,
+                        description,
+                        pipelineIds: [] // The collectionFactory should add this field
+                    },
+                    table: 'collections'
+                });
+                assert.instanceOf(model, Collection);
+                assert.deepEqual(model, dataWithoutPipelineIds);
+            });
+        });
     });
 
     describe('get', () => {


### PR DESCRIPTION
## Context

Currently a branch is not being tested (when a user does not specify pipelineIds in their request).

## Objective

This PR adds a test for that branch and makes sure that the collectionFactory adds in the pipelineIds field with a value of empty array.

## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)