### PR TITLE
feat(770): support external trigger (rebuild_on)

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,61 @@ factory.get(id).then(model => {
 | :-------------   | :---- | :-------------|
 | id | Number | The unique ID for the Template Tag |
 
+### Trigger Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.TriggerFactory.getInstance({
+    datastore
+});
+const config = {
+    dest: '~sd@123:component',
+    src: '~sd@456:main'
+}
+
+factory.create(config)
+    .then(model => {    // do something
+});
+```
+
+### Trigger Factory
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with trigger model
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.src | String | Yes | The job that initiates the trigger (ex: ~sd@123:component) |
+| config.dest | String | Yes | The job that is triggered (ex: ~sd@456:main) |
+
+#### Get
+Get trigger based on id.
+```js
+factory.get(id).then(model => {
+    // do stuff with trigger model
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | Number | The unique ID for the trigger |
+
+#### List
+List triggers that have dest as `~sd@456:main`
+```js
+// update template version value
+factory.list({
+    params: {
+        dest: '~sd@456:main'
+    }
+}).then(recs => 
+    // do things with the records 
+);
+```
 ### Token Factory
 #### Search
 ```js

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const SecretFactory = require('./lib/secretFactory');
 const TemplateFactory = require('./lib/templateFactory');
 const TemplateTagFactory = require('./lib/templateTagFactory');
 const TokenFactory = require('./lib/tokenFactory');
+const TriggerFactory = require('./lib/triggerFactory');
 const UserFactory = require('./lib/userFactory');
 
 module.exports = {
@@ -21,5 +22,6 @@ module.exports = {
     TemplateFactory,
     TemplateTagFactory,
     TokenFactory,
+    TriggerFactory,
     UserFactory
 };

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -335,11 +335,11 @@ class PipelineModel extends BaseModel {
                         const triggersToSync = [];
                         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
                         const pipelineId = this.id;
-                        let requiresList = [];
 
                         // Loop through all existing jobs
                         existingJobs.forEach((job) => {
                             const jobName = job.name;
+                            let requiresList = [];
 
                             // if it's in the yaml, update it
                             if (parsedConfigJobNames.includes(jobName)) {
@@ -374,17 +374,17 @@ class PipelineModel extends BaseModel {
                                 name: jobName,
                                 permutations
                             };
+                            const requiresList = permutations[0].requires || [];
 
                             // If the job has not been processed, create it (new jobs)
                             if (!jobsProcessed.includes(jobName)) {
                                 jobsToSync.push(factory.create(jobConfig));
 
                                 // sync external triggers for new jobs
-                                requiresList = permutations[0].requires;
                                 triggersToSync.push(syncExternalTriggers({
                                     pipelineId: this.id,
                                     jobName,
-                                    requiresList: requiresList || []
+                                    requiresList
                                 }));
                             }
                         });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -6,13 +6,54 @@ const BaseModel = require('./base');
 const parser = require('screwdriver-config-parser');
 const workflowParser = require('screwdriver-workflow-parser');
 const hoek = require('hoek');
-const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
+const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const PAGINATE_PAGE = 1;
 const PAGINATE_COUNT = 50;
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
     job: 2 // main or undefined if using legacy
 };
+
+/**
+ * Sync external triggers
+ * Remove the trigger if the job is no longer in yaml, or if the src is no longer in 'requires'
+ * Add the trigger src is in 'requires' and was not in the database yet
+ * @method syncExternalTriggers
+ * @param  {Object}     config              config
+ * @param  {Number}     config.pipelineId   pipelineId belongs to this job
+ * @param  {String}     config.jobName      name of the job
+ * @param  {Array}      config.requiresList requires value of this job
+ * @return {Promise}
+ */
+function syncExternalTriggers(config) {
+    // Lazy load factory dependency to prevent circular dependency issues
+    // https://nodejs.org/api/modules.html#modules_cycles
+    /* eslint-disable global-require */
+    const TriggerFactory = require('./triggerFactory');
+    /* eslint-enable global-require */
+
+    const triggerFactory = TriggerFactory.getInstance();
+    const newSrcList = config.requiresList;
+    const dest = `~sd@${config.pipelineId}:${config.jobName}`;
+    const processed = [];
+
+    // list records that would trigger this job
+    return triggerFactory.list({ params: { dest } })
+    .then((records) => {
+        // if the src is not in the new src list, then remove it
+        const toRemove = records.filter(rec => !newSrcList.includes(rec.src));
+
+        // if the src is not in the old src list, then create in datastore
+        const oldSrcList = records.map(r => r.src); // get the old src list
+        const toCreate = newSrcList.filter(src =>
+          !oldSrcList.includes(src) && EXTERNAL_TRIGGER.test(src));
+
+        toRemove.forEach(rec => processed.push(rec.remove()));
+        toCreate.forEach(src => processed.push(triggerFactory.create({ src, dest })));
+
+        return Promise.all(processed);
+    });
+}
 
 class PipelineModel extends BaseModel {
     /**
@@ -291,43 +332,68 @@ class PipelineModel extends BaseModel {
                     .then((existingJobs) => {
                         const jobsToSync = [];
                         const jobsProcessed = [];
+                        const triggersToSync = [];
                         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
+                        const pipelineId = this.id;
+                        let requiresList = [];
 
                         // Loop through all existing jobs
                         existingJobs.forEach((job) => {
+                            const jobName = job.name;
+
                             // if it's in the yaml, update it
-                            if (parsedConfigJobNames.includes(job.name)) {
-                                job.permutations = parsedConfig.jobs[job.name];
+                            if (parsedConfigJobNames.includes(jobName)) {
+                                const permutations = parsedConfig.jobs[jobName];
+
+                                requiresList = permutations[0].requires || [];
+                                job.permutations = permutations;
                                 job.archived = false;
                                 jobsToSync.push(job.update());
-                            // if it's not in the yaml and archive it
+                            // if it's not in the yaml then archive it
                             } else if (!job.isPR()) {
                                 job.archived = true;
                                 jobsToSync.push(job.update());
                             }
+
+                            // sync external triggers for existing jobs
+                            triggersToSync.push(syncExternalTriggers({
+                                pipelineId,
+                                jobName,
+                                requiresList
+                            }));
+
                             // if it's a PR, leave it alone
                             jobsProcessed.push(job.name);
                         });
 
                         // Loop through all defined jobs in the yaml
                         Object.keys(parsedConfig.jobs).forEach((jobName) => {
+                            const permutations = parsedConfig.jobs[jobName];
                             const jobConfig = {
-                                pipelineId: this.id,
+                                pipelineId,
                                 name: jobName,
-                                permutations: parsedConfig.jobs[jobName]
+                                permutations
                             };
 
-                            // If the job has not been processed, create it
+                            // If the job has not been processed, create it (new jobs)
                             if (!jobsProcessed.includes(jobName)) {
                                 jobsToSync.push(factory.create(jobConfig));
+
+                                // sync external triggers for new jobs
+                                requiresList = permutations[0].requires;
+                                triggersToSync.push(syncExternalTriggers({
+                                    pipelineId: this.id,
+                                    jobName,
+                                    requiresList: requiresList || []
+                                }));
                             }
                         });
 
-                        return jobsToSync;
+                        return Promise.all(triggersToSync)
+                        .then(() => Promise.all(jobsToSync));
                     });
             })
             // wait until all promises have resolved
-            .then(jobs => Promise.all(jobs))
             .then((updatedJobs) => {
                 // Add jobId to workflowGraph.nodes
                 const nodes = this.workflowGraph.nodes;

--- a/lib/trigger.js
+++ b/lib/trigger.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BaseModel = require('./base');
+
+class TriggerModel extends BaseModel {
+    /**
+     * Construct a TriggerModel object
+     * @method constructor
+     * @param  {Object}    config
+     * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {Number}    config.pipelineId    The pipeline Id
+     * @param  {String}    config.jobName       The job's name
+     * @param  {String}    config.trigger       The triggered job in the pipelineId:jobName format. Example: 12345:main
+     */
+    constructor(config) {
+        super('trigger', config);
+    }
+
+}
+
+module.exports = TriggerModel;

--- a/lib/trigger.js
+++ b/lib/trigger.js
@@ -8,9 +8,8 @@ class TriggerModel extends BaseModel {
      * @method constructor
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
-     * @param  {Number}    config.pipelineId    The pipeline Id
-     * @param  {String}    config.jobName       The job's name
-     * @param  {String}    config.trigger       The triggered job in the pipelineId:jobName format. Example: 12345:main
+     * @param  {String}    config.src           Job that initiates the trigger
+     * @param  {String}    config.dest          Job that is triggered
      */
     constructor(config) {
         super('trigger', config);

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const Trigger = require('./trigger');
+let instance;
+
+class TriggerFactory extends BaseFactory {
+    /**
+     * Construct a TriggerFactory object
+     * @method constructor
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('trigger', config);
+    }
+
+    /**
+     * Instantiate a Trigger class
+     * @method createClass
+     * @param  {Object}     config               Trigger data
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     * @param  {Number}     config.pipelineId    The pipeline Id
+     * @param  {String}     config.jobName       The job's name
+     * @param  {String}     config.trigger       The triggered job in the pipelineId:jobName format. Example: 12345:main
+     * @return {Trigger}
+     */
+    createClass(config) {
+        return new Trigger(config);
+    }
+
+    /**
+     * Get an instance of the TriggerFactory
+     * @method getInstance
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore
+     * @return {TriggerFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(TriggerFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = TriggerFactory;

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -20,7 +20,7 @@ class TriggerFactory extends BaseFactory {
      * @method createClass
      * @param  {Object}     config               Trigger data
      * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
-     * @param  {Number}     config.src           Job that initiates the trigger
+     * @param  {String}     config.src           Job that initiates the trigger
      * @param  {String}     config.dest          Job that is triggered
      * @return {Trigger}
      */

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -20,9 +20,8 @@ class TriggerFactory extends BaseFactory {
      * @method createClass
      * @param  {Object}     config               Trigger data
      * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
-     * @param  {Number}     config.pipelineId    The pipeline Id
-     * @param  {String}     config.jobName       The job's name
-     * @param  {String}     config.trigger       The triggered job in the pipelineId:jobName format. Example: 12345:main
+     * @param  {Number}     config.src           Job that initiates the trigger
+     * @param  {String}     config.dest          Job that is triggered
      * @return {Trigger}
      */
     createClass(config) {

--- a/test/data/parserWithRequires.json
+++ b/test/data/parserWithRequires.json
@@ -1,0 +1,101 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "4"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            },
+            {
+                "image": "node:5",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "5"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            },
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "6"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            }
+        ],
+        "publish": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "bump",
+                        "command": "npm run bump"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish --tag $NODE_TAG"
+                    },
+                    {
+                        "name": "tag",
+                        "command": "git push origin --tags"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_TAG": "latest"
+                },
+                "requires": ["main"]
+            }
+        ]
+    },
+    "workflow": [],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" }
+        ]
+    },
+    "annotations": {
+        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
+    }
+}

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -422,6 +422,14 @@ describe('Event Factory', () => {
                 });
             })
         );
+
+        it('use username as displayName if displayLabel is not set', () => {
+            scm.getDisplayName.returns(null);
+
+            return factory.create(config).then((model) => {
+                assert.equal(model.causeMessage, 'Started by stjohn');
+            });
+        });
     });
 
     describe('getInstance', () => {

--- a/test/lib/trigger.test.js
+++ b/test/lib/trigger.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const mockery = require('mockery');
+const schema = require('screwdriver-data-schema');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Trigger Model', () => {
+    let BaseModel;
+    let TriggerModel;
+    let datastore;
+    let createConfig;
+    let trigger;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            update: sinon.stub()
+        };
+
+        // eslint-disable-next-line global-require
+        BaseModel = require('../../lib/base');
+
+        // eslint-disable-next-line global-require
+        TriggerModel = require('../../lib/trigger');
+
+        createConfig = {
+            datastore,
+            id: 1111,
+            pipelineId: 12345,
+            jobName: 'component',
+            trigger: '5678:main'
+        };
+        trigger = new TriggerModel(createConfig);
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
+        assert.instanceOf(trigger, TriggerModel);
+        assert.instanceOf(trigger, BaseModel);
+        schema.models.secret.allKeys.forEach((key) => {
+            assert.strictEqual(trigger[key], createConfig[key]);
+        });
+    });
+});

--- a/test/lib/trigger.test.js
+++ b/test/lib/trigger.test.js
@@ -35,9 +35,8 @@ describe('Trigger Model', () => {
         createConfig = {
             datastore,
             id: 1111,
-            pipelineId: 12345,
-            jobName: 'component',
-            trigger: '5678:main'
+            src: '~sd@12345:component',
+            dest: '~sd@5678:main'
         };
         trigger = new TriggerModel(createConfig);
     });

--- a/test/lib/triggerFactory.test.js
+++ b/test/lib/triggerFactory.test.js
@@ -7,13 +7,11 @@ const sinon = require('sinon');
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('Trigger Factory', () => {
-    const pipelineId = 12345;
-    const jobName = 'component';
-    const trigger = '5678:main';
+    const src = '~sd@12345:component';
+    const dest = '~sd@5678:main';
     const metaData = {
-        pipelineId,
-        jobName,
-        trigger
+        src,
+        dest
     };
     let TriggerFactory;
     let datastore;
@@ -67,9 +65,8 @@ describe('Trigger Factory', () => {
         beforeEach(() => {
             expected = {
                 id: generatedId,
-                pipelineId,
-                jobName,
-                trigger
+                src,
+                dest
             };
         });
 
@@ -77,9 +74,8 @@ describe('Trigger Factory', () => {
             datastore.save.resolves(expected);
 
             return factory.create({
-                pipelineId,
-                jobName,
-                trigger
+                src,
+                dest
             }).then((model) => {
                 assert.instanceOf(model, Trigger);
                 Object.keys(expected).forEach((key) => {

--- a/test/lib/triggerFactory.test.js
+++ b/test/lib/triggerFactory.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Trigger Factory', () => {
+    const pipelineId = 12345;
+    const jobName = 'component';
+    const trigger = '5678:main';
+    const metaData = {
+        pipelineId,
+        jobName,
+        trigger
+    };
+    let TriggerFactory;
+    let datastore;
+    let factory;
+    let Trigger;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            get: sinon.stub(),
+            scan: sinon.stub()
+        };
+
+        // eslint-disable-next-line global-require
+        Trigger = require('../../lib/trigger');
+        // eslint-disable-next-line global-require
+        TriggerFactory = require('../../lib/triggerFactory');
+
+        factory = new TriggerFactory({ datastore });
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a Trigger model', () => {
+            const model = factory.createClass(metaData);
+
+            assert.instanceOf(model, Trigger);
+        });
+    });
+
+    describe('create', () => {
+        const generatedId = 1234135;
+        let expected;
+
+        beforeEach(() => {
+            expected = {
+                id: generatedId,
+                pipelineId,
+                jobName,
+                trigger
+            };
+        });
+
+        it('creates a Trigger given pipelineId, jobName, and trigger', () => {
+            datastore.save.resolves(expected);
+
+            return factory.create({
+                pipelineId,
+                jobName,
+                trigger
+            }).then((model) => {
+                assert.instanceOf(model, Trigger);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+        });
+
+        it('should get an instance', () => {
+            const f1 = TriggerFactory.getInstance(config);
+            const f2 = TriggerFactory.getInstance(config);
+
+            assert.instanceOf(f1, TriggerFactory);
+            assert.instanceOf(f2, TriggerFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(TriggerFactory.getInstance,
+                Error, 'No datastore provided to TriggerFactory');
+        });
+    });
+});

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -34,7 +34,8 @@ describe('User Model', () => {
             save: sinon.stub()
         };
         scmMock = {
-            getPermissions: sinon.stub()
+            getPermissions: sinon.stub(),
+            getDisplayName: sinon.stub()
         };
         hashaMock = {
             sha1: sinon.stub()
@@ -191,6 +192,16 @@ describe('User Model', () => {
                 .catch((err) => {
                     assert.deepEqual(err, expectedError);
                 });
+        });
+    });
+
+    describe('getFullDisplayName', () => {
+        it('get full display name', () => {
+            scmMock.getDisplayName.withArgs({ scmContext }).returns('github.com');
+
+            const userDisplayName = user.getFullDisplayName();
+
+            assert.deepEqual(userDisplayName, 'github.com:me');
         });
     });
 


### PR DESCRIPTION
This PR creates Trigger Factory, Trigger Model, and Sync external triggers. 
There are a couple scenarios:
- For an existing job: if job is not in the yaml anymore, requireList = []; if job is still in yaml, requireList = requires value of that job config
- It is a new job: requireList = requires value of that job config

For syncExternalTrigger: list triggers that has `dest` as the current job. If the record is not in the new requireList, then remove it. If the requireList has new values that are not currently in the database, then create it. 

Blocked by: https://github.com/screwdriver-cd/data-schema/pull/190
Related: https://github.com/screwdriver-cd/screwdriver/issues/770