### PR TITLE
fix: rename `command` key to `name`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1115,7 +1115,7 @@ const factory = Model.CommandFactory.getInstance({
 });
 const config = {
     namespace: 'testCommandNS',
-    command: 'testCommand',
+    name: 'testCommand',
     version: '1.3',
     description: 'This is a test command',
     maintainer: 'foo@bar.com',
@@ -1144,7 +1144,7 @@ factory.create(config).then(model => {
 | :-------------   | :---- | :-------------|  :-------------|
 | config        | Object | Yes | Configuration Object |
 | config.namespace | String | Yes | The command namespace |
-| config.command | String | Yes | The command name |
+| config.name | String | Yes | The command name |
 | config.version | String | Yes | Version of the command |
 | config.description | String | Yes | Description of the command |
 | config.maintainer | String | Yes | Maintainer's email |
@@ -1186,7 +1186,7 @@ const factory = Model.CommandTagFactory.getInstance({
 });
 const config = {
     namespace: 'testCommandNS',
-    command: 'testCommand',
+    name: 'testCommand',
     tag: 'stable',
     version: '1.3.5'
 }
@@ -1217,7 +1217,7 @@ factory.create(config).then(model => {
 | :-------------   | :---- | :-------------|  :-------------|
 | config        | Object | Yes | Configuration Object |
 | config.namespace | String | Yes | The command namespace |
-| config.command | String | Yes | The command name |
+| config.name | String | Yes | The command name |
 | config.tag | String | Yes | The command tag (e.g. stable, latest, etc) |
 | config.version | String | Yes | Exact version of the command |
 

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -27,7 +27,7 @@ class CommandFactory extends BaseFactory {
      * @param  {Object}     config               Command data
      * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
      * @param  {String}     config.namespace     The command namespace
-     * @param  {String}     config.command       The command name
+     * @param  {String}     config.name          The command name
      * @param  {String}     config.version       Version of the command
      * @param  {String}     config.description   Description of the command
      * @param  {String}     config.maintainer    Maintainer's email
@@ -47,7 +47,7 @@ class CommandFactory extends BaseFactory {
      * @param  {Object}     config               Config object
      * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
      * @param  {String}     config.namespace     The command namespace
-     * @param  {String}     config.command       The command name
+     * @param  {String}     config.name          The command name
      * @param  {String}     config.version       Version of the command
      * @param  {String}     config.description   Description of the command
      * @param  {String}     config.maintainer    Maintainer's email
@@ -61,7 +61,7 @@ class CommandFactory extends BaseFactory {
         const [, major, minor] = VERSION_REGEX.exec(config.version);
         const searchVersion = minor ? `${major}${minor}` : major;
 
-        return this.getCommand(`${config.namespace}/${config.command}@${searchVersion}`)
+        return this.getCommand(`${config.namespace}/${config.name}@${searchVersion}`)
         .then((latest) => {
             if (!latest) {
                 config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
@@ -93,7 +93,7 @@ class CommandFactory extends BaseFactory {
             // Get a command using the exact command version
             return super.get({
                 namespace: commandNamespace,
-                command: commandName,
+                name: commandName,
                 version: versionOrTag
             });
         }
@@ -108,7 +108,7 @@ class CommandFactory extends BaseFactory {
             // Get a command tag
             return commandTagFactory.get({
                 namespace: commandNamespace,
-                command: commandName,
+                name: commandName,
                 tag: versionOrTag
             })
             .then((commandTag) => {
@@ -120,14 +120,14 @@ class CommandFactory extends BaseFactory {
                 // Get a command using the exact command version
                 return super.get({
                     namespace: commandNamespace,
-                    command: commandName,
+                    name: commandName,
                     version: commandTag.version
                 });
             });
         }
 
         // Get all commands with the same name
-        return super.list({ params: { namespace: commandNamespace, command: commandName } })
+        return super.list({ params: { namespace: commandNamespace, name: commandName } })
             .then((commands) => {
                 // If no version provided, return the most recently published command
                 if (!versionOrTag) {

--- a/lib/commandTag.js
+++ b/lib/commandTag.js
@@ -9,7 +9,7 @@ class CommandTagModel extends BaseModel {
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
      * @param  {String}    config.namespace     The command namespace
-     * @param  {String}    config.command       The command name
+     * @param  {String}    config.name          The command name
      * @param  {String}    config.tag           The command tag (e.g.: 'stable' or 'latest')
      * @param  {String}    config.version       Version of the command
      */

--- a/lib/commandTagFactory.js
+++ b/lib/commandTagFactory.js
@@ -21,7 +21,7 @@ class CommandTagFactory extends BaseFactory {
      * @param  {Object}     config               Command tag data
      * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
      * @param  {String}     config.namespace     The command namespace
-     * @param  {String}     config.command       The command name
+     * @param  {String}     config.name          The command name
      * @param  {String}     config.tag           The command tag (e.g.: 'stable' or 'latest')
      * @param  {String}     config.version       Version of the command
      * @return {CommandTag}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hoek": "^4.0.1",
     "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.10.0",
-    "screwdriver-data-schema": "^18.4.0",
+    "screwdriver-data-schema": "^18.10.1",
     "screwdriver-workflow-parser": "^1.1.1"
   }
 }

--- a/test/lib/command.test.js
+++ b/test/lib/command.test.js
@@ -33,7 +33,7 @@ describe('Command Model', () => {
             datastore,
             id: 12345,
             namespace: 'testCommandNS',
-            command: 'testCommand',
+            name: 'testCommand',
             version: '1.3',
             maintainer: 'foo@bar.com',
             description: 'this is a command',

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -8,7 +8,7 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('Command Factory', () => {
     const namespace = 'testCommandNS';
-    const command = 'testCommand';
+    const name = 'testCommand';
     const version = '1.3';
     const maintainer = 'foo@bar.com';
     const description = 'this is a command';
@@ -20,7 +20,7 @@ describe('Command Factory', () => {
     };
     const metaData = {
         namespace,
-        command,
+        name,
         version,
         maintainer,
         description,
@@ -87,7 +87,7 @@ describe('Command Factory', () => {
         beforeEach(() => {
             expected = {
                 namespace,
-                command,
+                name,
                 version,
                 maintainer,
                 description,
@@ -105,7 +105,7 @@ describe('Command Factory', () => {
 
             return factory.create({
                 namespace,
-                command,
+                name,
                 version,
                 maintainer,
                 description,
@@ -127,7 +127,7 @@ describe('Command Factory', () => {
 
             return factory.create({
                 namespace,
-                command,
+                name,
                 version: 1,
                 maintainer,
                 description,
@@ -144,7 +144,7 @@ describe('Command Factory', () => {
         it('creates a Command and auto-bumps version when latest returns something', () => {
             const latest = {
                 namespace,
-                command,
+                name,
                 version: `${version}.0`,
                 maintainer,
                 description,
@@ -160,7 +160,7 @@ describe('Command Factory', () => {
 
             return factory.create({
                 namespace,
-                command,
+                name,
                 version,
                 maintainer,
                 description,
@@ -213,32 +213,32 @@ describe('Command Factory', () => {
                 {
                     id: '1',
                     namespace: 'testCommandNS',
-                    command: 'testCommand',
+                    name: 'testCommand',
                     version: '1.0.1'
                 },
                 {
                     id: '3',
                     namespace: 'testCommandNS',
-                    command: 'testCommand',
+                    name: 'testCommand',
                     version: '1.0.3'
                 },
                 {
                     id: '2',
                     namespace: 'testCommandNS',
-                    command: 'testCommand',
+                    name: 'testCommand',
                     version: '1.0.2'
                 },
                 {
                     id: '4',
                     namespace: 'testCommandNS',
-                    command: 'testCommand',
+                    name: 'testCommand',
                     version: '2.0.1'
                 }
             ];
         });
 
         it(
-          'should get the correct command for a given namespace/command@exactVersion 1.0.2',
+          'should get the correct command for a given namespace/name@exactVersion 1.0.2',
           () => {
               fullCommandName = `${commandNamespace}/${commandName}@1.0.2`;
               expected = Object.assign({}, returnValue[2]);
@@ -253,7 +253,7 @@ describe('Command Factory', () => {
           }
         );
 
-        it('should get the correct command for a given namespace/command@version 1.0', () => {
+        it('should get the correct command for a given namespace/name@version 1.0', () => {
             expected = Object.assign({}, returnValue[1]);
             datastore.scan.resolves(returnValue);
 
@@ -265,7 +265,7 @@ describe('Command Factory', () => {
             });
         });
 
-        it('should get the correct command for a given namespace/command@tag', () => {
+        it('should get the correct command for a given namespace/name@tag', () => {
             fullCommandName = `${commandNamespace}/${commandName}@latest`;
             expected = Object.assign({}, returnValue[2]);
             commandTagFactoryMock.get.resolves({ version: '1.0.2' });

--- a/test/lib/commandTag.test.js
+++ b/test/lib/commandTag.test.js
@@ -36,7 +36,7 @@ describe('CommandTag Model', () => {
             datastore,
             id: 12345,
             namespace: 'testCommandTagNS',
-            command: 'testCommandTag',
+            name: 'testCommandTag',
             tag: 'latest',
             version: '1.3.5'
         };

--- a/test/lib/commandTagFactory.test.js
+++ b/test/lib/commandTagFactory.test.js
@@ -8,12 +8,12 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('CommandTag Factory', () => {
     const namespace = 'testCommandTagNS';
-    const command = 'testCommandTag';
+    const name = 'testCommandTag';
     const version = '1.3.5';
     const tag = 'latest';
     const metaData = {
         namespace,
-        command,
+        name,
         tag,
         version
     };
@@ -70,18 +70,18 @@ describe('CommandTag Factory', () => {
             expected = {
                 id: generatedId,
                 namespace,
-                command,
+                name,
                 tag,
                 version
             };
         });
 
-        it('creates a CommandTag given namespace, command, tag, and version', () => {
+        it('creates a CommandTag given namespace, name, tag, and version', () => {
             datastore.save.resolves(expected);
 
             return factory.create({
                 namespace,
-                command,
+                name,
                 tag,
                 version
             }).then((model) => {


### PR DESCRIPTION
## Context

Screwdriver Commands feature.

## Objective

Rename `command` key of the `command` data schema to `name`.

## Note

- This PR is blocked by https://github.com/screwdriver-cd/data-schema/pull/198
- Unit tests will fail for the moment.

## To do before merged

- [x] bump up the dependent screwdriver-data-schema version.

## References

- [Design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md) 
- https://github.com/screwdriver-cd/screwdriver/pull/829
  