### PR TITLE
Secure tokens

### DIFF
--- a/lib/generateToken.js
+++ b/lib/generateToken.js
@@ -1,10 +1,18 @@
 'use strict';
 
-const nodeify = require('./nodeify');
-const crypto = require('crypto');
 const base64url = require('base64url');
+const crypto = require('crypto');
+const nodeify = require('./nodeify');
+
+// Config for pbkdf2
+// 100,000 iterations is still fast enough to be performant (84ms to run the unit test) while also
+// creating enough of a delay to stop brute force attacks
+// For more info, see https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet
 const ALGORITHM = 'sha256';
-const TOKEN_LENGTH = 256; // Measured in bits
+const ITERATIONS = 100000;
+
+// Token length, measured in bytes
+const TOKEN_LENGTH = 32;
 
 /**
  * Create a token value with crypto
@@ -12,17 +20,19 @@ const TOKEN_LENGTH = 256; // Measured in bits
  * @return {Promise}
  */
 function generateValue() {
-    return nodeify.withContext(crypto, 'randomBytes', [TOKEN_LENGTH / 8])
+    return nodeify.withContext(crypto, 'randomBytes', [TOKEN_LENGTH])
         .then(base64url);
 }
 
 /**
  * Use crypto to hash a token value
  * @param  {String} value   Token to hash
- * @return {String}         Hashed value
+ * @param  {String} salt    Salt value for PBKDF2
+ * @return {Promise}
  */
-function hashValue(value) {
-    return base64url(crypto.createHash(ALGORITHM).update(value).digest());
+function hashValue(value, salt) {
+    return nodeify.withContext(crypto, 'pbkdf2', [value, salt, ITERATIONS, TOKEN_LENGTH, ALGORITHM])
+        .then(base64url);
 }
 
 module.exports = {

--- a/lib/token.js
+++ b/lib/token.js
@@ -3,6 +3,8 @@
 const BaseModel = require('./base');
 const generateToken = require('./generateToken');
 
+const password = Symbol('password');
+
 class TokenModel extends BaseModel {
     /**
      * Construct a TokenModel object
@@ -14,9 +16,11 @@ class TokenModel extends BaseModel {
      * @param  {String}    config.name              The token name
      * @param  {String}    config.description       The token description
      * @param  {String}    config.lastUsed          The last time the token was used (ISO String)
+     * @param  {String}    config.password          Password used as a salt by PBKDF2
      */
     constructor(config) {
         super('token', config);
+        this[password] = config.password;
     }
 
     /**
@@ -30,9 +34,13 @@ class TokenModel extends BaseModel {
         return generateToken.generateValue()
             .then((bytes) => {
                 value = bytes;
-                this.hash = generateToken.hashValue(bytes);
 
-                return this.update();
+                return generateToken.hashValue(bytes, this[password])
+                    .then((hash) => {
+                        this.hash = hash;
+
+                        return this.update();
+                    });
             }).then((model) => {
                 model.value = value;
 

--- a/lib/tokenFactory.js
+++ b/lib/tokenFactory.js
@@ -4,6 +4,8 @@ const BaseFactory = require('./baseFactory');
 const Token = require('./token');
 const generateToken = require('./generateToken');
 
+const password = Symbol('password');
+
 let instance;
 
 class TokenFactory extends BaseFactory {
@@ -12,9 +14,11 @@ class TokenFactory extends BaseFactory {
      * @method constructor
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {String}    config.password      Password used as a salt by PBKDF2
      */
     constructor(config) {
         super('token', config);
+        this[password] = config.password;
     }
 
     /**
@@ -24,7 +28,11 @@ class TokenFactory extends BaseFactory {
      * @return {Token}
      */
     createClass(config) {
-        return new Token(config);
+        const c = config;
+
+        c.password = this[password];
+
+        return new Token(c);
     }
 
     /**
@@ -42,10 +50,14 @@ class TokenFactory extends BaseFactory {
         return generateToken.generateValue()
             .then((bytes) => {
                 value = bytes;
-                config.hash = generateToken.hashValue(bytes);
-                config.lastUsed = '';
 
-                return super.create(config);
+                return generateToken.hashValue(bytes, this[password])
+                    .then((hash) => {
+                        config.hash = hash;
+                        config.lastUsed = '';
+
+                        return super.create(config);
+                    });
             }).then((model) => {
                 model.value = value;
 
@@ -62,8 +74,13 @@ class TokenFactory extends BaseFactory {
      */
     get(config) {
         if (config.value) {
-            config.hash = generateToken.hashValue(config.value);
-            delete config.value;
+            return generateToken.hashValue(config.value, this[password])
+                .then((hash) => {
+                    config.hash = hash;
+                    delete config.value;
+
+                    return super.get(config);
+                });
         }
 
         return super.get(config);
@@ -74,6 +91,7 @@ class TokenFactory extends BaseFactory {
      * @method getInstance
      * @param  {Object}     config
      * @param  {Datastore}  config.datastore    A datastore instance
+     * @param  {String}     config.password     Password for encryption operations
      * @return {TokenFactory}
      */
     static getInstance(config) {

--- a/test/lib/generateToken.test.js
+++ b/test/lib/generateToken.test.js
@@ -9,7 +9,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('generateToken', () => {
     const RANDOM_BYTES = 'some random bytes';
     // Result of passing 'some random bytes' through a sha256 hash, in base64
-    const HASH = 'mF0EvjvxWMrVz5ZGJcnbe0ZPooUlv_DAB9VrV6bmZmg';
+    const expectedHash = 'qGFuuDVptDRID0ZAOjv8ZVXfT4QfXQzVKc_wyCZKEVg';
     let firstValue;
 
     it('generates a value', () =>
@@ -27,11 +27,12 @@ describe('generateToken', () => {
             });
     });
 
-    it('hashes a value', () => {
-        assert.strictEqual(generateToken.hashValue(RANDOM_BYTES), HASH);
-    });
+    it('hashes a value', () => generateToken.hashValue(RANDOM_BYTES, '')
+        .then((hash) => {
+            assert.strictEqual(hash, expectedHash);
+        }));
 
     it('hashes a different value to a different hash', () => {
-        assert.notEqual(generateToken.hashValue('some different bytes'), HASH);
+        assert.notEqual(generateToken.hashValue('some different bytes', ''), expectedHash);
     });
 });

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -8,6 +8,7 @@ const schema = require('screwdriver-data-schema');
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('Token Model', () => {
+    const password = 'totallySecurePassword';
     let datastore;
     let generateTokenMock;
     let BaseModel;
@@ -46,7 +47,8 @@ describe('Token Model', () => {
             id: 6789,
             name: 'Mobile client auth token',
             description: 'For the mobile app',
-            lastUsed: '2017-05-10T01:49:59.327Z'
+            lastUsed: '2017-05-10T01:49:59.327Z',
+            password
         };
         token = new TokenModel(createConfig);
     });
@@ -89,12 +91,12 @@ describe('Token Model', () => {
             const newHash = 'a new hash';
 
             generateTokenMock.generateValue.resolves(newValue);
-            generateTokenMock.hashValue.returns(newHash);
+            generateTokenMock.hashValue.resolves(newHash);
 
             return token.refresh()
                 .then((model) => {
                     assert.calledOnce(generateTokenMock.generateValue);
-                    assert.calledWith(generateTokenMock.hashValue, newValue);
+                    assert.calledWith(generateTokenMock.hashValue, newValue, password);
                     assert.strictEqual(model.value, newValue);
                     assert.strictEqual(model.hash, newHash);
                 });

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('Token Factory', () => {
+    const password = 'totallySecurePassword';
     const name = 'mobile_token';
     const description = 'a token for a mobile app';
     const userId = 6789;
@@ -45,7 +46,7 @@ describe('Token Factory', () => {
         };
 
         generateTokenMock.generateValue.resolves(randomBytes);
-        generateTokenMock.hashValue.returns(hash);
+        generateTokenMock.hashValue.resolves(hash);
 
         mockery.registerMock('./generateToken', generateTokenMock);
     });
@@ -61,7 +62,7 @@ describe('Token Factory', () => {
         TokenFactory = require('../../lib/tokenFactory');
         /* eslint-enable global-require */
 
-        factory = new TokenFactory({ datastore });
+        factory = new TokenFactory({ datastore, password });
     });
 
     afterEach(() => {
@@ -75,7 +76,7 @@ describe('Token Factory', () => {
 
     describe('createClass', () => {
         it('should return a Token', () => {
-            const model = factory.createClass(tokenData);
+            const model = factory.createClass(Object.assign({}, tokenData));
 
             assert.instanceOf(model, Token);
         });
@@ -93,7 +94,7 @@ describe('Token Factory', () => {
             }).then((model) => {
                 assert.isTrue(datastore.save.calledOnce);
                 assert.calledOnce(generateTokenMock.generateValue);
-                assert.calledWith(generateTokenMock.hashValue, randomBytes);
+                assert.calledWith(generateTokenMock.hashValue, randomBytes, password);
                 assert.calledWith(datastore.save, {
                     params: expected,
                     table: 'tokens'


### PR DESCRIPTION
* undoes https://github.com/screwdriver-cd/models/pull/189, adding the token changes back to models
* fix all uses of `generateToken.hashValue` to be async