### PR TITLE
fix: pipeline.getJobs don't sort by workflow if no workflow

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -497,8 +497,8 @@ class PipelineModel extends BaseModel {
 
         return factory.list(listConfig)
             .then((jobs) => {
-                // If archived is true, don't sort and just return jobs
-                if (listConfig.params.archived) {
+                // If using the new config or archived is true, don't sort and just return jobs
+                if (!Array.isArray(workflow) || !workflow.length || listConfig.params.archived) {
                     return jobs;
                 }
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -777,6 +777,30 @@ describe('Pipeline Model', () => {
                 assert.deepEqual(result, [blahJob, publishJob]);
             });
         });
+
+        it('Get jobs without sorting for new workflows', () => {
+            const config = {
+                params: {
+                    archived: false
+                }
+            };
+            const expected = {
+                params: {
+                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    archived: false
+                },
+                paginate
+            };
+            const jobList = [blahJob, publishJob];
+
+            pipeline.workflow = [];
+            jobFactoryMock.list.resolves(jobList);
+
+            return pipeline.getJobs(config).then((result) => {
+                assert.calledWith(jobFactoryMock.list, expected);
+                assert.deepEqual(result, [blahJob, publishJob]);
+            });
+        });
     });
 
     describe('get events', () => {


### PR DESCRIPTION
`pipeline.getJobs` don't sort by workflow if no workflow or length equals to 0. This will be the case for new workflow.