### PR TITLE
fix(tokens): token objects need password for hashing

### DIFF
--- a/lib/tokenFactory.js
+++ b/lib/tokenFactory.js
@@ -28,7 +28,11 @@ class TokenFactory extends BaseFactory {
      * @return {Token}
      */
     createClass(config) {
-        return new Token(config);
+        const c = config;
+
+        c.password = this[password];
+
+        return new Token(c);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.10.0",
-    "screwdriver-data-schema": "^17.0.0"
+    "screwdriver-data-schema": "^17.0.3"
   }
 }

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -76,7 +76,7 @@ describe('Token Factory', () => {
 
     describe('createClass', () => {
         it('should return a Token', () => {
-            const model = factory.createClass(tokenData);
+            const model = factory.createClass(Object.assign({}, tokenData));
 
             assert.instanceOf(model, Token);
         });


### PR DESCRIPTION
Forgot to give tokens the password for hashing, without which they cannot be refreshed.

Also pulls in the change from https://github.com/screwdriver-cd/data-schema/pull/171 to increase the length of hash we store in the database.