### PR TITLE
feat(collections): Add type to config for pipeline getJobs

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -423,6 +423,7 @@ class PipelineModel extends BaseModel {
      * @param  {Object}   [config]                  Configuration object
      * @param  {Object}   [config.params]           Filter params
      * @param  {Boolean}  [config.params.archived]  Get archived/non-archived jobs
+     * @param  {String}   [config.type]             Type of jobs (pr or pipeline)
      * @return {Promise}  Resolves to an array of jobs
      */
     getJobs(config) {
@@ -438,6 +439,10 @@ class PipelineModel extends BaseModel {
         };
 
         const listConfig = (config) ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
+
+        if (listConfig.type) {
+            delete listConfig.type;
+        }
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
@@ -468,6 +473,13 @@ class PipelineModel extends BaseModel {
 
                 // sort them by pr number
                 prJobs = prJobs.sort((job1, job2) => job1.prNum - job2.prNum);
+
+                if (config && config.type === 'pr') {
+                    return prJobs;
+                }
+                if (config && config.type === 'pipeline') {
+                    return workflowJobs;
+                }
 
                 return workflowJobs.concat(prJobs);
             });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -639,6 +639,52 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('Only gets PR jobs', () => {
+            const config = {
+                type: 'pr'
+            };
+            const expected = {
+                params: {
+                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    archived: false
+                },
+                paginate
+            };
+            const jobList = [publishJob, blahJob, mainJob, pr10, pr3];
+            const expectedJobs = [pr3, pr10];
+
+            pipeline.workflow = ['main', 'publish', 'blah'];
+            jobFactoryMock.list.resolves(jobList);
+
+            return pipeline.getJobs(config).then((result) => {
+                assert.calledWith(jobFactoryMock.list, expected);
+                assert.deepEqual(result, expectedJobs);
+            });
+        });
+
+        it('Only gets Pipeline jobs', () => {
+            const config = {
+                type: 'pipeline'
+            };
+            const expected = {
+                params: {
+                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    archived: false
+                },
+                paginate
+            };
+            const jobList = [publishJob, blahJob, mainJob, pr10, pr3];
+            const expectedJobs = [mainJob, publishJob, blahJob];
+
+            pipeline.workflow = ['main', 'publish', 'blah'];
+            jobFactoryMock.list.resolves(jobList);
+
+            return pipeline.getJobs(config).then((result) => {
+                assert.calledWith(jobFactoryMock.list, expected);
+                assert.deepEqual(result, expectedJobs);
+            });
+        });
+
         it('Get archived jobs', () => {
             const config = {
                 params: {


### PR DESCRIPTION
## Context

For the user dashboards we need to get info about the number of PRs open and failing for each pipeline in a collection. It would be nice to be able to get only the PR jobs for a pipeline with a single call to the model.

## Objective

This PR adds a param to the config of getJobs for the pipeline model to specify an optional type for the jobs wanted. The user can specify either 'pipeline' or 'pr' which would return only the workflow jobs or PR jobs respectively. Not specifying a type will return all the jobs.

## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)