### PR TITLE
feat(api): Add commandFactory and commandTagFactory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,9 +1123,8 @@ const config = {
     habitat: {
         mode: 'remote',
         package: 'core/git/2.14.1',
-        binary: 'git'
-    },
-    labels: ['beta', 'stable']
+        command: 'git'
+    }
 }
 
 factory.create(config)
@@ -1153,7 +1152,6 @@ factory.create(config).then(model => {
 | config.habitat | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Habitat command |
 | config.docker | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Docker command |
 | config.binary | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Binary command |
-| config.labels | Array | No | Labels attached to the command |
 
 #### Get
 Get a command based on id.
@@ -1190,7 +1188,7 @@ const config = {
     namespace: 'testCommandNS',
     command: 'testCommand',
     tag: 'stable',
-    version: '1.3'
+    version: '1.3.5'
 }
 
 factory.create(config)
@@ -1202,7 +1200,7 @@ factory.create(config)
 Update a specific command tag
 ```js
 // update command version value
-model.version = '2.4';
+model.version = '2.4.8';
 
 model.update()
 ```
@@ -1221,7 +1219,7 @@ factory.create(config).then(model => {
 | config.namespace | String | Yes | The command namespace |
 | config.command | String | Yes | The command name |
 | config.tag | String | Yes | The command tag (e.g. stable, latest, etc) |
-| config.version | String | Yes | Version of the command |
+| config.version | String | Yes | Exact version of the command |
 
 #### Get
 Get a command tag based on id.

--- a/README.md
+++ b/README.md
@@ -1133,12 +1133,6 @@ factory.create(config)
     });
 ```
 
-#### Update
-Update a specific command
-```js
-model.update()
-```
-
 ### Command Factory
 #### Create
 ```js

--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,141 @@ Remove a specific collection
 model.remove()
 ```
 
+### Command Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.CommandFactory.getInstance({
+    datastore
+});
+const config = {
+    namespace: 'testCommandNS',
+    command: 'testCommand',
+    version: '1.3',
+    description: 'This is a test command',
+    maintainer: 'foo@bar.com',
+    format: 'habitat',
+    habitat: {
+        mode: 'remote',
+        package: 'core/git/2.14.1',
+        binary: 'git'
+    },
+    labels: ['beta', 'stable']
+}
+
+factory.create(config)
+    .then(model => {    // do something
+    });
+```
+
+#### Update
+Update a specific command
+```js
+model.update()
+```
+
+### Command Factory
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with command model
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.namespace | String | Yes | The command namespace |
+| config.command | String | Yes | The command name |
+| config.version | String | Yes | Version of the command |
+| config.description | String | Yes | Description of the command |
+| config.maintainer | String | Yes | Maintainer's email |
+| config.format | String | Yes | Format of the command, habitat or docker or binary |
+| config.habitat | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Habitat command |
+| config.docker | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Docker command |
+| config.binary | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Binary command |
+| config.labels | Array | No | Labels attached to the command |
+
+#### Get
+Get a command based on id.
+```js
+factory.get(id).then(model => {
+    // do stuff with command model
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | Number | The unique ID for the Command |
+
+#### Get Command
+Get the latest command by name or get a specific command using namespace, command name and version or tag. The version can be in any valid version format: either major, major.minor, or major.minor.patch. If no version is specified, the function will resolve with the latest version published. If no match is found, the function will resolve null.
+```js
+factory.getCommand(fullCommandName).then(model => {
+    // do stuff with command model
+});
+```
+
+| Parameter        | Type   |  Required | Description |
+| :-------------   | :----- | :-------------|  :-------------|
+| fullCommandName | String | Yes | Namespace and name of the command and the version or tag (e.g. chefdk/knife@1.2.3 or chefdk/knife@latest). Can also be just namespace and name of the command (e.g. chefdk/knife) |
+
+### Command Tag Model
+```js
+'use strict';
+const Model = require('screwdriver-models');
+const factory = Model.CommandTagFactory.getInstance({
+    datastore
+});
+const config = {
+    namespace: 'testCommandNS',
+    command: 'testCommand',
+    tag: 'stable',
+    version: '1.3'
+}
+
+factory.create(config)
+    .then(model => {    // do something
+    });
+```
+
+#### Update
+Update a specific command tag
+```js
+// update command version value
+model.version = '2.4';
+
+model.update()
+```
+
+### Command Tag Factory
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with command tag model
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.namespace | String | Yes | The command namespace |
+| config.command | String | Yes | The command name |
+| config.tag | String | Yes | The command tag (e.g. stable, latest, etc) |
+| config.version | String | Yes | Version of the command |
+
+#### Get
+Get a command tag based on id.
+```js
+factory.get(id).then(model => {
+    // do stuff with command model
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | Number | The unique ID for the Command Tag |
+
 ## Testing
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 const BuildFactory = require('./lib/buildFactory');
 const CollectionFactory = require('./lib/collectionFactory');
+const CommandFactory = require('./lib/commandFactory');
+const CommandTagFactory = require('./lib/commandTagFactory');
 const EventFactory = require('./lib/eventFactory');
 const JobFactory = require('./lib/jobFactory');
 const PipelineFactory = require('./lib/pipelineFactory');
@@ -15,6 +17,8 @@ const UserFactory = require('./lib/userFactory');
 module.exports = {
     BuildFactory,
     CollectionFactory,
+    CommandFactory,
+    CommandTagFactory,
     EventFactory,
     JobFactory,
     PipelineFactory,

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const BaseModel = require('./base');
+
+class CommandModel extends BaseModel {
+
+    /**
+     * Construct an CommandModel object
+     * @method constructor
+     * @param  {Object}   config                Config object to create the command with
+     * @param  {Object}   config.datastore      Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('command', config);
+    }
+}
+
+module.exports = CommandModel;

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -35,7 +35,6 @@ class CommandFactory extends BaseFactory {
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command
      * @param  {Object}     config.binary        Binary config of the command
-     * @param  {Array}      [config.labels]      Labels attached to the command
      * @return {Command}
      */
     createClass(config) {
@@ -56,7 +55,6 @@ class CommandFactory extends BaseFactory {
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command
      * @param  {Object}     config.binary        Binary config of the command
-     * @param  {Array}      [config.labels]      Labels attached to the command
      * @return {Promise}
      */
     create(config) {

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const Command = require('./command');
+const compareVersions = require('compare-versions');
+const schema = require('screwdriver-data-schema');
+let instance;
+
+const FULL_COMMAND_NAME_REGEX = schema.config.regex.FULL_COMMAND_NAME;
+const EXACT_VERSION_REGEX = schema.config.regex.EXACT_VERSION;
+const VERSION_REGEX = schema.config.regex.VERSION;
+
+class CommandFactory extends BaseFactory {
+    /**
+     * Construct a CommandFactory object
+     * @method constructor
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore         Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('command', config);
+    }
+
+    /**
+     * Instantiate a Command class
+     * @method createClass
+     * @param  {Object}     config               Command data
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     * @param  {String}     config.namespace     The command namespace
+     * @param  {String}     config.command       The command name
+     * @param  {String}     config.version       Version of the command
+     * @param  {String}     config.description   Description of the command
+     * @param  {String}     config.maintainer    Maintainer's email
+     * @param  {String}     config.format        Format of the command
+     * @param  {Object}     config.habitat       Habitat config of the command
+     * @param  {Object}     config.docker        Docker config of the command
+     * @param  {Object}     config.binary        Binary config of the command
+     * @param  {Array}      [config.labels]      Labels attached to the command
+     * @return {Command}
+     */
+    createClass(config) {
+        return new Command(config);
+    }
+
+    /**
+     * Create a new command of the correct version (See schema definition)
+     * @method create
+     * @param  {Object}     config               Config object
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     * @param  {String}     config.namespace     The command namespace
+     * @param  {String}     config.command       The command name
+     * @param  {String}     config.version       Version of the command
+     * @param  {String}     config.description   Description of the command
+     * @param  {String}     config.maintainer    Maintainer's email
+     * @param  {String}     config.format        Format of the command
+     * @param  {Object}     config.habitat       Habitat config of the command
+     * @param  {Object}     config.docker        Docker config of the command
+     * @param  {Object}     config.binary        Binary config of the command
+     * @param  {Array}      [config.labels]      Labels attached to the command
+     * @return {Promise}
+     */
+    create(config) {
+        const [, major, minor] = VERSION_REGEX.exec(config.version);
+        const searchVersion = minor ? `${major}${minor}` : major;
+
+        return this.getCommand(`${config.namespace}/${config.command}@${searchVersion}`)
+        .then((latest) => {
+            if (!latest) {
+                config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
+            } else {
+                // eslint-disable-next-line max-len
+                const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latest.version);
+                const patch = parseInt(latestPatch.slice(1), 10) + 1;
+
+                config.version = `${latestMajor}${latestMinor}.${patch}`;
+            }
+
+            return super.create(config);
+        });
+    }
+
+    /**
+     * Get a the latest command by config using the full command name
+     * @method getCommand
+     * @param  {String}     fullCommandName    Name of the command and the version or tag (e.g. chefdk/knife@1.2.3)
+     * @return {Promise}                       Resolves command model or null if not found
+     */
+    getCommand(fullCommandName) {
+        const [, commandNamespace, commandName, versionOrTag]
+            = FULL_COMMAND_NAME_REGEX.exec(fullCommandName);
+        const isExactVersion = EXACT_VERSION_REGEX.exec(versionOrTag);
+        const isVersion = VERSION_REGEX.exec(versionOrTag);
+
+        if (isExactVersion) {
+            // Get a command using the exact command version
+            return super.get({
+                namespace: commandNamespace,
+                command: commandName,
+                version: versionOrTag
+            });
+        }
+
+        // If tag is passed in, get the version from the tag
+        if (versionOrTag && !isVersion) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // eslint-disable-next-line global-require
+            const CommandTagFactory = require('./commandTagFactory');
+            const commandTagFactory = CommandTagFactory.getInstance();
+
+            // Get a command tag
+            return commandTagFactory.get({
+                namespace: commandNamespace,
+                command: commandName,
+                tag: versionOrTag
+            })
+            .then((commandTag) => {
+                // Return null if no command tag exists
+                if (!commandTag) {
+                    return null;
+                }
+
+                // Get a command using the exact command version
+                return super.get({
+                    namespace: commandNamespace,
+                    command: commandName,
+                    version: commandTag.version
+                });
+            });
+        }
+
+        // Get all commands with the same name
+        return super.list({ params: { namespace: commandNamespace, command: commandName } })
+            .then((commands) => {
+                // If no version provided, return the most recently published command
+                if (!versionOrTag) {
+                    return commands[0];
+                }
+
+                // Get commands that have versions beginning with the version given
+                const filtered = commands.filter(command =>
+                    command.version.startsWith(versionOrTag));
+
+                // Sort commands by descending order
+                filtered.sort((a, b) => compareVersions(b.version, a.version));
+
+                // Return first filtered command or null if none
+                return filtered[0] || null;
+            });
+    }
+
+    /**
+     * Get an instance of the CommandFactory
+     * @method getInstance
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore
+     * @return {CommandFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(CommandFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = CommandFactory;

--- a/lib/commandTag.js
+++ b/lib/commandTag.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BaseModel = require('./base');
+
+class CommandTagModel extends BaseModel {
+    /**
+     * Construct a CommandTagModel object
+     * @method constructor
+     * @param  {Object}    config
+     * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {String}    config.namespace     The command namespace
+     * @param  {String}    config.command       The command name
+     * @param  {String}    config.tag           The command tag (e.g.: 'stable' or 'latest')
+     * @param  {String}    config.version       Version of the command
+     */
+    constructor(config) {
+        super('commandTag', config);
+    }
+}
+
+module.exports = CommandTagModel;

--- a/lib/commandTagFactory.js
+++ b/lib/commandTagFactory.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const CommandTag = require('./commandTag');
+let instance;
+
+class CommandTagFactory extends BaseFactory {
+    /**
+     * Construct a CommandTagFactory object
+     * @method constructor
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('commandTag', config);
+    }
+
+    /**
+     * Instantiate a CommandTag class
+     * @method createClass
+     * @param  {Object}     config               Command tag data
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     * @param  {String}     config.namespace     The command namespace
+     * @param  {String}     config.command       The command name
+     * @param  {String}     config.tag           The command tag (e.g.: 'stable' or 'latest')
+     * @param  {String}     config.version       Version of the command
+     * @return {CommandTag}
+     */
+    createClass(config) {
+        return new CommandTag(config);
+    }
+
+    /**
+     * Get an instance of the CommandTagFactory
+     * @method getInstance
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore
+     * @return {CommandTagFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(CommandTagFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = CommandTagFactory;

--- a/test/lib/command.test.js
+++ b/test/lib/command.test.js
@@ -32,7 +32,6 @@ describe('Command Model', () => {
         createConfig = {
             datastore,
             id: 12345,
-            labels: ['test', 'beta'],
             namespace: 'testCommandNS',
             command: 'testCommand',
             version: '1.3',

--- a/test/lib/command.test.js
+++ b/test/lib/command.test.js
@@ -41,10 +41,11 @@ describe('Command Model', () => {
             habitat: {
                 mode: 'remote',
                 package: 'core/git/2.14.1',
-                binary: 'git'
+                command: 'git'
             },
             docker: {
-                image: 'node:1.2.3'
+                image: 'chefdk:1.2.3',
+                command: 'knife'
             },
             binary: {
                 file: './foobar.sh'

--- a/test/lib/command.test.js
+++ b/test/lib/command.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+const schema = require('screwdriver-data-schema');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Command Model', () => {
+    let CommandModel;
+    let datastore;
+    let command;
+    let BaseModel;
+    let createConfig;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {};
+        // eslint-disable-next-line global-require
+        CommandModel = require('../../lib/command');
+
+        // eslint-disable-next-line global-require
+        BaseModel = require('../../lib/base');
+
+        createConfig = {
+            datastore,
+            id: 12345,
+            labels: ['test', 'beta'],
+            namespace: 'testCommandNS',
+            command: 'testCommand',
+            version: '1.3',
+            maintainer: 'foo@bar.com',
+            description: 'this is a command',
+            format: 'habitat',
+            habitat: {
+                mode: 'remote',
+                package: 'core/git/2.14.1',
+                binary: 'git'
+            },
+            docker: {
+                image: 'node:1.2.3'
+            },
+            binary: {
+                file: './foobar.sh'
+            }
+        };
+        command = new CommandModel(createConfig);
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
+        assert.instanceOf(command, CommandModel);
+        assert.instanceOf(command, BaseModel);
+        schema.models.command.allKeys.forEach((key) => {
+            assert.strictEqual(command[key], createConfig[key]);
+        });
+    });
+});

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -16,7 +16,7 @@ describe('Command Factory', () => {
     const habitat = {
         mode: 'remote',
         package: 'core/git/2.14.1',
-        binary: 'git'
+        command: 'git'
     };
     const metaData = {
         namespace,

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -12,7 +12,6 @@ describe('Command Factory', () => {
     const version = '1.3';
     const maintainer = 'foo@bar.com';
     const description = 'this is a command';
-    const labels = ['test', 'beta'];
     const format = 'habitat';
     const habitat = {
         mode: 'remote',
@@ -25,7 +24,6 @@ describe('Command Factory', () => {
         version,
         maintainer,
         description,
-        labels,
         format,
         habitat
     };
@@ -93,7 +91,6 @@ describe('Command Factory', () => {
                 version,
                 maintainer,
                 description,
-                labels,
                 format,
                 habitat,
                 id: generatedId
@@ -112,7 +109,6 @@ describe('Command Factory', () => {
                 version,
                 maintainer,
                 description,
-                labels,
                 format,
                 habitat
             }).then((model) => {
@@ -135,7 +131,6 @@ describe('Command Factory', () => {
                 version: 1,
                 maintainer,
                 description,
-                labels,
                 format,
                 habitat
             }).then((model) => {
@@ -153,7 +148,6 @@ describe('Command Factory', () => {
                 version: `${version}.0`,
                 maintainer,
                 description,
-                labels,
                 format,
                 habitat,
                 id: generatedId
@@ -170,7 +164,6 @@ describe('Command Factory', () => {
                 version,
                 maintainer,
                 description,
-                labels,
                 format,
                 habitat
             }).then((model) => {

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -1,0 +1,319 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Command Factory', () => {
+    const namespace = 'testCommandNS';
+    const command = 'testCommand';
+    const version = '1.3';
+    const maintainer = 'foo@bar.com';
+    const description = 'this is a command';
+    const labels = ['test', 'beta'];
+    const format = 'habitat';
+    const habitat = {
+        mode: 'remote',
+        package: 'core/git/2.14.1',
+        binary: 'git'
+    };
+    const metaData = {
+        namespace,
+        command,
+        version,
+        maintainer,
+        description,
+        labels,
+        format,
+        habitat
+    };
+    let CommandFactory;
+    let datastore;
+    let commandTagFactoryMock;
+    let factory;
+    let Command;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            get: sinon.stub(),
+            scan: sinon.stub()
+        };
+        commandTagFactoryMock = {
+            get: sinon.stub()
+        };
+
+        mockery.registerMock('./commandTagFactory', {
+            getInstance: sinon.stub().returns(commandTagFactoryMock)
+        });
+
+        /* eslint-disable global-require */
+        Command = require('../../lib/command');
+        CommandFactory = require('../../lib/commandFactory');
+        /* eslint-enable global-require */
+
+        factory = new CommandFactory({ datastore });
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a Command', () => {
+            const model = factory.createClass(metaData);
+
+            assert.instanceOf(model, Command);
+        });
+    });
+
+    describe('create', () => {
+        const generatedId = 1234135;
+        let expected;
+
+        beforeEach(() => {
+            expected = {
+                namespace,
+                command,
+                version,
+                maintainer,
+                description,
+                labels,
+                format,
+                habitat,
+                id: generatedId
+            };
+        });
+
+        it('creates a Command given major/minor version and no latest commands', () => {
+            expected.version = `${version}.0`;
+
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([]);
+
+            return factory.create({
+                namespace,
+                command,
+                version,
+                maintainer,
+                description,
+                labels,
+                format,
+                habitat
+            }).then((model) => {
+                assert.instanceOf(model, Command);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        it('creates a Command given major version and no latest commands', () => {
+            expected.version = '1.0.0';
+
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([]);
+
+            return factory.create({
+                namespace,
+                command,
+                version: 1,
+                maintainer,
+                description,
+                labels,
+                format,
+                habitat
+            }).then((model) => {
+                assert.instanceOf(model, Command);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        it('creates a Command and auto-bumps version when latest returns something', () => {
+            const latest = {
+                namespace,
+                command,
+                version: `${version}.0`,
+                maintainer,
+                description,
+                labels,
+                format,
+                habitat,
+                id: generatedId
+            };
+
+            expected.version = `${version}.1`;
+
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([latest]);
+
+            return factory.create({
+                namespace,
+                command,
+                version,
+                maintainer,
+                description,
+                labels,
+                format,
+                habitat
+            }).then((model) => {
+                assert.instanceOf(model, Command);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+        });
+
+        it('should get an instance', () => {
+            const f1 = CommandFactory.getInstance(config);
+            const f2 = CommandFactory.getInstance(config);
+
+            assert.instanceOf(f1, CommandFactory);
+            assert.instanceOf(f2, CommandFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(CommandFactory.getInstance,
+                Error, 'No datastore provided to CommandFactory');
+        });
+    });
+
+    describe('getCommand', () => {
+        const commandNamespace = 'testCommandNS';
+        const commandName = 'testCommand';
+        const commandVersion = '1.0';
+        let fullCommandName;
+        let expected;
+        let returnValue;
+
+        beforeEach(() => {
+            fullCommandName = `${commandNamespace}/${commandName}@${commandVersion}`;
+
+            returnValue = [
+                {
+                    id: '1',
+                    namespace: 'testCommandNS',
+                    command: 'testCommand',
+                    version: '1.0.1'
+                },
+                {
+                    id: '3',
+                    namespace: 'testCommandNS',
+                    command: 'testCommand',
+                    version: '1.0.3'
+                },
+                {
+                    id: '2',
+                    namespace: 'testCommandNS',
+                    command: 'testCommand',
+                    version: '1.0.2'
+                },
+                {
+                    id: '4',
+                    namespace: 'testCommandNS',
+                    command: 'testCommand',
+                    version: '2.0.1'
+                }
+            ];
+        });
+
+        it(
+          'should get the correct command for a given namespace/command@exactVersion 1.0.2',
+          () => {
+              fullCommandName = `${commandNamespace}/${commandName}@1.0.2`;
+              expected = Object.assign({}, returnValue[2]);
+              datastore.get.resolves(returnValue[2]);
+
+              return factory.getCommand(fullCommandName).then((model) => {
+                  assert.instanceOf(model, Command);
+                  Object.keys(expected).forEach((key) => {
+                      assert.strictEqual(model[key], expected[key]);
+                  });
+              });
+          }
+        );
+
+        it('should get the correct command for a given namespace/command@version 1.0', () => {
+            expected = Object.assign({}, returnValue[1]);
+            datastore.scan.resolves(returnValue);
+
+            return factory.getCommand(fullCommandName).then((model) => {
+                assert.instanceOf(model, Command);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        it('should get the correct command for a given namespace/command@tag', () => {
+            fullCommandName = `${commandNamespace}/${commandName}@latest`;
+            expected = Object.assign({}, returnValue[2]);
+            commandTagFactoryMock.get.resolves({ version: '1.0.2' });
+            datastore.get.resolves(returnValue[2]);
+
+            return factory.getCommand(fullCommandName).then((model) => {
+                assert.instanceOf(model, Command);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        it('should return null if no command tag returned by get', () => {
+            fullCommandName = `${commandNamespace}/${commandName}@latest`;
+            commandTagFactoryMock.get.resolves(null);
+
+            return factory.getCommand(fullCommandName).then((model) => {
+                assert.isNull(model);
+            });
+        });
+
+        it('should get the correct command for a given namespace with no version or tag', () => {
+            fullCommandName = `${commandNamespace}/${commandName}`;
+            expected = Object.assign({}, returnValue[0]);
+            datastore.scan.resolves(returnValue);
+
+            return factory.getCommand(fullCommandName).then((model) => {
+                assert.instanceOf(model, Command);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        it('should return null if no command returned by list', () => {
+            datastore.scan.resolves([]);
+
+            return factory.getCommand(fullCommandName).then((model) => {
+                assert.strictEqual(model, null);
+            });
+        });
+    });
+});

--- a/test/lib/commandTag.test.js
+++ b/test/lib/commandTag.test.js
@@ -38,7 +38,7 @@ describe('CommandTag Model', () => {
             namespace: 'testCommandTagNS',
             command: 'testCommandTag',
             tag: 'latest',
-            version: '1.3'
+            version: '1.3.5'
         };
         commandTag = new CommandTagModel(createConfig);
     });

--- a/test/lib/commandTag.test.js
+++ b/test/lib/commandTag.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const mockery = require('mockery');
+const schema = require('screwdriver-data-schema');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('CommandTag Model', () => {
+    let BaseModel;
+    let CommandTagModel;
+    let datastore;
+    let createConfig;
+    let commandTag;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            update: sinon.stub()
+        };
+
+        // eslint-disable-next-line global-require
+        BaseModel = require('../../lib/base');
+
+        // eslint-disable-next-line global-require
+        CommandTagModel = require('../../lib/commandTag');
+
+        createConfig = {
+            datastore,
+            id: 12345,
+            namespace: 'testCommandTagNS',
+            command: 'testCommandTag',
+            tag: 'latest',
+            version: '1.3'
+        };
+        commandTag = new CommandTagModel(createConfig);
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
+        assert.instanceOf(commandTag, CommandTagModel);
+        assert.instanceOf(commandTag, BaseModel);
+        schema.models.commandTag.allKeys.forEach((key) => {
+            assert.strictEqual(commandTag[key], createConfig[key]);
+        });
+    });
+});

--- a/test/lib/commandTagFactory.test.js
+++ b/test/lib/commandTagFactory.test.js
@@ -9,7 +9,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('CommandTag Factory', () => {
     const namespace = 'testCommandTagNS';
     const command = 'testCommandTag';
-    const version = '1.3';
+    const version = '1.3.5';
     const tag = 'latest';
     const metaData = {
         namespace,

--- a/test/lib/commandTagFactory.test.js
+++ b/test/lib/commandTagFactory.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('CommandTag Factory', () => {
+    const namespace = 'testCommandTagNS';
+    const command = 'testCommandTag';
+    const version = '1.3';
+    const tag = 'latest';
+    const metaData = {
+        namespace,
+        command,
+        tag,
+        version
+    };
+    let CommandTagFactory;
+    let datastore;
+    let factory;
+    let CommandTag;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            get: sinon.stub(),
+            scan: sinon.stub()
+        };
+
+        // eslint-disable-next-line global-require
+        CommandTag = require('../../lib/commandTag');
+        // eslint-disable-next-line global-require
+        CommandTagFactory = require('../../lib/commandTagFactory');
+
+        factory = new CommandTagFactory({ datastore });
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a CommandTag model', () => {
+            const model = factory.createClass(metaData);
+
+            assert.instanceOf(model, CommandTag);
+        });
+    });
+
+    describe('create', () => {
+        const generatedId = 1234135;
+        let expected;
+
+        beforeEach(() => {
+            expected = {
+                id: generatedId,
+                namespace,
+                command,
+                tag,
+                version
+            };
+        });
+
+        it('creates a CommandTag given namespace, command, tag, and version', () => {
+            datastore.save.resolves(expected);
+
+            return factory.create({
+                namespace,
+                command,
+                tag,
+                version
+            }).then((model) => {
+                assert.instanceOf(model, CommandTag);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+        });
+
+        it('should get an instance', () => {
+            const f1 = CommandTagFactory.getInstance(config);
+            const f2 = CommandTagFactory.getInstance(config);
+
+            assert.instanceOf(f1, CommandTagFactory);
+            assert.instanceOf(f2, CommandTagFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(CommandTagFactory.getInstance,
+                Error, 'No datastore provided to CommandTagFactory');
+        });
+    });
+});


### PR DESCRIPTION
## Context

This PR adds commandFactory and commandTagFactory.
These data models are based on the following Commands design document and used by the Commands REST API impl.

https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md

## This PR's Goal (Phase 1: Minimum Viable Product)
- Commands REST API (minimum)
  - post: create a command.
  - get: retrieve command details.
- data-schemas and **data(factory)**
  - elemental CRUD (minimum).

## Note: These models are dependent on the latest data-schemas (WIP).

Unit tests will fail for the moment, because these models require `command` and `commandTag` data-schemas (WIP).
https://github.com/screwdriver-cd/data-schema/pull/195

- Unit tests on local machine
```
$ git clone https://github.com/wdstar/data-schema.git
$ cd data-schema/
$ npm link
$ cd ..
$ git clone https://github.com/sonic-screwdriver-cd/models.git
$ cd models/
$ git checkout -b command origin/command
$ npm install
$ npm link screwdriver-data-schema
$ npm test
...
  252 passing (24s)


=============================== Coverage summary ===============================
Statements   : 100% ( 940/940 )
Branches     : 100% ( 253/253 )
Functions    : 100% ( 314/314 )
Lines        : 100% ( 902/902 )
================================================================================
```

## To do before merged

- [ ] update the `screwdriver-data-schema` dependency.