### PR TITLE
feat: sync PRs with new format

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -4,9 +4,15 @@
 
 const BaseModel = require('./base');
 const parser = require('screwdriver-config-parser');
+const workflowParser = require('screwdriver-workflow-parser');
 const hoek = require('hoek');
+const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
 const PAGINATE_PAGE = 1;
 const PAGINATE_COUNT = 50;
+const REGEX_CAPTURING_GROUP = {
+    pr: 1, // PR-1
+    job: 2 // main or undefined if using legacy
+};
 
 class PipelineModel extends BaseModel {
     /**
@@ -61,6 +67,17 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Get part of a PR job name based on given type
+     * @method _getPartialJobName
+     * @param  {String}    jobName      Name of a PR job
+     * @param  {String}    type         Type can either be pr or job, e.g. pr => PR-1, job => main
+     * @return {String}                 Substring of a PR job name based on given type
+     */
+    _getPartialJobName(jobName, type) {
+        return jobName.match(PR_JOB_NAME)[REGEX_CAPTURING_GROUP[type]];
+    }
+
+    /**
      * Get a list of PR jobs to create or update
      * @method _checkPRState
      * @param  {Array}    existingJobs      List pipeline's existing jobs
@@ -75,30 +92,33 @@ class PipelineModel extends BaseModel {
             toUnarchive: []
         };
         const existingPRs = existingJobs.filter(j => j.isPR());   // list of PRs according to SD
-        const existingPRsNames = existingPRs.map(j => j.name);
         const openedPRsNames = openedPRs.map(j => j.name);
         const openedPRsRef = openedPRs.map(j => j.ref);
 
         existingPRs.forEach((job) => {
+            // getting PR and number e.g. PR-1
+            // eslint-disable-next-line no-underscore-dangle
+            const prName = this._getPartialJobName(job.name, 'pr');
+
             // if PR is closed, add it to archive list
-            if (openedPRsNames.indexOf(job.name) < 0 && job.archived === false) {
+            if (!openedPRsNames.includes(prName) && !job.archived) {
                 jobList.toArchive.push(job);
             }
         });
 
         openedPRsNames.forEach((name, i) => {
-            const index = existingPRsNames.indexOf(name);
+            const matchedPRs = existingPRs.filter(job => job.name.startsWith(name));
 
-            if (index < 0) {
-                // if opened PR is not in the list of existingPRs, create it
-                jobList.toCreate.push({ name, ref: openedPRsRef[i] });
-            } else {
-                const job = existingPRs[index];
-
-                // if opened PR was previously archived, unarchive it
+            // if opened PR was previously archived, unarchive it
+            matchedPRs.forEach((job) => {
                 if (job.archived) {
-                    jobList.toUnarchive.push(existingPRs[index]);
+                    jobList.toUnarchive.push(job);
                 }
+            });
+
+            // if opened PR is not in the list of existingPRs, create it
+            if (matchedPRs.length === 0) {
+                jobList.toCreate.push({ name, ref: openedPRsRef[i] });
             }
         });
 
@@ -124,13 +144,12 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Go through the list of job names and create it
-     * @method _createJob
-     * @param  {Array}      jobList         Array of job names and refs
-     * @param  {Number}     pipelineId      Pipeline id that the job belongs to
+     * Go through the list of pr names and create pr jobs
+     * @method _createPRJob
+     * @param  {Array}      prList       Array of PR names and refs
      * @return {Promise}
      */
-    _createJob(jobList) {
+    _createPRJob(prList) {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -139,15 +158,25 @@ class PipelineModel extends BaseModel {
 
         const factory = JobFactory.getInstance();
 
-        const jobsToCreate = jobList.map(j =>
-            this.getConfiguration(j.ref).then((config) => {
-                const jobConfig = {
-                    pipelineId: this.id,
-                    name: j.name,
-                    permutations: config.jobs.main
-                };
+        const jobsToCreate = prList.map(pr =>
+            this.getConfiguration(pr.ref).then((config) => {
+                const prJobNames = workflowParser.getNextJobs(config.workflowGraph, {
+                    trigger: '~pr',
+                    prNum: pr.name.split('-')[1]
+                });
 
-                return factory.create(jobConfig);
+                return Promise.all[prJobNames.map((name) => {
+                    // eslint-disable-next-line no-underscore-dangle
+                    const jobName = this._getPartialJobName(name, 'job');
+
+                    const jobConfig = {
+                        pipelineId: this.id,
+                        name,
+                        permutations: config.jobs[jobName]
+                    };
+
+                    return factory.create(jobConfig);
+                })];
             }));
 
         return Promise.all(jobsToCreate);
@@ -190,7 +219,7 @@ class PipelineModel extends BaseModel {
                 const jobList = this._checkPRState(existingJobs, openedPRs);
 
                 return Promise.all([
-                    this._createJob(jobList.toCreate),
+                    this._createPRJob(jobList.toCreate),
                     this._updateJobArchive(jobList.toArchive, true),
                     this._updateJobArchive(jobList.toUnarchive, false)
                 ]);
@@ -206,14 +235,6 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     syncPR(prNum) {
-        // Lazy load factory dependency to prevent circular dependency issues
-        // https://nodejs.org/api/modules.html#modules_cycles
-        /* eslint-disable global-require */
-        const JobFactory = require('./jobFactory');
-        /* eslint-enable global-require */
-
-        const jobFactory = JobFactory.getInstance();
-
         return this.admin
             .then(user => user.unsealToken())
             .then(token => this.scm.getPrInfo({
@@ -224,12 +245,20 @@ class PipelineModel extends BaseModel {
             }))
             .then(prInfo => Promise.all([
                 this.getConfiguration(prInfo.ref),
-                jobFactory.get({ pipelineId: this.id, name: `PR-${prNum}` })
+                this.jobs
             ]))
-            .then(([parsedConfig, job]) => {
-                job.permutations = parsedConfig.jobs.main;
+            .then(([parsedConfig, jobs]) => {
+                const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}`));
 
-                return job.update();
+                return prJobs.map((job) => {
+                    // eslint-disable-next-line no-underscore-dangle
+                    const nameMatched = this._getPartialJobName(job.name, 'job');
+                    const jobName = nameMatched || 'main';
+
+                    job.permutations = parsedConfig.jobs[jobName];
+
+                    return job.update();
+                });
             })
             .then(() => this);
     }
@@ -255,11 +284,24 @@ class PipelineModel extends BaseModel {
             // get list of jobs to create
             .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;
+                this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 
-                return this.update()
-                    .then(() => this.jobs)
-                    // update job list
+                return this.jobs
+                    .then((existingJobs) => {
+                        // Add jobId to workflowGraph.nodes
+                        existingJobs.forEach((job) => {
+                            const nodes = this.workflowGraph.nodes;
+
+                            const idx = nodes.findIndex(n => n.name === job.name);
+
+                            if (idx !== -1) {
+                                nodes[idx].id = job.id;
+                            }
+                        });
+
+                        return this.update().then(() => existingJobs);
+                    })
                     .then((existingJobs) => {
                         const jobsToSync = [];
                         const jobsProcessed = [];

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -252,8 +252,7 @@ class PipelineModel extends BaseModel {
 
                 return prJobs.map((job) => {
                     // eslint-disable-next-line no-underscore-dangle
-                    const nameMatched = this._getPartialJobName(job.name, 'job');
-                    const jobName = nameMatched || 'main';
+                    const jobName = this._getPartialJobName(job.name, 'job') || 'main';
 
                     job.permutations = parsedConfig.jobs[jobName];
 
@@ -287,21 +286,8 @@ class PipelineModel extends BaseModel {
                 this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 
-                return this.jobs
-                    .then((existingJobs) => {
-                        // Add jobId to workflowGraph.nodes
-                        existingJobs.forEach((job) => {
-                            const nodes = this.workflowGraph.nodes;
-
-                            const idx = nodes.findIndex(n => n.name === job.name);
-
-                            if (idx !== -1) {
-                                nodes[idx].id = job.id;
-                            }
-                        });
-
-                        return this.update().then(() => existingJobs);
-                    })
+                return this.update()
+                    .then(() => this.jobs)
                     .then((existingJobs) => {
                         const jobsToSync = [];
                         const jobsProcessed = [];
@@ -342,6 +328,20 @@ class PipelineModel extends BaseModel {
             })
             // wait until all promises have resolved
             .then(jobs => Promise.all(jobs))
+            .then(() => this.jobs.then((updatedJobs) => {
+                // Add jobId to workflowGraph.nodes
+                const nodes = this.workflowGraph.nodes;
+
+                nodes.forEach((node) => {
+                    const job = updatedJobs.find(j => j.name === node.name);
+
+                    if (job) {
+                        node.id = job.id;
+                    }
+                });
+
+                return this.update();
+            }))
             .then(() => this);
     }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.10.0",
-    "screwdriver-data-schema": "^18.0.0"
+    "screwdriver-data-schema": "^18.0.0",
+    "screwdriver-workflow-parser": "^1.1.1"
   }
 }

--- a/test/data/parser.json
+++ b/test/data/parser.json
@@ -81,6 +81,19 @@
         "main",
         "publish"
     ],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main"},
+            { "src": "~commit", "dest": "main"},
+            { "src": "main", "dest": "publish"}
+        ]
+    },
     "annotations": {
         "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
     }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -271,6 +271,42 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('stores workflowGraph to pipeline', () => {
+            jobs = [{
+                update: sinon.stub().resolves(null),
+                isPR: sinon.stub(),
+                id: 1,
+                name: 'main',
+                permutations: ['node:3'],
+                state: 'ENABLED'
+            },
+            {
+                update: sinon.stub().resolves(null),
+                isPR: sinon.stub(),
+                id: 2,
+                name: 'publish',
+                permutations: ['node:3'],
+                state: 'ENABLED'
+            }];
+            jobFactoryMock.list.resolves(jobs);
+
+            return pipeline.sync().then(() => {
+                assert.deepEqual(pipeline.workflowGraph, {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'main', id: 1 },
+                        { name: 'publish', id: 2 }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'main' },
+                        { src: '~commit', dest: 'main' },
+                        { src: 'main', dest: 'publish' }
+                    ]
+                });
+            });
+        });
+
         it('stores annotations to pipeline', () => {
             jobs = [];
             jobFactoryMock.list.resolves(jobs);
@@ -411,7 +447,7 @@ describe('Pipeline Model', () => {
         });
 
         it('update PR config', () => {
-            jobFactoryMock.get.resolves(prJob);
+            jobFactoryMock.list.resolves([prJob]);
 
             return pipeline.syncPR(1).then(() => {
                 assert.calledWith(scmMock.getFile, {
@@ -423,6 +459,39 @@ describe('Pipeline Model', () => {
                 });
                 assert.called(prJob.update);
                 assert.deepEqual(prJob.permutations, PARSED_YAML.jobs.main);
+            });
+        });
+
+        it('update PR config for multiple PR jobs', () => {
+            const firstPRJob = {
+                update: sinon.stub().resolves(null),
+                isPR: sinon.stub().returns(true),
+                name: 'PR-1:main',
+                state: 'ENABLED',
+                archived: false
+            };
+            const secondPRJob = {
+                update: sinon.stub().resolves(null),
+                isPR: sinon.stub().returns(true),
+                name: 'PR-1:publish',
+                state: 'ENABLED',
+                archived: false
+            };
+
+            jobFactoryMock.list.resolves([firstPRJob, secondPRJob]);
+
+            return pipeline.syncPR(1).then(() => {
+                assert.calledWith(scmMock.getFile, {
+                    path: 'screwdriver.yaml',
+                    ref: 'pulls/1/merge',
+                    scmUri,
+                    scmContext,
+                    token: 'foo'
+                });
+                assert.calledOnce(firstPRJob.update);
+                assert.calledOnce(secondPRJob.update);
+                assert.deepEqual(firstPRJob.permutations, PARSED_YAML.jobs.main);
+                assert.deepEqual(secondPRJob.permutations, PARSED_YAML.jobs.publish);
             });
         });
 
@@ -439,7 +508,7 @@ describe('Pipeline Model', () => {
         it('returns error if fails to get PR job', () => {
             const error = new Error('fails to get job');
 
-            jobFactoryMock.get.rejects(error);
+            jobFactoryMock.list.rejects(error);
 
             return pipeline.syncPR(1).catch((err) => {
                 assert.deepEqual(err, error);
@@ -493,7 +562,7 @@ describe('Pipeline Model', () => {
                 .then(() => {
                     assert.calledWith(jobFactoryMock.create, {
                         pipelineId: testId,
-                        name: 'PR-2',
+                        name: 'PR-2:main',
                         permutations: PARSED_YAML.jobs.main
                     });
                 });


### PR DESCRIPTION
- sync PRs with new format, e.g. `PR-1:main`, `PR-1:second`
- store `workflowGraph` in pipeline

Related to https://github.com/screwdriver-cd/screwdriver/issues/723