### PR TITLE
fix: force this.jobs to reload after sync

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -340,6 +340,10 @@ class PipelineModel extends BaseModel {
                     }
                 });
 
+                // jobs updated or new jobs created during sync
+                // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
+                delete this.jobs;
+
                 return this.update();
             })
             .then(() => this);
@@ -416,6 +420,7 @@ class PipelineModel extends BaseModel {
         // so we redefine the pipeline property here to resolve to the
         // resulting promise and not try to recreate the factory, etc.
         Object.defineProperty(this, 'jobs', {
+            configurable: true,
             enumerable: true,
             value: jobs
         });


### PR DESCRIPTION
In eventFactory, we called `pipeline.sync()` first and then call `pipeline.jobs`.
https://github.com/screwdriver-cd/models/blob/master/lib/eventFactory.js#L275
https://github.com/screwdriver-cd/models/blob/master/lib/eventFactory.js#L163

This leads to a weird problem that `pipeline.jobs` only contains an old list of jobs. 
That's because we call `this.jobs` inside pipeline `sync()` first, and update/create jobs afterwards. `this.jobs` is set and cached. So eventFactory only gets the old jobs. 

Delete this.jobs will force a DB query when next time `pipeline.jobs` is called.