### PR TITLE
fix: create PR jobs when new jobs added to the config in PR

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -16,7 +16,7 @@ let instance;
  * @param  {Array}     config.jobs      PR jobs
  * @param  {Array}     config.nextJobs  PR job names to trigger next
  * @param  {Number}    config.prNum     PR number
- * @return {Object}                     Object with jobsToStart array and jobsToCreate array
+ * @return {Object}                     Object with jobsToStart array of job object and jobsToCreate array of jobName
  */
 function splitPRJobs(config) {
     const { jobs, nextJobs, prNum } = config;
@@ -30,11 +30,10 @@ function splitPRJobs(config) {
     const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
     // Get the job name part, e.g. main from PR-1:main
     const missingJobNames = missingPRJobNames.map(name => name.split(':')[1]);
-    const missingJobs = jobs.filter(j => missingJobNames.includes(j.name));
 
     return {
         jobsToStart,
-        jobsToCreate: missingJobs
+        jobsToCreate: missingJobNames
     };
 }
 
@@ -108,7 +107,7 @@ function getJobsFromPR(config) {
         trigger: startFrom,
         prNum
     });
-    // Get jobs to start and create
+    // Get jobs to start and jobNames to create
     const { jobsToStart, jobsToCreate } = splitPRJobs({
         jobs,
         nextJobs,
@@ -116,12 +115,12 @@ function getJobsFromPR(config) {
     });
 
     // Create missing PR jobs
-    return Promise.all(jobsToCreate.map(j =>
+    return Promise.all(jobsToCreate.map(jobName =>
         // Create jobs
         jobFactory.create({
-            permutations: pipelineConfig.jobs[j.name],
+            permutations: pipelineConfig.jobs[jobName],
             pipelineId: pipeline.id,
-            name: `PR-${prNum}:${j.name}`
+            name: `PR-${prNum}:${jobName}`
         })))
     // Add newly created PR jobs to jobsToStart array
     .then(newJobs => jobsToStart.concat(newJobs));

--- a/test/data/parserWithWorkflowGraphPR.json
+++ b/test/data/parserWithWorkflowGraphPR.json
@@ -1,0 +1,61 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "4"
+                }
+            }
+        ],
+        "new_main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "bump",
+                        "command": "npm run bump"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish --tag $NODE_TAG"
+                    },
+                    {
+                        "name": "tag",
+                        "command": "git push origin --tags"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_TAG": "latest"
+                }
+            }
+        ]
+    },
+    "workflow": [],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "new_main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "~pr", "dest": "new_main" },
+            { "src": "~commit", "dest": "new_main" }
+        ]
+    }
+}

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -4,6 +4,7 @@ const assert = require('chai').assert;
 const sinon = require('sinon');
 const mockery = require('mockery');
 const PARSED_YAML = require('../data/parserWithWorkflowGraph');
+const PARSED_YAML_PR = require('../data/parserWithWorkflowGraphPR');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -301,17 +302,19 @@ describe('Event Factory', () => {
                     id: 5,
                     name: 'PR-1:main'
                 };
-                const prPublish = {
+                const prNewMain = {
                     id: 6,
-                    name: 'PR-1:publish'
+                    name: 'PR-1:new_main'
                 };
 
                 jobFactoryMock.create.onCall(0).resolves(prComponent);
-                jobFactoryMock.create.onCall(1).resolves(prPublish);
+                jobFactoryMock.create.onCall(1).resolves(prNewMain);
                 config.startFrom = '~pr';
                 config.prRef = 'branch';
                 config.prNum = '1';
                 config.type = 'pr';
+                // Return config in PR with new job named new_main
+                syncedPipelineMock.getConfiguration.withArgs(config.prRef).resolves(PARSED_YAML_PR);
 
                 return factory.create(config).then((model) => {
                     assert.instanceOf(model, Event);
@@ -322,7 +325,7 @@ describe('Event Factory', () => {
                     }));
                     assert.calledWith(jobFactoryMock.create.secondCall, sinon.match({
                         pipelineId: 8765,
-                        name: 'PR-1:publish'
+                        name: 'PR-1:new_main'
                     }));
                     assert.calledTwice(buildFactoryMock.create);
                     assert.calledWith(buildFactoryMock.create.firstCall, sinon.match({


### PR DESCRIPTION
Removing  `const missingJobs = jobs.filter(j => missingJobNames.includes(j.name));`

We are only using `missingJobs.name` in the following calls. So there is no need to get the job objects. And this is giving side effect that when user adds a new job in PR, e.g. `new_main` and requires `~pr`, that PR job won't be created because it's filtered out by the above line. 