### PR TITLE
feat: add pipelineId to command

### DIFF
--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -35,6 +35,7 @@ class CommandFactory extends BaseFactory {
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command
      * @param  {Object}     config.binary        Binary config of the command
+     * @param  {String}     config.pipelineId    pipelineId of the command
      * @return {Command}
      */
     createClass(config) {
@@ -55,6 +56,7 @@ class CommandFactory extends BaseFactory {
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command
      * @param  {Object}     config.binary        Binary config of the command
+     * @param  {Object}     config.pipelineId    pipelineId of the command
      * @return {Promise}
      */
     create(config) {

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -56,7 +56,7 @@ class CommandFactory extends BaseFactory {
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command
      * @param  {Object}     config.binary        Binary config of the command
-     * @param  {Object}     config.pipelineId    pipelineId of the command
+     * @param  {String}     config.pipelineId    pipelineId of the command
      * @return {Promise}
      */
     create(config) {

--- a/test/lib/command.test.js
+++ b/test/lib/command.test.js
@@ -49,7 +49,8 @@ describe('Command Model', () => {
             },
             binary: {
                 file: './foobar.sh'
-            }
+            },
+            pipelineId: '8765'
         };
         command = new CommandModel(createConfig);
     });

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -18,6 +18,7 @@ describe('Command Factory', () => {
         package: 'core/git/2.14.1',
         command: 'git'
     };
+    const pipelineId = '8765';
     const metaData = {
         namespace,
         name,
@@ -25,7 +26,8 @@ describe('Command Factory', () => {
         maintainer,
         description,
         format,
-        habitat
+        habitat,
+        pipelineId
     };
     let CommandFactory;
     let datastore;
@@ -93,7 +95,8 @@ describe('Command Factory', () => {
                 description,
                 format,
                 habitat,
-                id: generatedId
+                id: generatedId,
+                pipelineId
             };
         });
 
@@ -110,7 +113,8 @@ describe('Command Factory', () => {
                 maintainer,
                 description,
                 format,
-                habitat
+                habitat,
+                pipelineId
             }).then((model) => {
                 assert.instanceOf(model, Command);
                 Object.keys(expected).forEach((key) => {
@@ -132,7 +136,8 @@ describe('Command Factory', () => {
                 maintainer,
                 description,
                 format,
-                habitat
+                habitat,
+                pipelineId
             }).then((model) => {
                 assert.instanceOf(model, Command);
                 Object.keys(expected).forEach((key) => {
@@ -150,7 +155,8 @@ describe('Command Factory', () => {
                 description,
                 format,
                 habitat,
-                id: generatedId
+                id: generatedId,
+                pipelineId
             };
 
             expected.version = `${version}.1`;
@@ -165,7 +171,8 @@ describe('Command Factory', () => {
                 maintainer,
                 description,
                 format,
-                habitat
+                habitat,
+                pipelineId
             }).then((model) => {
                 assert.instanceOf(model, Command);
                 Object.keys(expected).forEach((key) => {


### PR DESCRIPTION
## Context
Like template, to limit a pipeline which updates the command only a pipeline which created the command, I add a pipelineId to the command in [data-schema](https://github.com/screwdriver-cd/data-schema/pull/199). Related to data-schema, I fixed models.

## Objective
Add pipelineId to the command.

## Note
Unit tests will fail for the moment, because these models require `command` data-schema.
https://github.com/screwdriver-cd/data-schema/pull/199

## To do before merged
- [x] update the screwdriver-data-schema dependency.

## Related
https://github.com/screwdriver-cd/data-schema/pull/199