### PR TITLE
fix(771): allow meta to be passed externally

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -145,13 +145,14 @@ class BuildFactory extends BaseFactory {
     /**
      * Create a new Build
      * @method create
-     * @param  {Object}    config                Config object
-     * @param  {String}    config.eventId        The eventId that this build belongs to
-     * @param  {String}    config.jobId          The job associated with this build
-     * @param  {String}    config.username       The user that created this build
-     * @param  {String}    config.scmContext     The scm context to which user belongs
-     * @param  {String}    [config.sha]          The sha of the build
-     * @param  {String}    [config.prRef]        The PR branch or reference
+     * @param  {Object}    config                   Config object
+     * @param  {String}    config.eventId           The eventId that this build belongs to
+     * @param  {String}    config.jobId             The job associated with this build
+     * @param  {String}    config.username          The user that created this build
+     * @param  {String}    config.scmContext        The scm context to which user belongs
+     * @param  {String}    [config.sha]             The sha of the build
+     * @param  {String}    [config.prRef]           The PR branch or reference
+     * @param  {String}    [config.parentBuildId]   Id of the build that triggers this build
      * @return {Promise}
      */
     create(config) {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -139,6 +139,8 @@ function getJobsFromPR(config) {
  * @param  {Number}   [config.eventConfig.prNum]             PR number if it's a PR event
  * @param  {String}   [config.eventConfig.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
  *                                                           (Optional for backwards compatibility)
+ * @param  {String}   [config.eventConfig.causeMessage]      Message that describes why the event was created
+ * @param  {String}   [config.parentBuildId]                 Id of the build that starts this event
  * @param  {Number}   config.eventId                         Event id
  * @param  {Pipeline} config.pipeline                        Pipeline to create builds
  * @param  {Object}   config.pipelineConfig
@@ -260,6 +262,7 @@ class EventFactory extends BaseFactory {
      * @param  {String}  [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
      *                                              Optional for backwards compatibility
      * @param  {String}  [config.causeMessage]      Message that describes why the event was created
+     * @param  {String}  [config.parentBuildId]     Id of the build that starts this event
      * @return {Promise}
      */
     create(config) {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -216,6 +216,7 @@ describe('Build Factory', () => {
                 table: 'builds',
                 params: {
                     eventId,
+                    parentBuildId: 12345,
                     cause: 'Started by user github:i_made_the_request',
                     commit,
                     createTime: isoTime,
@@ -246,19 +247,19 @@ describe('Build Factory', () => {
             userFactoryMock.get.resolves(user);
             delete saveConfig.params.commit;
 
-            return factory.create({ garbage, username, jobId, eventId, sha }).then(() => {
-                assert.calledWith(datastore.save, saveConfig);
-            });
+            return factory.create({
+                garbage, username, jobId, eventId, sha, parentBuildId: 12345
+            }).then(() => assert.calledWith(datastore.save, saveConfig));
         });
 
         it('use username as displayName if displayLabel is not set', () => {
             scmMock.getDisplayName.returns(null);
             saveConfig.params.cause = 'Started by user i_made_the_request';
             delete saveConfig.params.commit;
+            delete saveConfig.params.parentBuildId;
 
-            return factory.create({ username, jobId, eventId, sha }).then(() => {
-                assert.calledWith(datastore.save, saveConfig);
-            });
+            return factory.create({ username, jobId, eventId, sha }).then(() =>
+                assert.calledWith(datastore.save, saveConfig));
         });
 
         it('creates a new build in the datastore, looking up sha', () => {
@@ -271,7 +272,9 @@ describe('Build Factory', () => {
             jobFactoryMock.get.resolves(jobMock);
             userFactoryMock.get.resolves(user);
 
-            return factory.create({ username, scmContext, jobId, eventId, prRef }).then((model) => {
+            return factory.create({
+                username, scmContext, jobId, eventId, prRef, parentBuildId: 12345
+            }).then((model) => {
                 assert.instanceOf(model, Build);
                 assert.calledOnce(jobFactory.getInstance);
                 assert.calledWith(jobFactoryMock.get, jobId);
@@ -336,6 +339,7 @@ describe('Build Factory', () => {
 
             jobFactoryMock.get.resolves(jobMock);
             delete saveConfig.params.commit;
+            delete saveConfig.params.parentBuildId;
 
             return factory.create({ username, jobId, eventId, sha }).then((model) => {
                 assert.calledWith(datastore.save, saveConfig);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -130,6 +130,7 @@ describe('Event Factory', () => {
                 pipelineId,
                 sha,
                 username: 'stjohn',
+                parentBuildId: 12345,
                 scmContext
             };
             expected = {
@@ -288,6 +289,7 @@ describe('Event Factory', () => {
                     assert.notCalled(jobFactoryMock.create);
                     assert.calledOnce(buildFactoryMock.create);
                     assert.calledWith(buildFactoryMock.create.firstCall, sinon.match({
+                        parentBuildId: 12345,
                         eventId: model.id,
                         jobId: 5,
                         prRef: 'branch'
@@ -329,11 +331,13 @@ describe('Event Factory', () => {
                     }));
                     assert.calledTwice(buildFactoryMock.create);
                     assert.calledWith(buildFactoryMock.create.firstCall, sinon.match({
+                        parentBuildId: 12345,
                         eventId: model.id,
                         jobId: 5,
                         prRef: 'branch'
                     }));
                     assert.calledWith(buildFactoryMock.create.secondCall, sinon.match({
+                        parentBuildId: 12345,
                         eventId: model.id,
                         jobId: 6,
                         prRef: 'branch'
@@ -352,6 +356,7 @@ describe('Event Factory', () => {
                     assert.instanceOf(model, Event);
                     assert.notCalled(jobFactoryMock.create);
                     assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
                         eventId: model.id,
                         jobId: 1
                     }));
@@ -367,6 +372,7 @@ describe('Event Factory', () => {
                     assert.instanceOf(model, Event);
                     assert.notCalled(jobFactoryMock.create);
                     assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
                         eventId: model.id,
                         jobId: 1
                     }));
@@ -385,6 +391,7 @@ describe('Event Factory', () => {
                     assert.calledOnce(pipelineMock.sync);
                     assert.calledOnce(buildFactoryMock.create);
                     assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
                         eventId: model.id,
                         jobId: 1
                     }));


### PR DESCRIPTION
Launcher will look up the meta from `parentBuildId`: https://github.com/screwdriver-cd/launcher/blob/master/launch.go#L202-L222

However, this value is not set when being triggered by an external pipeline. This and https://github.com/screwdriver-cd/screwdriver/pull/807 will fix the issue. There is actually no code change, but it will work because we will now pass in the `parentBuildId` from API. 

Related: 
https://github.com/screwdriver-cd/screwdriver/issues/771
