### PR TITLE
fix: call this.update() only once in sync

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -287,8 +287,7 @@ class PipelineModel extends BaseModel {
                 this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 
-                return this.update()
-                    .then(() => this.jobs)
+                return this.jobs
                     .then((existingJobs) => {
                         const jobsToSync = [];
                         const jobsProcessed = [];


### PR DESCRIPTION
After the first `this.update()`, we modified this.workflowGraph.nodes to add `jobId` directly, but that is not through a setter `this.workflowGraph = newWorkflowGraph`, so  during the second `this.update()`, it's not considered dirty and not get stored in the model.

Fixed it by calling `this.update()` only once.