### PR TITLE
feat(723): eventFactory also creates builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ factory.get({ scmUri }).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the pipeline |
+| id | Number | The unique ID for the pipeline |
 | config.scmUri | String | Source Code URI for the application |
 
 
@@ -159,7 +159,7 @@ const factory = Model.JobFactory.getInstance({
 });
 const config = {
     params: {
-        pipelineId: 'aabbccdd1234'
+        pipelineId: 1
     },
     paginate {
         page: 2,
@@ -189,7 +189,7 @@ factory.create(config).then(model => {
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
 | config        | Object | Configuration Object |
-| config.pipelineId | String | The pipelineId that the job belongs to |
+| config.pipelineId | Number | The pipelineId that the job belongs to |
 | config.name | String | The name of the job |
 
 #### Get
@@ -206,8 +206,8 @@ factory.get({ pipelineId, name }).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the job |
-| config.pipelineId | String | Id of the pipeline the job is associated with |
+| id | Number | The unique ID for the job |
+| config.pipelineId | Number | Id of the pipeline the job is associated with |
 | config.name | String Name of the job |
 
 ### Job Model
@@ -260,7 +260,7 @@ const factory = Model.BuildFactory.getInstance({
 });
 const config = {
     params: {
-        jobId: 'aaabbccdd1234'
+        jobId: 4
     },
     paginate {
         page: 2,
@@ -297,7 +297,7 @@ factory.create(config).then(model => {
 | config.container | String | No | Container for the build to run in |
 | config.sha | String | No | SHA used to kick off the build |
 | config.prRef | String | No | PR branch or reference; required for PR jobs |
-| config.eventId | String | No | Id of the event this build belongs to |
+| config.eventId | Number | No | Id of the event this build belongs to |
 
 #### Get
 Get a build based on id. Can pass the generatedId for the build, or the unique keys for the model, and the id will be determined automatically.
@@ -313,8 +313,8 @@ factory.get({ jobId, number }).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the build |
-| config.jobId | String | The unique ID for a job |
+| id | Number | The unique ID for the build |
+| config.jobId | Number | The unique ID for a job |
 | config.number | Number | build number |
 
 ### Build Model
@@ -438,7 +438,7 @@ factory.get({ token }).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the build |
+| id | Number | The unique ID for the build |
 | config.username | String | User name |
 | config.scmContext | String | Scm context to which user belongs |
 | config.accessToken | String | A user access token value |
@@ -520,7 +520,7 @@ const factory = Model.SecretFactory.getInstance({
 });
 const config = {
     params: {
-        pipelineId: '2d991790bab1ac8576097ca87f170df73410b55c'
+        pipelineId: 1
     },
     paginate {
         page: 2,
@@ -550,7 +550,7 @@ factory.create(config).then(model => {
 | Parameter        | Type  |  Required | Description |
 | :-------------   | :---- | :-------------|  :-------------|
 | config        | Object | Yes | Configuration Object |
-| config.pipelineId | String | Yes | Pipeline that this secret belongs to |
+| config.pipelineId | Number | Yes | Pipeline that this secret belongs to |
 | config.name | String | Yes | Secret name |
 | config.value | String | Yes | Secret value |
 | config.allowInPR | String | Yes | Flag to denote if this secret can be shown in PR builds |
@@ -569,8 +569,8 @@ factory.get({ pipelineId, name }).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the build |
-| config.pipelineId | String | Pipeline that the secret belongs to |
+| id | Number | The unique ID for the build |
+| config.pipelineId | Number | Pipeline that the secret belongs to |
 | config.name | String | Secret name |
 
 
@@ -583,7 +583,7 @@ const factory = Model.SecretFactory.getInstance({
     password            // Password for encryption operations
 });
 const config = {
-    pipelineId: '2d991790bab1ac8576097ca87f170df73410b55c',
+    pipelineId: 1,
     name: 'NPM_TOKEN',
     value: banana,
     allowInPR: false
@@ -611,7 +611,7 @@ const factory = Model.EventFactory.getInstance({
 });
 const config = {
     params: {
-        pipelineId: '2d991790bab1ac8576097ca87f170df73410b55c'
+        pipelineId: 1
     }
 }
 
@@ -636,9 +636,10 @@ factory.create(config).then(model => {
 | :-------------   | :---- | :-------------|  :-------------|
 | config        | Object | Yes | Configuration Object |
 | config.type | String | No | Event type: pipeline or pr |
-| config.pipelineId | String | Yes | Unique identifier of pipeline |
+| config.pipelineId | Number | Yes | Unique identifier of pipeline |
 | config.sha | String | Yes | Commit sha that the event was based on |
-| config.workflow | Array | Yes | Workflow of the pipeline |
+| config.workflow | Array | No | Workflow of the pipeline |
+| config.workflowGraph | Object | No | Workflow graph of the pipeline, with edges and nodes |
 | config.username | String | Yes | Username of the user that creates this event |
 | config.causeMessage | String | No | Message that describes why the event was created |
 
@@ -656,8 +657,8 @@ factory.get({ pipelineId, sha }).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the build |
-| config.pipelineId | String | Unique identifier of pipeline |
+| id | Number | The unique ID for the build |
+| config.pipelineId | Number | Unique identifier of pipeline |
 | config.sha | String | Commit sha that the event was based on |
 
 ### Event Model
@@ -669,9 +670,21 @@ const factory = Model.EventFactory.getInstance({
     scm
 });
 const config = {
-    pipelineId: '12345f642bbfd1886623964b4cff12db59869e5d',
+    pipelineId: 1,
     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
-    workflow: ['main', 'publish'],    
+    workflowGraph: {
+        nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main' },
+            { name: 'publish' }
+        ],
+        edges: [
+            { src: '~pr', dest: 'main' },
+            { src: '~commit', dest: 'main' },
+            { src: 'main', dest: 'publish' }
+        ]
+    },    
     username: 'stjohn',
     causeMessage: 'Merge pull request #26 from screwdriver-cd/models'
 }
@@ -685,7 +698,7 @@ Example event model that got created:
 ```json
 {
     "type": "pipeline",
-    "pipelineId": "12345f642bbfd1886623964b4cff12db59869e5d",
+    "pipelineId": "1",
     "sha": "ccc49349d3cffbd12ea9e3d41521480b4aa5de5f",
     "createTime": "2038-01-19T03:14:08.131Z",
     "commit": {
@@ -698,7 +711,19 @@ Example event model that got created:
             "username": "imbatman"
         }
     },
-    "workflow": ["main", "publish"],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" }
+        ]
+    },
     "causeMessage": "Merge pull request #26 from screwdriver-cd/models",
     "creator": {
         "avatar": "https://avatars.githubusercontent.com/u/2042?v=3",
@@ -765,7 +790,7 @@ factory.create(config).then(model => {
 | config.description | String | Yes | Description of the template |
 | config.maintainer | Array | Yes | Maintainer's email |
 | config.config | Object | Yes | Config of the screwdriver-template.yaml |
-| config.pipelineId | String | Yes | pipelineId of the template |
+| config.pipelineId | Number | Yes | pipelineId of the template |
 | config.labels | Array | No | Labels attached to the template |
 
 #### Get
@@ -778,7 +803,7 @@ factory.get(id).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the Template |
+| id | Number | The unique ID for the Template |
 
 #### Get Template
 Get the latest template by name or get a specific template using name and version or name and tag. The version can be in any valid version format: either major, major.minor, or major.minor.patch. If no version is specified, the function will resolve with the latest version published. If no match is found, the function will resolve null.
@@ -844,7 +869,7 @@ factory.get(id).then(model => {
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
-| id | String | The unique ID for the Template Tag |
+| id | Number | The unique ID for the Template Tag |
 
 ### Token Factory
 #### Search

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -14,11 +14,11 @@ let instance;
  * @param  {String}     jobName     Job name
  * @return {Job}                    Job object
  */
-function createJob(jobFactory, job, jobName) {
+function createJob(jobFactory, { permutations, jobName, pipelineId }) {
     return jobFactory.create({
-        pipelineId: job.pipelineId,
+        pipelineId,
         name: jobName,
-        permutations: job.permutations
+        permutations
     });
 }
 
@@ -56,37 +56,60 @@ function createBuilds(pipeline, config, eventId) {
     return pipeline.jobs.then((jobs) => {
         let nextJobs;
 
-        // When startFrom is ~commit or jobName
+        // When startFrom is ~commit
+        if (startFrom === '~commit') {
+            return pipeline.sync()
+            .then((p) => {
+                nextJobs = WorkflowParser.getNextJobs(p.workflowGraph, { trigger: startFrom });
+                jobsToStart = jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
+
+                return Promise.resolve([]);
+            });
+        }
+
+        // When startFrom is jobName
         if (startFrom !== '~pr') {
-            nextJobs = WorkflowParser.getNextJobs(pipeline.workflowGraph, { trigger: startFrom });
-            jobsToStart = jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
+            jobsToStart = jobs.filter(j => j.name === startFrom && j.state === 'ENABLED');
 
             return Promise.resolve([]);
         }
 
-        // Get next jobs for when startFrom is ~pr
-        nextJobs = WorkflowParser.getNextJobs(pipeline.workflowGraph, {
-            trigger: startFrom,
-            prNum: config.prNum
+        // When startFrom is ~pr
+        return pipeline.syncPR(config.prNum)
+        .then(() => {
+            // Get next jobs for when startFrom is ~pr
+            nextJobs = WorkflowParser.getNextJobs(pipeline.workflowGraph, {
+                trigger: startFrom,
+                prNum: config.prNum
+            });
+
+            // To start all existing and ENABLED PR-prNum jobs
+            const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${config.prNum}:`));
+            const enabledPRJobArray = PRJobArray.filter(j => j.state === 'ENABLED');
+
+            jobsToStart = enabledPRJobArray;
+
+            // Get all the missing PR- job names
+            const existingPRJobNames = PRJobArray.map(p => p.name);
+            const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
+            // Get the job name part, e.g. main from PR-1:main
+            const missingJobNames = missingPRJobNames.map(name => name.split(':')[1]);
+            const missingJobs = jobs.filter(j => missingJobNames.includes(j.name));
+
+            return pipeline.getConfiguration(config.prRef)
+            .then((parsedConfig) => {
+                console.log('parsedConfig: ', parsedConfig.jobs);
+
+                // Create missing PR jobs
+                return Promise.all(missingJobs.map(j =>
+                    createJob(jobFactory, {
+                        permutations: parsedConfig.jobs[j.name],
+                        jobName: `PR-${config.prNum}:${j.name}`,
+                        pipelineId: pipeline.id
+                    })
+                ));
+            });
         });
-
-        // To start all existing and ENABLED PR-prNum jobs
-        const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${config.prNum}:`));
-        const enabledPRJobArray = PRJobArray.filter(j => j.state === 'ENABLED');
-
-        jobsToStart = enabledPRJobArray;
-
-        // Get all the missing PR- job names
-        const existingPRJobNames = PRJobArray.map(p => p.name);
-        const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
-        // Get the job name part, e.g. main from PR-1:main
-        const missingJobNames = missingPRJobNames.map(name => name.split(':')[1]);
-        const missingJobs = jobs.filter(j => missingJobNames.includes(j.name));
-
-        // Create missing PR jobs
-        return Promise.all(missingJobs.map(j =>
-            createJob(jobFactory, j, `PR-${config.prNum}:${j.name}`)
-        ));
     })
     .then((newJobs) => {
         // Add newly created PR jobs to jobsToStart array

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -32,7 +32,7 @@ function createJob(jobFactory, job, jobName) {
  * @param  {String}   config.username            Username of the user that creates this event
  * @param  {String}   config.scmContext          The scm context to which user belongs
  * @param  {String}   [config.prRef]             Ref if it's a PR event
- * @param  {String}   [config.prNum]             PR number if it's a PR event
+ * @param  {Number}   [config.prNum]             PR number if it's a PR event
  * @param  {String}   [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
  *                                               (Optional for backwards compatibility)
  * @param  {Number}   eventId                    Event id
@@ -130,16 +130,16 @@ class EventFactory extends BaseFactory {
      * @method create
      * @param  {Object}  config
      * @param  {String}  [config.type = 'pipeline'] Type of event (pipeline or pr)
-     * @param  {String}  config.pipelineId          Unique id of the pipeline
+     * @param  {Number}  config.pipelineId          Unique id of the pipeline
      * @param  {Array}   config.workflow            Job names that will be executed for this event
-     * @param  {Array}   [config.workflowGraph]     Object with nodes and edges that represent the order of jobs
+     * @param  {Object}  [config.workflowGraph]     Object with nodes and edges that represent the order of jobs
      *                                              (Optional for backwards compatibility)
      * @param  {String}  config.sha                 SHA this project was built on
      * @param  {String}  config.username            Username of the user that creates this event
      * @param  {String}  config.scmContext          The scm context to which user belongs
      * @param  {String}  [config.prRef]             Ref if it's a PR event
      * @param  {String}  [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
-     *                                              Making optional for backward compatibility
+     *                                              Optional for backwards compatibility
      * @param  {String}  [config.causeMessage]      Message that describes why the event was created
      * @return {Promise}
      */

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -271,7 +271,7 @@ class EventFactory extends BaseFactory {
         const displayName = displayLabel ? `${displayLabel}:${config.username}` : config.username;
 
         return pipelineFactory.get(config.pipelineId)
-        // Sync pipeline
+        // Sync pipeline to make sure workflowGraph is generated
         .then(p => p.sync())
         .then((pipeline) => {
             const modelConfig = {
@@ -314,6 +314,7 @@ class EventFactory extends BaseFactory {
                         modelConfig.workflowGraph = latestConfig.workflowGraph;
                         modelConfig.workflow = latestConfig.workflow;
 
+                        // Create event
                         return super.create(modelConfig)
                         .then((event) => {
                             if (modelConfig.type === 'pipeline') {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -100,32 +100,30 @@ function getJobsFromPR(config) {
     }
 
     return pipeline.syncPR(prNum)
-    .then(() => {
+    .then(() => pipeline.getConfiguration(config.prRef))
+    .then((parsedConfig) => {
         // Get next jobs for when startFrom is ~pr
-        const nextJobs = workflowParser.getNextJobs(pipeline.workflowGraph, {
+        const nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
             trigger: startFrom,
-            prNum: config.prNum
+            prNum
         });
         // Get jobs to start and create
         const { jobsToStart, jobsToCreate } = splitPRJobs({
             jobs,
             nextJobs,
-            prNum: config.prNum
+            prNum
         });
 
-        return pipeline.getConfiguration(config.prRef)
-        .then(parsedConfig =>
-            // Create missing PR jobs
-            Promise.all(jobsToCreate.map(j =>
-                // Create jobs
-                jobFactory.create({
-                    permutations: parsedConfig.jobs[j.name],
-                    pipelineId: pipeline.id,
-                    name: `PR-${config.prNum}:${j.name}`
-                })))
-            // Add newly created PR jobs to jobsToStart array
-            .then(newJobs => jobsToStart.concat(newJobs))
-        );
+        // Create missing PR jobs
+        return Promise.all(jobsToCreate.map(j =>
+            // Create jobs
+            jobFactory.create({
+                permutations: parsedConfig.jobs[j.name],
+                pipelineId: pipeline.id,
+                name: `PR-${config.prNum}:${j.name}`
+            })))
+        // Add newly created PR jobs to jobsToStart array
+        .then(newJobs => jobsToStart.concat(newJobs));
     });
 }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -41,26 +41,25 @@ function splitPRJobs(config) {
  * Get commit jobs to start that are enabled
  * @method getJobsFromCommit
  * @param  {Object}   config
- * @param  {Array}    config.jobs      Array of job objects
- * @param  {Object}   config.pipeline  Pipeline object
- * @param  {String}   config.startFrom Startfrom (e.g. ~commit, ~pr, etc)
- * @return {Array}                     Array of commit jobs to start
+ * @param  {Array}    config.jobs                           Array of job objects
+ * @param  {Object}   config.pipelineConfig
+ * @param  {Array}    [config.pipelineConfig.workflow]      Order of jobs to be run
+ * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
+ * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
+ * @return {Array}                                          Array of commit jobs to start
  */
 function getJobsFromCommit(config) {
-    const { jobs, pipeline, startFrom } = config;
+    const { jobs, pipelineConfig, startFrom } = config;
 
     if (startFrom !== '~commit') {
         return [];
     }
 
-    return pipeline.sync()
-    .then((p) => {
-        const nextJobs = workflowParser.getNextJobs(p.workflowGraph, {
-            trigger: startFrom
-        });
-
-        return jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
+    const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+        trigger: startFrom
     });
+
+    return jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
 }
 
 /**
@@ -85,65 +84,69 @@ function getJobsFromJobName(config) {
  * Get PR jobs to start that are enabled
  * @method getJobsFromPR
  * @param  {Object}   config
- * @param  {Object}   config.jobFactory Job Factory
- * @param  {Array}    config.jobs       Array of job objects
- * @param  {Object}   config.pipeline   Pipeline object
- * @param  {Number}   config.prNum      PR number
- * @param  {String}   config.startFrom  Startfrom (e.g. ~commit, ~pr, etc)
- * @resolves {Array}                      Array of PR jobs to start
+ * @param  {Object}   config.jobFactory                     Job Factory
+ * @param  {Array}    config.jobs                           Array of job objects
+ * @param  {Object}   config.pipeline                       Pipeline object
+ * @param  {Object}   config.pipelineConfig
+ * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
+ * @param  {Array}    config.pipelineConfig.jobs            Array of job objects
+ * @param  {Number}   config.prNum                          PR number
+ * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
+ * @resolves {Array}                                        Array of PR jobs to start
  */
 function getJobsFromPR(config) {
-    const { jobFactory, jobs, pipeline, prNum, startFrom } = config;
+    const { jobFactory, jobs, pipeline, pipelineConfig, prNum, startFrom } = config;
 
     if (startFrom !== '~pr') {
         return [];
     }
 
-    return pipeline.syncPR(prNum)
-    .then(() => pipeline.getConfiguration(config.prRef))
-    .then((parsedConfig) => {
-        // Get next jobs for when startFrom is ~pr
-        const nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
-            trigger: startFrom,
-            prNum
-        });
-        // Get jobs to start and create
-        const { jobsToStart, jobsToCreate } = splitPRJobs({
-            jobs,
-            nextJobs,
-            prNum
-        });
-
-        // Create missing PR jobs
-        return Promise.all(jobsToCreate.map(j =>
-            // Create jobs
-            jobFactory.create({
-                permutations: parsedConfig.jobs[j.name],
-                pipelineId: pipeline.id,
-                name: `PR-${config.prNum}:${j.name}`
-            })))
-        // Add newly created PR jobs to jobsToStart array
-        .then(newJobs => jobsToStart.concat(newJobs));
+    // Get next jobs for when startFrom is ~pr
+    const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+        trigger: startFrom,
+        prNum
     });
+    // Get jobs to start and create
+    const { jobsToStart, jobsToCreate } = splitPRJobs({
+        jobs,
+        nextJobs,
+        prNum
+    });
+
+    // Create missing PR jobs
+    return Promise.all(jobsToCreate.map(j =>
+        // Create jobs
+        jobFactory.create({
+            permutations: pipelineConfig.jobs[j.name],
+            pipelineId: pipeline.id,
+            name: `PR-${prNum}:${j.name}`
+        })))
+    // Add newly created PR jobs to jobsToStart array
+    .then(newJobs => jobsToStart.concat(newJobs));
 }
 
 /**
  * Create builds associated with this event
  * For example, if startFrom ~commit, then create builds with jobs that have requires: ~commit
  * @method createBuilds
- * @param  {Pipeline} pipeline                   Pipeline to create builds
  * @param  {Object}   config
- * @param  {String}   config.sha                 SHA this project was built on
- * @param  {String}   config.username            Username of the user that creates this event
- * @param  {String}   config.scmContext          The scm context to which user belongs
- * @param  {String}   [config.prRef]             Ref if it's a PR event
- * @param  {Number}   [config.prNum]             PR number if it's a PR event
- * @param  {String}   [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
- *                                               (Optional for backwards compatibility)
- * @param  {Number}   eventId                    Event id
+ * @param  {Object}   config.eventConfig
+ * @param  {String}   config.eventConfig.sha                 SHA this project was built on
+ * @param  {String}   config.eventConfig.username            Username of the user that creates this event
+ * @param  {String}   config.eventConfig.scmContext          The scm context to which user belongs
+ * @param  {String}   [config.eventConfig.prRef]             Ref if it's a PR event
+ * @param  {Number}   [config.eventConfig.prNum]             PR number if it's a PR event
+ * @param  {String}   [config.eventConfig.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
+ *                                                           (Optional for backwards compatibility)
+ * @param  {Number}   config.eventId                         Event id
+ * @param  {Pipeline} config.pipeline                        Pipeline to create builds
+ * @param  {Object}   config.pipelineConfig
+ * @param  {Array}    [config.pipelineConfig.workflow]       Job names that will be executed for this event
+ * @param  {Object}   [config.pipelineConfig.workflowGraph]  Object with nodes and edges that represent the order of jobs
  */
-function createBuilds(pipeline, config, eventId) {
-    const startFrom = config.startFrom;
+function createBuilds(config) {
+    const { eventConfig, eventId, pipeline, pipelineConfig } = config;
+    const startFrom = eventConfig.startFrom;
 
     // If no startFrom, then do nothing. Remove once we switch to new workflow design
     if (!startFrom) {
@@ -161,7 +164,7 @@ function createBuilds(pipeline, config, eventId) {
         // When startFrom is ~commit
         const jobsFromCommit = getJobsFromCommit({
             jobs,
-            pipeline,
+            pipelineConfig,
             startFrom
         });
         // When startFrom is a job name
@@ -174,7 +177,8 @@ function createBuilds(pipeline, config, eventId) {
             jobFactory,
             jobs,
             pipeline,
-            prNum: config.prNum,
+            pipelineConfig,
+            prNum: eventConfig.prNum,
             startFrom
         });
 
@@ -183,15 +187,42 @@ function createBuilds(pipeline, config, eventId) {
     })
     .then((jobsToStart) => {
         // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
-        if (jobsToStart.length <= 0) {
+        if (jobsToStart.length === 0) {
             throw new Error('No jobs to start');
         }
 
         // Start builds
         return Promise.all(jobsToStart.map(j =>
-            buildFactory.create(Object.assign({ jobId: j.id, eventId }, config))
+            buildFactory.create(Object.assign({ jobId: j.id, eventId }, eventConfig))
         ));
     });
+}
+
+/**
+ * Get the latest workflowGraph and pipelineConfig after syncing
+ * @method getLatestConfig
+ * @param  {Object}         config
+ * @param  {Pipeline}       pipeline            Pipeline to be synced
+ * @param  {Object}         eventConfig
+ * @param  {Number}         [eventConfig.prNum] PR number
+ * @param  {String}         [eventConfig.prRef] PR ref
+ * @resolves {Object}                           Resolves with object with workflowGraph
+ */
+function getLatestConfig(config) {
+    const { pipeline, eventConfig } = config;
+
+    // For pull request
+    if (eventConfig.prRef) {
+        return pipeline.syncPR(eventConfig.prNum)
+        .then(() => pipeline.getConfiguration(eventConfig.prRef));
+    }
+
+    // For everything else
+    return pipeline.sync()
+    .then(p => ({
+        workflow: p.workflow,
+        workflowGraph: p.workflowGraph
+    }));
 }
 
 class EventFactory extends BaseFactory {
@@ -221,12 +252,10 @@ class EventFactory extends BaseFactory {
      * @param  {Object}  config
      * @param  {String}  [config.type = 'pipeline'] Type of event (pipeline or pr)
      * @param  {Number}  config.pipelineId          Unique id of the pipeline
-     * @param  {Array}   config.workflow            Job names that will be executed for this event
-     * @param  {Object}  [config.workflowGraph]     Object with nodes and edges that represent the order of jobs
-     *                                              (Optional for backwards compatibility)
      * @param  {String}  config.sha                 SHA this project was built on
      * @param  {String}  config.username            Username of the user that creates this event
      * @param  {String}  config.scmContext          The scm context to which user belongs
+     * @param  {String}  [config.prNum]             PR number if it's a PR event
      * @param  {String}  [config.prRef]             Ref if it's a PR event
      * @param  {String}  [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
      *                                              Optional for backwards compatibility
@@ -247,8 +276,6 @@ class EventFactory extends BaseFactory {
                 type: config.type || 'pipeline',
                 pipelineId: config.pipelineId,
                 sha: config.sha,
-                workflow: config.workflow,
-                workflowGraph: config.workflowGraph,
                 startFrom: config.startFrom,
                 causeMessage: config.causeMessage || `Started by ${displayName}`
             };
@@ -276,16 +303,31 @@ class EventFactory extends BaseFactory {
                     modelConfig.commit = commit;
                     modelConfig.createTime = (new Date()).toISOString();
 
-                    return super.create(modelConfig);
-                })
-                .then((event) => {
-                    if (modelConfig.type === 'pipeline') {
-                        pipeline.lastEventId = event.id;
-                    }
+                    // Sync pipeline or PR and get config
+                    return getLatestConfig({
+                        pipeline,
+                        eventConfig: config
+                    })
+                    .then((latestConfig) => {
+                        modelConfig.workflowGraph = latestConfig.workflowGraph;
+                        modelConfig.workflow = latestConfig.workflow;
 
-                    return pipeline.update()
-                        .then(() => createBuilds(pipeline, config, event.id))
-                        .then(() => event);
+                        return super.create(modelConfig)
+                        .then((event) => {
+                            if (modelConfig.type === 'pipeline') {
+                                pipeline.lastEventId = event.id;
+                            }
+
+                            return pipeline.update()
+                            .then(() => createBuilds({
+                                eventConfig: config,
+                                eventId: event.id,
+                                pipeline,
+                                pipelineConfig: latestConfig
+                            }))
+                            .then(() => event);
+                        });
+                    });
                 });
         });
     }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -2,23 +2,130 @@
 
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
-const WorkflowParser = require('screwdriver-workflow-parser');
+const workflowParser = require('screwdriver-workflow-parser');
 
 let instance;
 
 /**
- * Create a job
- * @method createJob
- * @param  {JobFactory} jobFactory  Job factory
- * @param  {Job}        job         Job object
- * @param  {String}     jobName     Job name
- * @return {Job}                    Job object
+ * Returns 2 arrays:
+ * 1. Jobs to start
+ * 2. Job to create
+ * @method splitPRJobs
+ * @param  {Object}    config
+ * @param  {Array}     config.jobs      PR jobs
+ * @param  {Array}     config.nextJobs  PR job names to trigger next
+ * @param  {Number}    config.prNum     PR number
+ * @return {Object}                     Object with jobsToStart array and jobsToCreate array
  */
-function createJob(jobFactory, { permutations, jobName, pipelineId }) {
-    return jobFactory.create({
-        pipelineId,
-        name: jobName,
-        permutations
+function splitPRJobs(config) {
+    const { jobs, nextJobs, prNum } = config;
+    // Get jobsToStart
+    // To start all existing and ENABLED PR-prNum jobs
+    const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
+    const jobsToStart = PRJobArray.filter(j => j.state === 'ENABLED');
+    // Get jobsToCreate
+    // Get all the missing PR- job names
+    const existingPRJobNames = PRJobArray.map(p => p.name);
+    const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
+    // Get the job name part, e.g. main from PR-1:main
+    const missingJobNames = missingPRJobNames.map(name => name.split(':')[1]);
+    const missingJobs = jobs.filter(j => missingJobNames.includes(j.name));
+
+    return {
+        jobsToStart,
+        jobsToCreate: missingJobs
+    };
+}
+
+/**
+ * Get commit jobs to start that are enabled
+ * @method getJobsFromCommit
+ * @param  {Object}   config
+ * @param  {Array}    config.jobs      Array of job objects
+ * @param  {Object}   config.pipeline  Pipeline object
+ * @param  {String}   config.startFrom Startfrom (e.g. ~commit, ~pr, etc)
+ * @return {Array}                     Array of commit jobs to start
+ */
+function getJobsFromCommit(config) {
+    const { jobs, pipeline, startFrom } = config;
+
+    if (startFrom !== '~commit') {
+        return [];
+    }
+
+    return pipeline.sync()
+    .then((p) => {
+        const nextJobs = workflowParser.getNextJobs(p.workflowGraph, {
+            trigger: startFrom
+        });
+
+        return jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
+    });
+}
+
+/**
+ * Get jobs from job name to start that are enabled
+ * @method getJobsToStart
+ * @param  {Object}   config
+ * @param  {Array}    config.jobs      Array of job objects
+ * @param  {String}   config.startFrom Startfrom (e.g. ~commit, ~pr, etc)
+ * @return {Array}                     Array of jobs to start
+ */
+function getJobsFromJobName(config) {
+    const { jobs, startFrom } = config;
+
+    if (startFrom === '~commit' || startFrom === '~pr') {
+        return [];
+    }
+
+    return jobs.filter(j => j.name === startFrom && j.state === 'ENABLED');
+}
+
+/**
+ * Get PR jobs to start that are enabled
+ * @method getJobsFromPR
+ * @param  {Object}   config
+ * @param  {Object}   config.jobFactory Job Factory
+ * @param  {Array}    config.jobs       Array of job objects
+ * @param  {Object}   config.pipeline   Pipeline object
+ * @param  {Number}   config.prNum      PR number
+ * @param  {String}   config.startFrom  Startfrom (e.g. ~commit, ~pr, etc)
+ * @resolves {Array}                      Array of PR jobs to start
+ */
+function getJobsFromPR(config) {
+    const { jobFactory, jobs, pipeline, prNum, startFrom } = config;
+
+    if (startFrom !== '~pr') {
+        return [];
+    }
+
+    return pipeline.syncPR(prNum)
+    .then(() => {
+        // Get next jobs for when startFrom is ~pr
+        const nextJobs = workflowParser.getNextJobs(pipeline.workflowGraph, {
+            trigger: startFrom,
+            prNum: config.prNum
+        });
+        // Get jobs to start and create
+        const { jobsToStart, jobsToCreate } = splitPRJobs({
+            jobs,
+            nextJobs,
+            prNum: config.prNum
+        });
+
+        return pipeline.getConfiguration(config.prRef)
+        .then(parsedConfig =>
+            // Create missing PR jobs
+            Promise.all(jobsToCreate.map(j =>
+                // Create jobs
+                jobFactory.create({
+                    permutations: parsedConfig.jobs[j.name],
+                    pipelineId: pipeline.id,
+                    name: `PR-${config.prNum}:${j.name}`
+                })))
+            // Add newly created PR jobs to jobsToStart array
+            .then(newJobs => jobsToStart.concat(newJobs))
+        );
     });
 }
 
@@ -39,7 +146,6 @@ function createJob(jobFactory, { permutations, jobName, pipelineId }) {
  */
 function createBuilds(pipeline, config, eventId) {
     const startFrom = config.startFrom;
-    let jobsToStart = [];
 
     // If no startFrom, then do nothing. Remove once we switch to new workflow design
     if (!startFrom) {
@@ -54,70 +160,33 @@ function createBuilds(pipeline, config, eventId) {
     /* eslint-enable global-require */
 
     return pipeline.jobs.then((jobs) => {
-        let nextJobs;
-
         // When startFrom is ~commit
-        if (startFrom === '~commit') {
-            return pipeline.sync()
-            .then((p) => {
-                nextJobs = WorkflowParser.getNextJobs(p.workflowGraph, { trigger: startFrom });
-                jobsToStart = jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
-
-                return Promise.resolve([]);
-            });
-        }
-
-        // When startFrom is jobName
-        if (startFrom !== '~pr') {
-            jobsToStart = jobs.filter(j => j.name === startFrom && j.state === 'ENABLED');
-
-            return Promise.resolve([]);
-        }
-
-        // When startFrom is ~pr
-        return pipeline.syncPR(config.prNum)
-        .then(() => {
-            // Get next jobs for when startFrom is ~pr
-            nextJobs = WorkflowParser.getNextJobs(pipeline.workflowGraph, {
-                trigger: startFrom,
-                prNum: config.prNum
-            });
-
-            // To start all existing and ENABLED PR-prNum jobs
-            const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${config.prNum}:`));
-            const enabledPRJobArray = PRJobArray.filter(j => j.state === 'ENABLED');
-
-            jobsToStart = enabledPRJobArray;
-
-            // Get all the missing PR- job names
-            const existingPRJobNames = PRJobArray.map(p => p.name);
-            const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
-            // Get the job name part, e.g. main from PR-1:main
-            const missingJobNames = missingPRJobNames.map(name => name.split(':')[1]);
-            const missingJobs = jobs.filter(j => missingJobNames.includes(j.name));
-
-            return pipeline.getConfiguration(config.prRef)
-            .then((parsedConfig) => {
-                console.log('parsedConfig: ', parsedConfig.jobs);
-
-                // Create missing PR jobs
-                return Promise.all(missingJobs.map(j =>
-                    createJob(jobFactory, {
-                        permutations: parsedConfig.jobs[j.name],
-                        jobName: `PR-${config.prNum}:${j.name}`,
-                        pipelineId: pipeline.id
-                    })
-                ));
-            });
+        const jobsFromCommit = getJobsFromCommit({
+            jobs,
+            pipeline,
+            startFrom
         });
-    })
-    .then((newJobs) => {
-        // Add newly created PR jobs to jobsToStart array
-        jobsToStart = jobsToStart.concat(newJobs);
+        // When startFrom is a job name
+        const jobsFromJobName = getJobsFromJobName({
+            jobs,
+            startFrom
+        });
+        // When startFrom is ~pr
+        const jobsFromPR = getJobsFromPR({
+            jobFactory,
+            jobs,
+            pipeline,
+            prNum: config.prNum,
+            startFrom
+        });
 
+        return Promise.all([jobsFromCommit, jobsFromJobName, jobsFromPR])
+        .then(result => result.reduce((a, b) => a.concat(b)));
+    })
+    .then((jobsToStart) => {
         // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
         if (jobsToStart.length <= 0) {
-            return Promise.reject(new Error('No jobs to start'));
+            throw new Error('No jobs to start');
         }
 
         // Start builds

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -2,8 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
-const jobConfigSchema = require('screwdriver-data-schema').config.job;
-const joi = require('joi');
+const WorkflowParser = require('screwdriver-workflow-parser');
 
 let instance;
 
@@ -40,6 +39,7 @@ function createJob(jobFactory, job, jobName) {
  */
 function createBuilds(pipeline, config, eventId) {
     const startFrom = config.startFrom;
+    let jobsToStart = [];
 
     // If no startFrom, then do nothing. Remove once we switch to new workflow design
     if (!startFrom) {
@@ -54,62 +54,53 @@ function createBuilds(pipeline, config, eventId) {
     /* eslint-enable global-require */
 
     return pipeline.jobs.then((jobs) => {
-        const jobNamesArray = jobs.map(j => j.name);
-        const jobsToCreate = [];
-        let jobsToStart = [];
+        let nextJobs;
 
-        jobs.forEach((job) => {
-            const jobName = job.name;
-            const isEnabled = job.state === 'ENABLED';
-            const isJobName = !joi.validate(startFrom, jobConfigSchema.jobname).error;
-            const isTrigger = !joi.validate(startFrom, jobConfigSchema.trigger).error;
-            const prJobName = `PR-${config.prNum}-${jobName}`;
-            const requires = job.permutations.requires; // eg. [~commit, ~pr, jobA]
+        // When startFrom is ~commit or jobName
+        if (startFrom !== '~pr') {
+            nextJobs = WorkflowParser.getNextJobs(pipeline.workflowGraph, { trigger: startFrom });
+            jobsToStart = jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
 
-            // Do nothing if job is disabled
-            if (!isEnabled) {
-                return;
-            }
+            return Promise.resolve([]);
+        }
 
-            // Skip if PR job already exists
-            if (jobNamesArray.includes(prJobName)) {
-                return;
-            }
-
-            // Skip if PR number does not match
-            if (startFrom === '~pr' && job.isPR() && job.prNum() !== config.prNum) {
-                return;
-            }
-
-            // If startFrom is a jobname, start the job
-            if ((isJobName && startFrom === jobName)) {
-                jobsToStart.push(job);
-            // If startFrom is a trigger (example: ~commit, ~pr) and is required
-            } else if (isTrigger && requires && requires.includes(startFrom)) {
-                // If startFrom is ~commit or if startFrom is ~pr and the job is a PR, start job
-                if (startFrom === '~commit' || job.isPR()) {
-                    jobsToStart.push(job);
-                // PR job doesn't exist yet, create the job
-                } else {
-                    jobsToCreate.push(createJob(jobFactory, job, prJobName));
-                }
-            }
+        // Get next jobs for when startFrom is ~pr
+        nextJobs = WorkflowParser.getNextJobs(pipeline.workflowGraph, {
+            trigger: startFrom,
+            prNum: config.prNum
         });
 
-        return Promise.all(jobsToCreate)
-            .then((newJobs) => {
-                jobsToStart = jobsToStart.concat(newJobs);
+        // To start all existing and ENABLED PR-prNum jobs
+        const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${config.prNum}:`));
+        const enabledPRJobArray = PRJobArray.filter(j => j.state === 'ENABLED');
 
-                // No jobs to start (For example: job are disabled, or startFrom is not valid)
-                if (jobsToStart.length <= 0) {
-                    return Promise.reject(new Error('No jobs to start'));
-                }
+        jobsToStart = enabledPRJobArray;
 
-                // Start builds
-                return Promise.all(jobsToStart.map(j =>
-                    buildFactory.create(Object.assign({ jobId: j.id, eventId }, config))
-                ));
-            });
+        // Get all the missing PR- job names
+        const existingPRJobNames = PRJobArray.map(p => p.name);
+        const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
+        // Get the job name part, e.g. main from PR-1:main
+        const missingJobNames = missingPRJobNames.map(name => name.split(':')[1]);
+        const missingJobs = jobs.filter(j => missingJobNames.includes(j.name));
+
+        // Create missing PR jobs
+        return Promise.all(missingJobs.map(j =>
+            createJob(jobFactory, j, `PR-${config.prNum}:${j.name}`)
+        ));
+    })
+    .then((newJobs) => {
+        // Add newly created PR jobs to jobsToStart array
+        jobsToStart = jobsToStart.concat(newJobs);
+
+        // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
+        if (jobsToStart.length <= 0) {
+            return Promise.reject(new Error('No jobs to start'));
+        }
+
+        // Start builds
+        return Promise.all(jobsToStart.map(j =>
+            buildFactory.create(Object.assign({ jobId: j.id, eventId }, config))
+        ));
     });
 }
 
@@ -141,6 +132,8 @@ class EventFactory extends BaseFactory {
      * @param  {String}  [config.type = 'pipeline'] Type of event (pipeline or pr)
      * @param  {String}  config.pipelineId          Unique id of the pipeline
      * @param  {Array}   config.workflow            Job names that will be executed for this event
+     * @param  {Array}   [config.workflowGraph]     Object with nodes and edges that represent the order of jobs
+     *                                              (Optional for backwards compatibility)
      * @param  {String}  config.sha                 SHA this project was built on
      * @param  {String}  config.username            Username of the user that creates this event
      * @param  {String}  config.scmContext          The scm context to which user belongs
@@ -165,6 +158,7 @@ class EventFactory extends BaseFactory {
                 pipelineId: config.pipelineId,
                 sha: config.sha,
                 workflow: config.workflow,
+                workflowGraph: config.workflowGraph,
                 startFrom: config.startFrom,
                 causeMessage: config.causeMessage || `Started by ${displayName}`
             };

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -8,6 +8,22 @@ const joi = require('joi');
 let instance;
 
 /**
+ * Create a job
+ * @method createJob
+ * @param  {JobFactory} jobFactory  Job factory
+ * @param  {Job}        job         Job object
+ * @param  {String}     jobName     Job name
+ * @return {Job}                    Job object
+ */
+function createJob(jobFactory, job, jobName) {
+    return jobFactory.create({
+        pipelineId: job.pipelineId,
+        name: jobName,
+        permutations: job.permutations
+    });
+}
+
+/**
  * Create builds associated with this event
  * For example, if startFrom ~commit, then create builds with jobs that have requires: ~commit
  * @method createBuilds
@@ -17,10 +33,10 @@ let instance;
  * @param  {String}   config.username            Username of the user that creates this event
  * @param  {String}   config.scmContext          The scm context to which user belongs
  * @param  {String}   [config.prRef]             Ref if it's a PR event
- * @param  {String}   [config.prNum]             PR Number if it's a PR event
+ * @param  {String}   [config.prNum]             PR number if it's a PR event
  * @param  {String}   [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
- *                                               Making optional for backward compatibility
- * @param  {Number}   eventId                    Event's id
+ *                                               (Optional for backwards compatibility)
+ * @param  {Number}   eventId                    Event id
  */
 function createBuilds(pipeline, config, eventId) {
     const startFrom = config.startFrom;
@@ -37,39 +53,45 @@ function createBuilds(pipeline, config, eventId) {
     const jobFactory = JobFactory.getInstance();
     /* eslint-enable global-require */
 
-    const createJob = (job, jobName) => jobFactory.create({
-        pipelineId: job.pipelineId,
-        name: jobName,
-        permutations: job.permutations
-    });
-
     return pipeline.jobs.then((jobs) => {
         const jobNamesArray = jobs.map(j => j.name);
         const jobsToCreate = [];
         let jobsToStart = [];
 
         jobs.forEach((job) => {
-            const enabled = job.state === 'ENABLED';
-            const requires = job.permutations.requires;
-            const isJobName = joi.validate(startFrom, jobConfigSchema.jobname);
-            const isTrigger = joi.validate(startFrom, jobConfigSchema.trigger);
+            const jobName = job.name;
+            const isEnabled = job.state === 'ENABLED';
+            const isJobName = !joi.validate(startFrom, jobConfigSchema.jobname).error;
+            const isTrigger = !joi.validate(startFrom, jobConfigSchema.trigger).error;
+            const prJobName = `PR-${config.prNum}-${jobName}`;
+            const requires = job.permutations.requires; // eg. [~commit, ~pr, jobA]
 
-            if (enabled) {
-                // if startFrom is a jobname, then start that job
-                if (!isJobName.error && startFrom === job.name) {
+            // Do nothing if job is disabled
+            if (!isEnabled) {
+                return;
+            }
+
+            // Skip if PR job already exists
+            if (jobNamesArray.includes(prJobName)) {
+                return;
+            }
+
+            // Skip if PR number does not match
+            if (startFrom === '~pr' && job.isPR() && job.prNum() !== config.prNum) {
+                return;
+            }
+
+            // If startFrom is a jobname, start the job
+            if ((isJobName && startFrom === jobName)) {
+                jobsToStart.push(job);
+            // If startFrom is a trigger (example: ~commit, ~pr) and is required
+            } else if (isTrigger && requires && requires.includes(startFrom)) {
+                // If startFrom is ~commit or if startFrom is ~pr and the job is a PR, start job
+                if (startFrom === '~commit' || job.isPR()) {
                     jobsToStart.push(job);
-                // if startFrom is a trigger (example: ~commit, ~pr) then start jobs that include that key
-                } else if (!isTrigger.error && requires && requires.includes(startFrom)) {
-                    const prJobName = `PR-${config.prNum}-${job.name}`;
-                    const prJobIndex = jobNamesArray.indexOf(prJobName);
-
-                    // if startFrom is not ~pr, or if ~pr and PR job already exists
-                    if (startFrom !== '~pr' || prJobIndex >= 0) {
-                        jobsToStart.push(job);
-                    } else {
-                        // PR job doesn't exist yet, need to create the job
-                        jobsToCreate.push(createJob(job, prJobName));
-                    }
+                // PR job doesn't exist yet, create the job
+                } else {
+                    jobsToCreate.push(createJob(jobFactory, job, prJobName));
                 }
             }
         });
@@ -83,6 +105,7 @@ function createBuilds(pipeline, config, eventId) {
                     return Promise.reject(new Error('No jobs to start'));
                 }
 
+                // Start builds
                 return Promise.all(jobsToStart.map(j =>
                     buildFactory.create(Object.assign({ jobId: j.id, eventId }, config))
                 ));

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -2,8 +2,60 @@
 
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
+const jobConfigSchema = require('screwdriver-data-schema').config.job;
+const joi = require('joi');
 
 let instance;
+
+/**
+ * Create builds associated with this event
+ * For example, if startFrom ~commit, then create builds with jobs that have requires: ~commit
+ * @method createBuilds
+ * @param  {Pipeline} pipeline                   Pipeline to create builds
+ * @param  {Object}   config
+ * @param  {String}   config.sha                 SHA this project was built on
+ * @param  {String}   config.username            Username of the user that creates this event
+ * @param  {String}   config.scmContext          The scm context to which user belongs
+ * @param  {String}   [config.prRef]             Ref if it's a PR event
+ * @param  {String}   [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
+ *                                               Making optional for backward compatibility
+ * @param  {Number}   eventId                    Event's id
+ */
+function createBuilds(pipeline, config, eventId) {
+    const startFrom = config.startFrom;
+
+    // If no startFrom, then do nothing. Remove once we switch to new workflow design
+    if (!startFrom) {
+        return null;
+    }
+
+    // eslint-disable-next-line global-require
+    const BuildFactory = require('./buildFactory');
+    const buildFactory = BuildFactory.getInstance();
+
+    return pipeline.jobs.then((jobs) => {
+        const jobsToStart = jobs.filter((job) => {
+            const enabled = job.state === 'ENABLED';
+            const requires = job.permutations.requires;
+            const isJobName = joi.validate(startFrom, jobConfigSchema.jobname);
+            const isTrigger = joi.validate(startFrom, jobConfigSchema.trigger);
+
+            return enabled && (
+                (!isJobName.error && startFrom === job.name) ||                 // if startFrom is a jobname, then start that job
+                (!isTrigger.error && requires && requires.includes(startFrom))  // if startFrom is a trigger, then start if requires includes that key
+            );
+        });
+
+        if (jobsToStart.length > 0) {
+            return Promise.all(jobsToStart.map(j =>
+                buildFactory.create(Object.assign({ jobId: j.id, eventId }, config))
+            ));
+        }
+
+        // No jobs to start (For example: job are disabled, or startFrom is not valid)
+        return Promise.reject(new Error('No jobs to start'));
+    });
+}
 
 class EventFactory extends BaseFactory {
     /**
@@ -36,16 +88,17 @@ class EventFactory extends BaseFactory {
      * @param  {String}  config.sha                 SHA this project was built on
      * @param  {String}  config.username            Username of the user that creates this event
      * @param  {String}  config.scmContext          The scm context to which user belongs
+     * @param  {String}  [config.prRef]             Ref if it's a PR event
+     * @param  {String}  [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
+     *                                              Making optional for backward compatibility
      * @param  {String}  [config.causeMessage]      Message that describes why the event was created
      * @return {Promise}
      */
     create(config) {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
-        /* eslint-disable global-require */
+        // eslint-disable-next-line global-require
         const PipelineFactory = require('./pipelineFactory');
-        /* eslint-enable global-require */
-
         const pipelineFactory = PipelineFactory.getInstance();
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${config.username}` : config.username;
@@ -56,6 +109,7 @@ class EventFactory extends BaseFactory {
                 pipelineId: config.pipelineId,
                 sha: config.sha,
                 workflow: config.workflow,
+                startFrom: config.startFrom,
                 causeMessage: config.causeMessage || `Started by ${displayName}`
             };
 
@@ -90,6 +144,7 @@ class EventFactory extends BaseFactory {
                     }
 
                     return pipeline.update()
+                        .then(() => createBuilds(pipeline, config, event.id))
                         .then(() => event);
                 });
         });

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -199,7 +199,7 @@ function createBuilds(config) {
 }
 
 /**
- * Get the latest workflowGraph and pipelineConfig after syncing
+ * Get the latest workflowGraph and pipelineConfig
  * @method getLatestConfig
  * @param  {Object}         config
  * @param  {Pipeline}       pipeline            Pipeline to be synced
@@ -218,11 +218,10 @@ function getLatestConfig(config) {
     }
 
     // For everything else
-    return pipeline.sync()
-    .then(p => ({
-        workflow: p.workflow,
-        workflowGraph: p.workflowGraph
-    }));
+    return Promise.resolve({
+        workflow: pipeline.workflow,
+        workflowGraph: pipeline.workflowGraph
+    });
 }
 
 class EventFactory extends BaseFactory {
@@ -271,65 +270,69 @@ class EventFactory extends BaseFactory {
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${config.username}` : config.username;
 
-        return pipelineFactory.get(config.pipelineId).then((pipeline) => {
-            const modelConfig = {
-                type: config.type || 'pipeline',
-                pipelineId: config.pipelineId,
-                sha: config.sha,
-                startFrom: config.startFrom,
-                causeMessage: config.causeMessage || `Started by ${displayName}`
-            };
+        return pipelineFactory.get(config.pipelineId)
+            // Sync pipeline
+            .then(p => p.sync())
+            .then((pipeline) => {
+                const modelConfig = {
+                    type: config.type || 'pipeline',
+                    pipelineId: config.pipelineId,
+                    sha: config.sha,
+                    startFrom: config.startFrom,
+                    causeMessage: config.causeMessage || `Started by ${displayName}`
+                };
 
-            return pipeline.token
-                .then(token =>
-                    this.scm.decorateAuthor({           // decorate user who creates this event
-                        username: config.username,
-                        scmContext: config.scmContext,
-                        token
-                    })
-                    .then((creator) => {
-                        modelConfig.creator = creator;
-
-                        const scmUri = pipeline.scmUri;
-
-                        return this.scm.decorateCommit({
-                            scmUri,
+                return pipeline.token
+                    .then(token =>
+                        this.scm.decorateAuthor({           // decorate user who creates this event
+                            username: config.username,
                             scmContext: config.scmContext,
-                            sha: config.sha,
                             token
-                        });
-                    }))
-                .then((commit) => {
-                    modelConfig.commit = commit;
-                    modelConfig.createTime = (new Date()).toISOString();
+                        })
+                        .then((creator) => {
+                            modelConfig.creator = creator;
 
-                    // Sync pipeline or PR and get config
-                    return getLatestConfig({
-                        pipeline,
-                        eventConfig: config
-                    })
-                    .then((latestConfig) => {
-                        modelConfig.workflowGraph = latestConfig.workflowGraph;
-                        modelConfig.workflow = latestConfig.workflow;
+                            const scmUri = pipeline.scmUri;
 
-                        return super.create(modelConfig)
-                        .then((event) => {
-                            if (modelConfig.type === 'pipeline') {
-                                pipeline.lastEventId = event.id;
-                            }
+                            return this.scm.decorateCommit({
+                                scmUri,
+                                scmContext: config.scmContext,
+                                sha: config.sha,
+                                token
+                            });
+                        }))
+                    .then((commit) => {
+                        modelConfig.commit = commit;
+                        modelConfig.createTime = (new Date()).toISOString();
 
-                            return pipeline.update()
-                            .then(() => createBuilds({
-                                eventConfig: config,
-                                eventId: event.id,
-                                pipeline,
-                                pipelineConfig: latestConfig
-                            }))
-                            .then(() => event);
+                        // Get latest config
+                        return getLatestConfig({
+                            pipeline,
+                            eventConfig: config
+                        })
+                        .then((latestConfig) => {
+                            modelConfig.workflowGraph = latestConfig.workflowGraph;
+                            modelConfig.workflow = latestConfig.workflow;
+
+                            return super.create(modelConfig)
+                            .then((event) => {
+                                if (modelConfig.type === 'pipeline') {
+                                    pipeline.lastEventId = event.id;
+                                }
+
+                                return pipeline.update()
+                                // Start builds
+                                .then(() => createBuilds({
+                                    eventConfig: config,
+                                    eventId: event.id,
+                                    pipeline,
+                                    pipelineConfig: latestConfig
+                                }))
+                                .then(() => event);
+                            });
                         });
                     });
-                });
-        });
+            });
     }
 
     /**

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -271,68 +271,68 @@ class EventFactory extends BaseFactory {
         const displayName = displayLabel ? `${displayLabel}:${config.username}` : config.username;
 
         return pipelineFactory.get(config.pipelineId)
-            // Sync pipeline
-            .then(p => p.sync())
-            .then((pipeline) => {
-                const modelConfig = {
-                    type: config.type || 'pipeline',
-                    pipelineId: config.pipelineId,
-                    sha: config.sha,
-                    startFrom: config.startFrom,
-                    causeMessage: config.causeMessage || `Started by ${displayName}`
-                };
+        // Sync pipeline
+        .then(p => p.sync())
+        .then((pipeline) => {
+            const modelConfig = {
+                type: config.type || 'pipeline',
+                pipelineId: config.pipelineId,
+                sha: config.sha,
+                startFrom: config.startFrom,
+                causeMessage: config.causeMessage || `Started by ${displayName}`
+            };
 
-                return pipeline.token
-                    .then(token =>
-                        this.scm.decorateAuthor({           // decorate user who creates this event
-                            username: config.username,
+            return pipeline.token
+                .then(token =>
+                    this.scm.decorateAuthor({           // decorate user who creates this event
+                        username: config.username,
+                        scmContext: config.scmContext,
+                        token
+                    })
+                    .then((creator) => {
+                        modelConfig.creator = creator;
+
+                        const scmUri = pipeline.scmUri;
+
+                        return this.scm.decorateCommit({
+                            scmUri,
                             scmContext: config.scmContext,
+                            sha: config.sha,
                             token
-                        })
-                        .then((creator) => {
-                            modelConfig.creator = creator;
+                        });
+                    }))
+                .then((commit) => {
+                    modelConfig.commit = commit;
+                    modelConfig.createTime = (new Date()).toISOString();
 
-                            const scmUri = pipeline.scmUri;
+                    // Get latest config
+                    return getLatestConfig({
+                        pipeline,
+                        eventConfig: config
+                    })
+                    .then((latestConfig) => {
+                        modelConfig.workflowGraph = latestConfig.workflowGraph;
+                        modelConfig.workflow = latestConfig.workflow;
 
-                            return this.scm.decorateCommit({
-                                scmUri,
-                                scmContext: config.scmContext,
-                                sha: config.sha,
-                                token
-                            });
-                        }))
-                    .then((commit) => {
-                        modelConfig.commit = commit;
-                        modelConfig.createTime = (new Date()).toISOString();
+                        return super.create(modelConfig)
+                        .then((event) => {
+                            if (modelConfig.type === 'pipeline') {
+                                pipeline.lastEventId = event.id;
+                            }
 
-                        // Get latest config
-                        return getLatestConfig({
-                            pipeline,
-                            eventConfig: config
-                        })
-                        .then((latestConfig) => {
-                            modelConfig.workflowGraph = latestConfig.workflowGraph;
-                            modelConfig.workflow = latestConfig.workflow;
-
-                            return super.create(modelConfig)
-                            .then((event) => {
-                                if (modelConfig.type === 'pipeline') {
-                                    pipeline.lastEventId = event.id;
-                                }
-
-                                return pipeline.update()
-                                // Start builds
-                                .then(() => createBuilds({
-                                    eventConfig: config,
-                                    eventId: event.id,
-                                    pipeline,
-                                    pipelineConfig: latestConfig
-                                }))
-                                .then(() => event);
-                            });
+                            return pipeline.update()
+                            // Start builds
+                            .then(() => createBuilds({
+                                eventConfig: config,
+                                eventId: event.id,
+                                pipeline,
+                                pipelineConfig: latestConfig
+                            }))
+                            .then(() => event);
                         });
                     });
-            });
+                });
+        });
     }
 
     /**

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -17,6 +17,7 @@ let instance;
  * @param  {String}   config.username            Username of the user that creates this event
  * @param  {String}   config.scmContext          The scm context to which user belongs
  * @param  {String}   [config.prRef]             Ref if it's a PR event
+ * @param  {String}   [config.prNum]             PR Number if it's a PR event
  * @param  {String}   [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
  *                                               Making optional for backward compatibility
  * @param  {Number}   eventId                    Event's id
@@ -29,31 +30,63 @@ function createBuilds(pipeline, config, eventId) {
         return null;
     }
 
-    // eslint-disable-next-line global-require
+    /* eslint-disable global-require */
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
+    const JobFactory = require('./jobFactory');
+    const jobFactory = JobFactory.getInstance();
+    /* eslint-enable global-require */
+
+    const createJob = (job, jobName) => jobFactory.create({
+        pipelineId: job.pipelineId,
+        name: jobName,
+        permutations: job.permutations
+    });
 
     return pipeline.jobs.then((jobs) => {
-        const jobsToStart = jobs.filter((job) => {
+        const jobNamesArray = jobs.map(j => j.name);
+        const jobsToCreate = [];
+        let jobsToStart = [];
+
+        jobs.forEach((job) => {
             const enabled = job.state === 'ENABLED';
             const requires = job.permutations.requires;
             const isJobName = joi.validate(startFrom, jobConfigSchema.jobname);
             const isTrigger = joi.validate(startFrom, jobConfigSchema.trigger);
 
-            return enabled && (
-                (!isJobName.error && startFrom === job.name) ||                 // if startFrom is a jobname, then start that job
-                (!isTrigger.error && requires && requires.includes(startFrom))  // if startFrom is a trigger, then start if requires includes that key
-            );
+            if (enabled) {
+                // if startFrom is a jobname, then start that job
+                if (!isJobName.error && startFrom === job.name) {
+                    jobsToStart.push(job);
+                // if startFrom is a trigger (example: ~commit, ~pr) then start jobs that include that key
+                } else if (!isTrigger.error && requires && requires.includes(startFrom)) {
+                    const prJobName = `PR-${config.prNum}-${job.name}`;
+                    const prJobIndex = jobNamesArray.indexOf(prJobName);
+
+                    // if startFrom is not ~pr, or if ~pr and PR job already exists
+                    if (startFrom !== '~pr' || prJobIndex >= 0) {
+                        jobsToStart.push(job);
+                    } else {
+                        // PR job doesn't exist yet, need to create the job
+                        jobsToCreate.push(createJob(job, prJobName));
+                    }
+                }
+            }
         });
 
-        if (jobsToStart.length > 0) {
-            return Promise.all(jobsToStart.map(j =>
-                buildFactory.create(Object.assign({ jobId: j.id, eventId }, config))
-            ));
-        }
+        return Promise.all(jobsToCreate)
+            .then((newJobs) => {
+                jobsToStart = jobsToStart.concat(newJobs);
 
-        // No jobs to start (For example: job are disabled, or startFrom is not valid)
-        return Promise.reject(new Error('No jobs to start'));
+                // No jobs to start (For example: job are disabled, or startFrom is not valid)
+                if (jobsToStart.length <= 0) {
+                    return Promise.reject(new Error('No jobs to start'));
+                }
+
+                return Promise.all(jobsToStart.map(j =>
+                    buildFactory.create(Object.assign({ jobId: j.id, eventId }, config))
+                ));
+            });
     });
 }
 

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -38,7 +38,7 @@ class JobFactory extends BaseFactory {
      * @param  {Object}    config               Config object
      * @param  {String}    config.pipelineId    The pipeline that the job belongs to
      * @param  {String}    config.name          The job name
-     * @param  {Array}     config.containers    List of container image names
+     * @param  {Array}     config.permutations  Array of configurations of the job
      * @return {Promise}
      */
     create(config) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -201,7 +201,7 @@ class PipelineModel extends BaseModel {
     /**
      * Sync PR by looking up the PR's screwdriver.yaml
      * Update the permutations to be correct
-     * @param   {Integer}   prNum        PR Number
+     * @param   {Number}   prNum        PR Number
      * @method syncPR
      * @return {Promise}
      */

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -255,6 +255,7 @@ class PipelineModel extends BaseModel {
             // get list of jobs to create
             .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;
+                this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 
                 return this.update()

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.10.0",
-    "screwdriver-data-schema": "^18.3.0"
+    "screwdriver-data-schema": "^18.4.0",
+    "screwdriver-workflow-parser": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.10.0",
-    "screwdriver-data-schema": "^18.0.0"
+    "screwdriver-data-schema": "^18.3.0"
   }
 }

--- a/test/data/parser.json
+++ b/test/data/parser.json
@@ -86,14 +86,12 @@
             { "name": "~pr" },
             { "name": "~commit" },
             { "name": "main" },
-            { "name": "foo" },
-            { "name": "bar" }
+            { "name": "publish" }
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "foo" },
-            { "src": "foo", "dest": "bar" }
+            { "src": "main", "dest": "publish" }
         ]
     },
     "annotations": {

--- a/test/data/parser.json
+++ b/test/data/parser.json
@@ -81,6 +81,21 @@
         "main",
         "publish"
     ],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "foo" },
+            { "name": "bar" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "foo" },
+            { "src": "foo", "dest": "bar" }
+        ]
+    },
     "annotations": {
         "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
     }

--- a/test/data/parserWithWorkflowGraph.json
+++ b/test/data/parserWithWorkflowGraph.json
@@ -1,0 +1,98 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "4"
+                }
+            },
+            {
+                "image": "node:5",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "5"
+                }
+            },
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "6"
+                }
+            }
+        ],
+        "publish": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "bump",
+                        "command": "npm run bump"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish --tag $NODE_TAG"
+                    },
+                    {
+                        "name": "tag",
+                        "command": "git push origin --tags"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_TAG": "latest"
+                }
+            }
+        ]
+    },
+    "workflow": [],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" },
+            { "src": "~pr", "dest": "publish" }
+        ]
+    },
+    "annotations": {
+        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
+    }
+}

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -3,7 +3,7 @@
 const assert = require('chai').assert;
 const sinon = require('sinon');
 const mockery = require('mockery');
-const PARSED_YAML = require('../data/parser');
+const PARSED_YAML = require('../data/parserWithWorkflowGraph');
 
 sinon.assert.expose(assert, { prefix: '' });
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -334,6 +334,7 @@ describe('Event Factory', () => {
                     assert.calledOnce(pipelineMock.sync);
                     assert.calledOnce(syncedPipelineMock.syncPR);
                     assert.calledWith(syncedPipelineMock.syncPR, '1');
+                    assert.strictEqual(syncedPipelineMock.lastEventId, null);
                 });
             });
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -260,29 +260,6 @@ describe('Pipeline Model', () => {
             };
         });
 
-        it('stores workflow graph to pipeline', () => {
-            jobs = [];
-            jobFactoryMock.list.resolves(jobs);
-            jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
-            jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
-
-            return pipeline.sync().then(() => {
-                assert.deepEqual(pipeline.workflowGraph, {
-                    nodes: [
-                        { name: '~pr' },
-                        { name: '~commit' },
-                        { name: 'main' },
-                        { name: 'publish' }
-                    ],
-                    edges: [
-                        { src: '~pr', dest: 'main' },
-                        { src: '~commit', dest: 'main' },
-                        { src: 'main', dest: 'publish' }
-                    ]
-                });
-            });
-        });
-
         it('stores workflow to pipeline', () => {
             jobs = [];
             jobFactoryMock.list.resolves(jobs);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -260,6 +260,31 @@ describe('Pipeline Model', () => {
             };
         });
 
+        it('stores workflow graph to pipeline', () => {
+            jobs = [];
+            jobFactoryMock.list.resolves(jobs);
+            jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
+            jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
+
+            return pipeline.sync().then(() => {
+                assert.deepEqual(pipeline.workflowGraph, {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'main' },
+                        { name: 'foo' },
+                        { name: 'bar' }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'main' },
+                        { src: '~commit', dest: 'main' },
+                        { src: 'main', dest: 'foo' },
+                        { src: 'foo', dest: 'bar' }
+                    ]
+                });
+            });
+        });
+
         it('stores workflow to pipeline', () => {
             jobs = [];
             jobFactoryMock.list.resolves(jobs);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -272,14 +272,12 @@ describe('Pipeline Model', () => {
                         { name: '~pr' },
                         { name: '~commit' },
                         { name: 'main' },
-                        { name: 'foo' },
-                        { name: 'bar' }
+                        { name: 'publish' }
                     ],
                     edges: [
                         { src: '~pr', dest: 'main' },
                         { src: '~commit', dest: 'main' },
-                        { src: 'main', dest: 'foo' },
-                        { src: 'foo', dest: 'bar' }
+                        { src: 'main', dest: 'publish' }
                     ]
                 });
             });


### PR DESCRIPTION
eventFactory now takes in a new field `startFrom`, it will create corresponding builds as well. 

For example:
startFrom = `main` then the `main` job will be started
startFrom = `~pr` then all the jobs that have `requires: ['~pr']` will be started

With this change, we will also get partial events. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/723
Blocked by: https://github.com/screwdriver-cd/config-parser/pull/48