### PR TITLE
fix(tokens): token hashes are 512 bits

### DIFF
--- a/lib/generateToken.js
+++ b/lib/generateToken.js
@@ -8,11 +8,12 @@ const nodeify = require('./nodeify');
 // 100,000 iterations is still fast enough to be performant (84ms to run the unit test) while also
 // creating enough of a delay to stop brute force attacks
 // For more info, see https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet
-const ALGORITHM = 'sha256';
+const ALGORITHM = 'sha512';
 const ITERATIONS = 100000;
 
-// Token length, measured in bytes
+// Token length and hash length, measured in bytes
 const TOKEN_LENGTH = 32;
+const HASH_LENGTH = 64;
 
 /**
  * Create a token value with crypto
@@ -31,7 +32,7 @@ function generateValue() {
  * @return {Promise}
  */
 function hashValue(value, salt) {
-    return nodeify.withContext(crypto, 'pbkdf2', [value, salt, ITERATIONS, TOKEN_LENGTH, ALGORITHM])
+    return nodeify.withContext(crypto, 'pbkdf2', [value, salt, ITERATIONS, HASH_LENGTH, ALGORITHM])
         .then(base64url);
 }
 

--- a/test/lib/generateToken.test.js
+++ b/test/lib/generateToken.test.js
@@ -8,8 +8,9 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('generateToken', () => {
     const RANDOM_BYTES = 'some random bytes';
-    // Result of passing 'some random bytes' through a sha256 hash, in base64
-    const expectedHash = 'qGFuuDVptDRID0ZAOjv8ZVXfT4QfXQzVKc_wyCZKEVg';
+    // Result of passing 'some random bytes' through PBKDF2 with our params
+    // eslint-disable-next-line max-len
+    const expectedHash = 'ZrUMoCeSsG10oaOVCgt_MS2YDu2AUo2xElZq3abIy0dxikNQIAVeUncAzp84zxU1ogl_jmUhH8MsfHIMZRz-Ig';
     let firstValue;
 
     it('generates a value', () =>


### PR DESCRIPTION
It was recommended to me that token hashes should be 512 bits.