### PR TITLE
chore: Upgrading versions of mocha, chai, and sinon

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     }
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
     "eslint": "^4.3.0",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^4.0.0",
+    "jenkins-mocha": "^6.0.0",
     "joi": "^13.0.0",
     "mockery": "^2.0.0",
-    "sinon": "^2.3.1"
+    "sinon": "^4.4.2"
   },
   "dependencies": {
     "async": "^2.0.1",

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -504,7 +504,7 @@ describe('Pipeline Model', () => {
         it('returns error if something explodes', () => {
             const error = new Error('blah');
 
-            jobFactoryMock.create.rejects(error);
+            jobFactoryMock.list.rejects(error);
 
             return pipeline.sync()
                 .catch((err) => {
@@ -589,6 +589,7 @@ describe('Pipeline Model', () => {
             const error = new Error('fails to get config');
 
             scmMock.getFile.rejects(error);
+            parserMock.rejects(error);
 
             return pipeline.syncPR(1).catch((err) => {
                 assert.deepEqual(err, error);


### PR DESCRIPTION
I had to update two tests because the tests were not actually working as expected and Chai was just ignoring the error.  Latest version of Chai does not ignore that error anymore.