### PR TITLE
fix(collections): Don't update lastEventId for PRs

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -85,7 +85,9 @@ class EventFactory extends BaseFactory {
                     return super.create(modelConfig);
                 })
                 .then((event) => {
-                    pipeline.lastEventId = event.id;
+                    if (modelConfig.type === 'pipeline') {
+                        pipeline.lastEventId = event.id;
+                    }
 
                     return pipeline.update()
                         .then(() => event);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -166,6 +166,17 @@ describe('Event Factory', () => {
                 });
             })
         );
+
+        it('should only update lastEventId if type is pipeline', () => {
+            config.type = 'pr';
+
+            return factory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                // lastEventId should not have been updated
+                assert.calledOnce(pipelineMock.update);
+                assert.strictEqual(pipelineMock.lastEventId, null);
+            });
+        });
     });
 
     describe('getInstance', () => {


### PR DESCRIPTION
## Context

Right now, the lastEventId for a pipeline gets updated for PRs as well. We only want to update it when it is not a PR event.

## Objective

This PR adds a check to only update lastEventId if it isn't a PR event.

## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)