### PR TITLE
fix: rollback new iron module

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "compare-versions": "^3.0.0",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.3",
-    "iron": "^5.0.1",
+    "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.10.0",
     "screwdriver-data-schema": "^18.10.1",
     "screwdriver-workflow-parser": "^1.1.1"


### PR DESCRIPTION
Beta api is broken right now:
```
/usr/src/app/node_modules/screwdriver-models/node_modules/iron/lib/index.js:68
exports.generateKey = async function (password, options) {
                            ^^^^^^^^

SyntaxError: Unexpected token function
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:549:28)
    at Object.Module._extensions..js (module.js:586:10)
    at Module.load (module.js:494:32)
    at tryModuleLoad (module.js:453:12)
    at Function.Module._load (module.js:445:3)
    at Module.require (module.js:504:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/src/app/node_modules/screwdriver-models/lib/secret.js:5:14)
    at Module._compile (module.js:577:32)
    at Object.Module._extensions..js (module.js:586:10)
    at Module.load (module.js:494:32)
    at tryModuleLoad (module.js:453:12)
    at Function.Module._load (module.js:445:3)
    at Module.require (module.js:504:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/src/app/node_modules/screwdriver-models/lib/secretFactory.js:4:16)
    at Module._compile (module.js:577:32)
    at Object.Module._extensions..js (module.js:586:10)
    at Module.load (module.js:494:32)
    at tryModuleLoad (module.js:453:12)
```