### PR TITLE
fix: Use new workflow syntax

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,16 +1,15 @@
-workflow:
-    - publish
-
 shared:
     image: node:8
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
+        requires: [main]
         template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM


### PR DESCRIPTION
Updating the screwdriver.yaml to use the `requires` syntax