### PR TITLE
feat(collections): Add lastEventId to pipeline model

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -83,6 +83,12 @@ class EventFactory extends BaseFactory {
                     modelConfig.createTime = (new Date()).toISOString();
 
                     return super.create(modelConfig);
+                })
+                .then((event) => {
+                    pipeline.lastEventId = event.id;
+
+                    return pipeline.update()
+                        .then(() => event);
                 });
         });
     }

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -13,6 +13,7 @@ describe('Event Factory', () => {
     let datastore;
     let factory;
     let pipelineFactoryMock;
+    let pipelineMock;
     let scm;
     let Event;
 
@@ -125,12 +126,16 @@ describe('Event Factory', () => {
                 commit
             };
 
-            pipelineFactoryMock.get.withArgs(pipelineId).resolves({
+            pipelineMock = {
                 pipelineId,
                 scmUri: 'github.com:1234:branch',
                 scmContext,
-                token: Promise.resolve('foo')
-            });
+                token: Promise.resolve('foo'),
+                lastEventId: null,
+                update: sinon.stub().resolves(null)
+            };
+
+            pipelineFactoryMock.get.withArgs(pipelineId).resolves(pipelineMock);
             scm.decorateAuthor.resolves(creator);
             scm.decorateCommit.resolves(commit);
             scm.getDisplayName.returns(displayName);
@@ -151,6 +156,7 @@ describe('Event Factory', () => {
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
                     token: 'foo'
                 });
+                assert.strictEqual(pipelineMock.lastEventId, model.id);
                 Object.keys(expected).forEach((key) => {
                     if (key === 'workflow') {
                         assert.deepEqual(model[key], expected[key]);


### PR DESCRIPTION
## Context

For the dashboards, we would like to have the last builds' health for each pipeline. Rather than making a call to get all the events for a pipeline to figure out which was the last event, it would be better to save the id of the last event for a pipeline during creation of the event itself.

## Objective

This PR will add modify the lastEventId field each time a new event is created for a pipeline

## References

Related PRs: [screwdriver-cd/data-schema#174](https://github.com/screwdriver-cd/data-schema/pull/174), [screwdriver-cd/screwdriver#714](https://github.com/screwdriver-cd/screwdriver/pull/714)

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)