### PR TITLE
Revert "fix: Update iron and fix seal and unseal token funcs"

### DIFF
--- a/lib/secret.js
+++ b/lib/secret.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseModel = require('./base');
+const nodeify = require('./nodeify');
 const iron = require('iron');
 // Get symbols for private fields
 const password = Symbol('password');
@@ -29,7 +30,7 @@ class SecretModel extends BaseModel {
      * @return {Promise}
      */
     update() {
-        return iron.seal(this.value, this[password], iron.defaults)
+        return nodeify.withContext(iron, 'seal', [this.value, this[password], iron.defaults])
             .then((sealed) => {
                 this.value = sealed;
 

--- a/lib/secretFactory.js
+++ b/lib/secretFactory.js
@@ -3,6 +3,7 @@
 const BaseFactory = require('./baseFactory');
 const Secret = require('./secret');
 const iron = require('iron');
+const nodeify = require('./nodeify');
 // Get symbols for private fields
 const password = Symbol('password');
 
@@ -16,7 +17,7 @@ let instance;
  * @return {Promise}
  */
 function sealSecret(secretvalue, pw) {
-    return iron.seal(secretvalue, pw, iron.defaults);
+    return nodeify.withContext(iron, 'seal', [secretvalue, pw, iron.defaults]);
 }
 
 /**
@@ -26,7 +27,7 @@ function sealSecret(secretvalue, pw) {
  * @return {Promise}
  */
 function unsealSecret(secret, pw) {
-    return iron.unseal(secret.value, pw, iron.defaults)
+    return nodeify.withContext(iron, 'unseal', [secret.value, pw, iron.defaults])
         .then((unsealed) => {
             secret.value = unsealed;
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -2,6 +2,7 @@
 
 const BaseModel = require('./base');
 const iron = require('iron');
+const nodeify = require('./nodeify');
 const PAGINATE_COUNT = 50;
 const PAGINATE_PAGE = 1;
 // Get symbols for private fields
@@ -34,7 +35,7 @@ class UserModel extends BaseModel {
      */
     sealToken(token) {
         // TODO: automatically update user model and datastore with new sealed token???
-        return iron.seal(token, this[password], iron.defaults);
+        return nodeify.withContext(iron, 'seal', [token, this[password], iron.defaults]);
     }
 
     /**
@@ -43,7 +44,8 @@ class UserModel extends BaseModel {
      * @return {Promise}
      */
     unsealToken() {
-        return iron.unseal(this.token, this[password], iron.defaults);
+        return nodeify.withContext(iron, 'unseal',
+            [this.token, this[password], iron.defaults]);
     }
 
     /** Fetch a user's tokens

--- a/lib/userFactory.js
+++ b/lib/userFactory.js
@@ -3,6 +3,7 @@
 const BaseFactory = require('./baseFactory');
 const User = require('./user');
 const iron = require('iron');
+const nodeify = require('./nodeify');
 // Get symbols for private fields
 const password = Symbol('password');
 
@@ -14,7 +15,7 @@ let instance;
  * @return {Promise}
  */
 const sealToken = (token, pw) =>
-    iron.seal(token, pw, iron.defaults);
+    nodeify.withContext(iron, 'seal', [token, pw, iron.defaults]);
 
 class UserFactory extends BaseFactory {
     /**

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
     "jenkins-mocha": "^4.0.0",
-    "joi": "^13.0.0",
+    "joi": "^10.0.5",
     "mockery": "^2.0.0",
     "sinon": "^2.3.1"
   },
@@ -50,7 +50,7 @@
     "compare-versions": "^3.0.0",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.3",
-    "iron": "^5.0.1",
+    "iron": "^4.0.1",
     "screwdriver-config-parser": "^3.10.0",
     "screwdriver-data-schema": "^18.10.1",
     "screwdriver-workflow-parser": "^1.1.1"

--- a/test/lib/secret.test.js
+++ b/test/lib/secret.test.js
@@ -73,7 +73,7 @@ describe('Secret Model', () => {
 
     describe('update', () => {
         beforeEach(() => {
-            ironMock.seal.resolves('sealedspiderman');
+            ironMock.seal.yieldsAsync(null, 'sealedspiderman');
         });
 
         it('promises to update a secret and seal the value before datastore saves it', () => {

--- a/test/lib/secretFactory.test.js
+++ b/test/lib/secretFactory.test.js
@@ -84,7 +84,7 @@ describe('Secret Factory', () => {
                 id: generatedId
             };
 
-            ironMock.seal.resolves(sealed);
+            ironMock.seal.yieldsAsync(null, sealed);
             datastore.save.resolves(expected);
 
             return factory.create({
@@ -126,7 +126,7 @@ describe('Secret Factory', () => {
                     name
                 }
             }).resolves(secretData);
-            ironMock.unseal.resolves(unsealed);
+            ironMock.unseal.yieldsAsync(null, unsealed);
         });
 
         it('calls datastore get with id and returns correct values', () =>
@@ -217,8 +217,8 @@ describe('Secret Factory', () => {
 
         it('calls datastore scan and returns correct values', () => {
             datastore.scan.resolves(datastoreReturnValue);
-            ironMock.unseal.withArgs('sealedsecret1value', password).resolves('batman');
-            ironMock.unseal.withArgs('sealedsecret2value', password).resolves('superman');
+            ironMock.unseal.withArgs('sealedsecret1value', password).yieldsAsync(null, 'batman');
+            ironMock.unseal.withArgs('sealedsecret2value', password).yieldsAsync(null, 'superman');
 
             return factory.list({ paginate })
                 .then((arr) => {

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -95,7 +95,7 @@ describe('User Model', () => {
 
         beforeEach(() => {
             ironMock.seal.withArgs(unsealedToken, password, ironMock.defaults)
-                .resolves('werlx');
+                .yieldsAsync(null, 'werlx');
         });
 
         it('promises to execute seal token', () =>
@@ -110,7 +110,7 @@ describe('User Model', () => {
             const expectedError = new Error('whaleIsNotSeal');
 
             ironMock.seal.withArgs(unsealedToken, password, ironMock.defaults)
-                .rejects(expectedError);
+                .yieldsAsync(expectedError);
 
             return user.sealToken(unsealedToken)
                 .then(() => {
@@ -127,7 +127,7 @@ describe('User Model', () => {
 
         beforeEach(() => {
             ironMock.unseal.withArgs(sealed, password, ironMock.defaults)
-                .resolves('1234');
+                .yieldsAsync(null, '1234');
         });
 
         it('promises to execute unseal token', () =>
@@ -141,7 +141,7 @@ describe('User Model', () => {
             const expectedError = new Error('TooCoolToBeSeal');
 
             ironMock.unseal.withArgs(sealed, password, ironMock.defaults)
-                .rejects(expectedError);
+                .yieldsAsync(expectedError);
 
             return user.unsealToken()
                 .then(() => {
@@ -164,7 +164,7 @@ describe('User Model', () => {
         };
 
         beforeEach(() => {
-            ironMock.unseal.resolves('12345');
+            ironMock.unseal.yieldsAsync(null, '12345');
             scmMock.getPermissions.resolves(repo.permissions);
         });
 

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -86,7 +86,7 @@ describe('User Factory', () => {
                 id: generatedId
             };
 
-            ironMock.seal.resolves(sealedToken);
+            ironMock.seal.yieldsAsync(null, sealedToken);
             hashaMock.sha1.returns(generatedId);
             datastore.save.resolves(expected);
 


### PR DESCRIPTION
Reverts screwdriver-cd/models#215

The new iron package requires node8 functionality. We are still using node6.
Rolling back so we can unblock the screwdriver-cd/screwdriver pipeline.