### PR TITLE
feat(809): get last successful build for a job

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -101,6 +101,7 @@ class Job extends BaseModel {
      * @param  {Object}   [config.paginate]         Pagination parameters
      * @param  {Number}   [config.paginate.count]   Number of items per page
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
+     * @param  {String}   [config.status]           List only builds with this status
      * @return {Promise}                            List of builds
      */
     getBuilds(config) {
@@ -122,6 +123,10 @@ class Job extends BaseModel {
             paginate
         };
 
+        if (config && config.status) {
+            listConfig.params.status = config.status;
+        }
+
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -137,21 +142,19 @@ class Job extends BaseModel {
      * @return {Promise}        List of running builds
      */
     getRunningBuilds() {
-        const listConfig = {
-            params: {
-                jobId: this.id,
-                status: ['RUNNING', 'QUEUED']
-            }
-        };
+        return Promise.all([
+            this.getBuilds({ status: 'RUNNING' }),
+            this.getBuilds({ status: 'QUEUED' })
+        ]).then(([runningBuilds, queuedBuilds]) => [...runningBuilds, ...queuedBuilds]);
+    }
 
-        // Lazy load factory dependency to prevent circular dependency issues
-        // https://nodejs.org/api/modules.html#modules_cycles
-        /* eslint-disable global-require */
-        const BuildFactory = require('./buildFactory');
-        /* eslint-enable global-require */
-        const factory = BuildFactory.getInstance();
-
-        return factory.list(listConfig);
+    /**
+     * Return the last successful build that belong to this job
+     * @return {Promise}        Resolves to the last successful build of this job
+     */
+    getLastSuccessfulBuild() {
+        return this.getBuilds({ status: 'SUCCESS' })
+          .then(successfulBuilds => successfulBuilds[0]);
     }
 
     /**


### PR DESCRIPTION
This is a bug fix as well as an initial work for https://github.com/screwdriver-cd/screwdriver/issues/809

I already started this on Friday so just submitting what I have so far. 

- `getRunningBuilds` never actually worked. We set `status: ['RUNNING', 'QUEUED']`, but [datastore](https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js) tries to search for exact match. `status` is a `string`, so this will never work. This PR refactors the code to search for `RUNNING` and `QUEUED` and returns the combined array. 
- Also added a `getLastSuccessfulBuild`, which will be used later for getting metadata of the last successful build in issue https://github.com/screwdriver-cd/screwdriver/issues/809