### PR TITLE
feat: get parentEventId config when recreate

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -263,7 +263,7 @@ class EventFactory extends BaseFactory {
      *                                              Optional for backwards compatibility
      * @param  {String}  [config.causeMessage]      Message that describes why the event was created
      * @param  {String}  [config.parentBuildId]     Id of the build that starts this event
-     * @param  {String}  [config.parentEventId]     Id of the event that starts this event
+     * @param  {String}  [config.workflowGraph]     workflowGraph of parentEvent if there is a parentEvent
      * @return {Promise}
      */
     create(config) {
@@ -314,34 +314,43 @@ class EventFactory extends BaseFactory {
                         modelConfig.commit = commit;
                         modelConfig.createTime = (new Date()).toISOString();
 
+                        if (config.workflowGraph) {
+                            modelConfig.workflowGraph = config.workflowGraph;
+
+                            return modelConfig;
+                        }
+
                         // Get latest config
                         return getLatestConfig({
                             pipeline,
                             eventConfig: config
+                        }).then((latestConfig) => {
+                            if (modelConfig.type === 'pr') {
+                                return latestConfig;
+                            }
+                            modelConfig.workflowGraph = latestConfig.workflowGraph;
+                            modelConfig.workflow = latestConfig.workflow; // TODO: deprecate this
+
+                            return modelConfig;
+                        });
+                    })
+                    .then(pipelineConfig => super.create(pipelineConfig)
+                        .then((event) => {
+                            if (modelConfig.type === 'pipeline') {
+                                pipeline.lastEventId = event.id;
+                            }
+
+                            return pipeline.update()
+                                // Start builds
+                                .then(() => createBuilds({
+                                    eventConfig: config,
+                                    eventId: event.id,
+                                    pipeline,
+                                    pipelineConfig
+                                }))
+                                .then(() => event);
                         })
-                            .then((latestConfig) => {
-                                modelConfig.workflowGraph = latestConfig.workflowGraph;
-                                modelConfig.workflow = latestConfig.workflow;
-
-                                // Create event
-                                return super.create(modelConfig)
-                                    .then((event) => {
-                                        if (modelConfig.type === 'pipeline') {
-                                            pipeline.lastEventId = event.id;
-                                        }
-
-                                        return pipeline.update()
-                                            // Start builds
-                                            .then(() => createBuilds({
-                                                eventConfig: config,
-                                                eventId: event.id,
-                                                pipeline,
-                                                pipelineConfig: latestConfig
-                                            }))
-                                            .then(() => event);
-                                    });
-                            });
-                    });
+                    );
             });
     }
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -459,6 +459,32 @@ describe('Event Factory', () => {
                 assert.equal(model.causeMessage, 'Started by stjohn');
             });
         });
+
+        it('should create using parentEvent workflowGraph', () => {
+            config.parentEventId = 222;
+            config.workflowGraph = {
+                nodes: [
+                    { name: '~commit' },
+                    { name: 'testJob' }
+                ],
+                edges: [
+                    { src: '~commit', dest: 'testJob' }
+                ]
+            };
+            expected.workflowGraph = config.workflowGraph;
+            expected.parentEventId = config.parentEventId;
+
+            return factory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                Object.keys(expected).forEach((key) => {
+                    if (key === 'workflowGraph') {
+                        assert.deepEqual(model[key], expected[key]);
+                    } else if (key === 'parentEventId') {
+                        assert.deepEqual(model[key], 222);
+                    }
+                });
+            });
+        });
     });
 
     describe('getInstance', () => {


### PR DESCRIPTION
API now passes in `workflowGraph` so that when we create a new event, it can take the workflowGraph of the parentEvent, instead of the latest config. 

## References
Related to https://github.com/screwdriver-cd/screwdriver/issues/806
