### PR TITLE
fix(770): External trigger should start one event

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -2,6 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
+const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 
 let instance;
@@ -38,20 +39,21 @@ function splitPRJobs(config) {
 }
 
 /**
- * Get commit jobs to start that are enabled
- * @method getJobsFromCommit
+ * Get triggered jobs to start that are enabled
+ * @method getJobsFromTrigger
  * @param  {Object}   config
  * @param  {Array}    config.jobs                           Array of job objects
  * @param  {Object}   config.pipelineConfig
  * @param  {Array}    [config.pipelineConfig.workflow]      Order of jobs to be run
  * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
- * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
+ * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, ~sd@123:main, etc)
  * @return {Array}                                          Array of commit jobs to start
  */
-function getJobsFromCommit(config) {
+function getJobsFromTrigger(config) {
     const { jobs, pipelineConfig, startFrom } = config;
+    const isTrigger = EXTERNAL_TRIGGER.test(startFrom);
 
-    if (startFrom !== '~commit') {
+    if (startFrom !== '~commit' && !isTrigger) {
         return [];
     }
 
@@ -162,7 +164,7 @@ function createBuilds(config) {
 
     return pipeline.jobs.then((jobs) => {
         // When startFrom is ~commit
-        const jobsFromCommit = getJobsFromCommit({
+        const jobsFromTrigger = getJobsFromTrigger({
             jobs,
             pipelineConfig,
             startFrom
@@ -182,7 +184,7 @@ function createBuilds(config) {
             startFrom
         });
 
-        return Promise.all([jobsFromCommit, jobsFromJobName, jobsFromPR])
+        return Promise.all([jobsFromTrigger, jobsFromJobName, jobsFromPR])
         .then(result => result.reduce((a, b) => a.concat(b)));
     })
     .then((jobsToStart) => {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -142,9 +142,11 @@ describe('Event Factory', () => {
                         { name: '~commit' },
                         { name: 'main' },
                         { name: 'disabledJob' },
-                        { name: 'publish' }
+                        { name: 'publish' },
+                        { name: '~sd@123:main' }
                     ],
                     edges: [
+                        { src: '~sd@123:main', dest: 'main' },
                         { src: '~pr', dest: 'main' },
                         { src: '~commit', dest: 'main' },
                         { src: 'main', dest: 'disabledJob' },
@@ -170,9 +172,11 @@ describe('Event Factory', () => {
                         { name: '~commit' },
                         { name: 'main' },
                         { name: 'disabledJob' },
-                        { name: 'publish' }
+                        { name: 'publish' },
+                        { name: '~sd@123:main' }
                     ],
                     edges: [
+                        { src: '~sd@123:main', dest: 'main' },
                         { src: '~pr', dest: 'main' },
                         { src: '~commit', dest: 'main' },
                         { src: 'main', dest: 'disabledJob' },
@@ -203,7 +207,7 @@ describe('Event Factory', () => {
                     pipelineId: 8765,
                     name: 'main',
                     permutations: {
-                        requires: ['~commit', '~pr']
+                        requires: ['~commit', '~pr', '~sd@123:main']
                     },
                     state: 'ENABLED'
                 }, {
@@ -340,6 +344,21 @@ describe('Event Factory', () => {
 
             it('should create commit builds', () => {
                 config.startFrom = '~commit';
+
+                return factory.create(config).then((model) => {
+                    assert.instanceOf(model, Event);
+                    assert.notCalled(jobFactoryMock.create);
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        eventId: model.id,
+                        jobId: 1
+                    }));
+                    assert.calledOnce(pipelineMock.sync);
+                    assert.notCalled(syncedPipelineMock.syncPR);
+                });
+            });
+
+            it('should create triggered builds', () => {
+                config.startFrom = '~sd@123:main';
 
                 return factory.create(config).then((model) => {
                     assert.instanceOf(model, Event);


### PR DESCRIPTION
Currently, an external trigger will start different events for each job that requires an external trigger.

This PR passes along the entire external trigger as a `startFrom` so one event can be created.

Related to https://github.com/screwdriver-cd/screwdriver/pull/779