### PR TITLE
fix: make sync take in optional ref

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -200,6 +200,7 @@ class EventFactory extends BaseFactory {
      *                                              Optional for backwards compatibility
      * @param  {String}  [config.causeMessage]      Message that describes why the event was created
      * @param  {String}  [config.parentBuildId]     Id of the build that starts this event
+     * @param  {String}  [config.parentEventId]     Id of the parent event
      * @param  {String}  [config.workflowGraph]     workflowGraph of parentEvent if there is a parentEvent
      * @return {Promise}
      */
@@ -211,10 +212,26 @@ class EventFactory extends BaseFactory {
         const pipelineFactory = PipelineFactory.getInstance();
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${config.username}` : config.username;
+        const modelConfig = {
+            type: config.type || 'pipeline',
+            pipelineId: config.pipelineId,
+            sha: config.sha,
+            startFrom: config.startFrom,
+            causeMessage: config.causeMessage || `Started by ${displayName}`
+        };
 
         return pipelineFactory.get(config.pipelineId)
             // Sync pipeline to make sure workflowGraph is generated
-            .then(p => p.sync())
+            .then((p) => {
+                if (config.parentEventId) {
+                    modelConfig.parentEventId = config.parentEventId;
+
+                    // Sync pipeline with the parentEvent sha and create jobs based on that sha
+                    return p.sync(config.sha);
+                }
+
+                return p.sync();
+            })
             .then((p) => {
                 if (config.prRef) {
                     return p.syncPR(config.prNum);
@@ -222,54 +239,42 @@ class EventFactory extends BaseFactory {
 
                 return p;
             })
-            .then((pipeline) => {
-                const modelConfig = {
-                    type: config.type || 'pipeline',
-                    pipelineId: config.pipelineId,
-                    sha: config.sha,
-                    startFrom: config.startFrom,
-                    causeMessage: config.causeMessage || `Started by ${displayName}`
-                };
-
-                return pipeline.token
-                    .then(token =>
-                        this.scm.decorateAuthor({ // decorate user who creates this event
-                            username: config.username,
-                            scmContext: config.scmContext,
-                            token
-                        })
-                            .then((creator) => {
-                                modelConfig.creator = creator;
-
-                                const scmUri = pipeline.scmUri;
-
-                                return this.scm.decorateCommit({
-                                    scmUri,
-                                    scmContext: config.scmContext,
-                                    sha: config.sha,
-                                    token
-                                });
-                            }))
-                    .then((commit) => {
-                        modelConfig.commit = commit;
-                        modelConfig.createTime = (new Date()).toISOString();
-
-                        // Get latest workflow graph
-                        return getLatestWorkflowGraph({
-                            pipeline,
-                            eventConfig: config
-                        });
+            .then(pipeline => pipeline.token
+                .then(token =>
+                    this.scm.decorateAuthor({ // decorate user who creates this event
+                        username: config.username,
+                        scmContext: config.scmContext,
+                        token
                     })
-                    .then((workflowGraph) => {
-                        if (config.parentEventId) {
-                            modelConfig.parentEventId = config.parentEventId;
-                            modelConfig.workflowGraph = config.workflowGraph;
-                        } else {
-                            modelConfig.workflowGraph = workflowGraph;
+                        .then((creator) => {
+                            modelConfig.creator = creator;
+
+                            return this.scm.decorateCommit({
+                                scmUri: pipeline.scmUri,
+                                scmContext: config.scmContext,
+                                sha: config.sha,
+                                token
+                            });
+                        }))
+                .then((commit) => {
+                    modelConfig.commit = commit;
+                    modelConfig.createTime = (new Date()).toISOString();
+
+                    // Get latest config
+                    return getLatestWorkflowGraph({
+                        pipeline,
+                        eventConfig: config
+                    }).then((latestConfig) => {
+                        if (modelConfig.type === 'pr') {
+                            return latestConfig;
                         }
+                        modelConfig.workflowGraph = latestConfig.workflowGraph;
+                        modelConfig.workflow = latestConfig.workflow; // TODO: deprecate this
 
-                        return super.create(modelConfig);
-                    })
+                        return modelConfig;
+                    });
+                })
+                .then(pipelineConfig => super.create(pipelineConfig)
                     .then((event) => {
                         if (modelConfig.type === 'pipeline') {
                             pipeline.lastEventId = event.id;
@@ -281,11 +286,12 @@ class EventFactory extends BaseFactory {
                                 eventConfig: config,
                                 eventId: event.id,
                                 pipeline,
-                                pipelineConfig: modelConfig
+                                pipelineConfig
                             }))
                             .then(() => event);
-                    });
-            });
+                    })
+                )
+            );
     }
 
     /**

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -260,37 +260,31 @@ class EventFactory extends BaseFactory {
                     modelConfig.commit = commit;
                     modelConfig.createTime = (new Date()).toISOString();
 
-                    // Get latest config
                     return getLatestWorkflowGraph({
                         pipeline,
                         eventConfig: config
-                    }).then((latestConfig) => {
-                        if (modelConfig.type === 'pr') {
-                            return latestConfig;
-                        }
-                        modelConfig.workflowGraph = latestConfig.workflowGraph;
-                        modelConfig.workflow = latestConfig.workflow; // TODO: deprecate this
-
-                        return modelConfig;
                     });
                 })
-                .then(pipelineConfig => super.create(pipelineConfig)
-                    .then((event) => {
-                        if (modelConfig.type === 'pipeline') {
-                            pipeline.lastEventId = event.id;
-                        }
+                .then((workflowGraph) => {
+                    modelConfig.workflowGraph = workflowGraph;
 
-                        return pipeline.update()
-                            // Start builds
-                            .then(() => createBuilds({
-                                eventConfig: config,
-                                eventId: event.id,
-                                pipeline,
-                                pipelineConfig
-                            }))
-                            .then(() => event);
-                    })
-                )
+                    return super.create(modelConfig);
+                })
+                .then((event) => {
+                    if (modelConfig.type === 'pipeline') {
+                        pipeline.lastEventId = event.id;
+                    }
+
+                    return pipeline.update()
+                        // Start builds
+                        .then(() => createBuilds({
+                            eventConfig: config,
+                            eventId: event.id,
+                            pipeline,
+                            pipelineConfig: modelConfig
+                        }))
+                        .then(() => event);
+                })
             );
     }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -357,9 +357,10 @@ class PipelineModel extends BaseModel {
      * Create, update, or disable jobs if necessary.
      * Store/update the pipeline workflow
      * @method sync
+     * @param {String} [ref]  A reference to fetch the screwdriver.yaml, can be branch/tag/commit
      * @return {Promise}
      */
-    sync() {
+    sync(ref) {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -369,7 +370,7 @@ class PipelineModel extends BaseModel {
         const factory = JobFactory.getInstance();
 
         // get the pipeline configuration
-        return this.getConfiguration()
+        return this.getConfiguration(ref)
             // get list of jobs to create
             .then((parsedConfig) => {
                 this.workflow = parsedConfig.workflow;

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -409,7 +409,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should create using parentEvent workflowGraph', () => {
+        it('should create using parentEvent workflowGraph and job configs', () => {
             config.parentEventId = 222;
             config.workflowGraph = {
                 nodes: [
@@ -422,8 +422,10 @@ describe('Event Factory', () => {
             };
             expected.workflowGraph = config.workflowGraph;
             expected.parentEventId = config.parentEventId;
+            syncedPipelineMock.workflowGraph = config.workflowGraph;
 
             return factory.create(config).then((model) => {
+                assert.calledWith(pipelineMock.sync, config.sha);
                 assert.instanceOf(model, Event);
                 Object.keys(expected).forEach((key) => {
                     if (key === 'workflowGraph') {


### PR DESCRIPTION
## Context
When user restarts a job from a past event. We want to fetch the exact same screwdriver.yaml in that event/sha and create/update jobs accordingly.

## Objective
make `pipeline.sync()` take in optional ref so that it can fetch the exact job config from parentEvent.

## Related to https://github.com/screwdriver-cd/screwdriver/issues/806