### PR TITLE
fix: syncPR creates missing PR jobs

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -8,36 +8,6 @@ const workflowParser = require('screwdriver-workflow-parser');
 let instance;
 
 /**
- * Returns 2 arrays:
- * 1. Jobs to start
- * 2. Job to create
- * @method splitPRJobs
- * @param  {Object}    config
- * @param  {Array}     config.jobs      PR jobs
- * @param  {Array}     config.nextJobs  PR job names to trigger next
- * @param  {Number}    config.prNum     PR number
- * @return {Object}                     Object with jobsToStart array of job object and jobsToCreate array of jobName
- */
-function splitPRJobs(config) {
-    const { jobs, nextJobs, prNum } = config;
-    // Get jobsToStart
-    // To start all existing and ENABLED PR-prNum jobs
-    const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
-    const jobsToStart = PRJobArray.filter(j => j.state === 'ENABLED');
-    // Get jobsToCreate
-    // Get all the missing PR- job names
-    const existingPRJobNames = PRJobArray.map(p => p.name);
-    const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
-    // Get the job name part, e.g. main from PR-1:main
-    const missingJobNames = missingPRJobNames.map(name => name.split(':')[1]);
-
-    return {
-        jobsToStart,
-        jobsToCreate: missingJobNames
-    };
-}
-
-/**
  * Get triggered jobs to start that are enabled
  * @method getJobsFromTrigger
  * @param  {Object}   config
@@ -85,45 +55,22 @@ function getJobsFromJobName(config) {
  * Get PR jobs to start that are enabled
  * @method getJobsFromPR
  * @param  {Object}   config
- * @param  {Object}   config.jobFactory                     Job Factory
  * @param  {Array}    config.jobs                           Array of job objects
- * @param  {Object}   config.pipeline                       Pipeline object
- * @param  {Object}   config.pipelineConfig
- * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
- * @param  {Array}    config.pipelineConfig.jobs            Array of job objects
  * @param  {Number}   config.prNum                          PR number
  * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
  * @resolves {Array}                                        Array of PR jobs to start
  */
 function getJobsFromPR(config) {
-    const { jobFactory, jobs, pipeline, pipelineConfig, prNum, startFrom } = config;
+    const { jobs, prNum, startFrom } = config;
 
     if (startFrom !== '~pr') {
         return [];
     }
 
-    // Get next jobs for when startFrom is ~pr
-    const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
-        trigger: startFrom,
-        prNum
-    });
-    // Get jobs to start and jobNames to create
-    const { jobsToStart, jobsToCreate } = splitPRJobs({
-        jobs,
-        nextJobs,
-        prNum
-    });
+    const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
+    const jobsToStart = PRJobArray.filter(j => j.state === 'ENABLED');
 
-    // Create missing PR jobs
-    return Promise.all(jobsToCreate.map(jobName =>
-        // Create jobs
-        jobFactory.create({
-            permutations: pipelineConfig.jobs[jobName],
-            pipelineId: pipeline.id,
-            name: `PR-${prNum}:${jobName}`
-        })))
-        // Add newly created PR jobs to jobsToStart array
-        .then(newJobs => jobsToStart.concat(newJobs));
+    return jobsToStart;
 }
 
 /**
@@ -159,8 +106,6 @@ function createBuilds(config) {
     /* eslint-disable global-require */
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
-    const JobFactory = require('./jobFactory');
-    const jobFactory = JobFactory.getInstance();
     /* eslint-enable global-require */
 
     return pipeline.jobs.then((jobs) => {
@@ -177,10 +122,7 @@ function createBuilds(config) {
         });
         // When startFrom is ~pr
         const jobsFromPR = getJobsFromPR({
-            jobFactory,
             jobs,
-            pipeline,
-            pipelineConfig,
             prNum: eventConfig.prNum,
             startFrom
         });
@@ -214,7 +156,7 @@ function createBuilds(config) {
 function getLatestConfig(config) {
     const { pipeline, eventConfig } = config;
 
-    // For pull request
+    // For pull request, syncPR then get Configuration
     if (eventConfig.prRef) {
         return pipeline.syncPR(eventConfig.prNum)
             .then(() => pipeline.getConfiguration(eventConfig.prRef));
@@ -287,10 +229,6 @@ class EventFactory extends BaseFactory {
                     causeMessage: config.causeMessage || `Started by ${displayName}`
                 };
 
-                if (config.parentEventId) {
-                    modelConfig.parentEventId = config.parentEventId;
-                }
-
                 return pipeline.token
                     .then(token =>
                         this.scm.decorateAuthor({ // decorate user who creates this event
@@ -314,43 +252,37 @@ class EventFactory extends BaseFactory {
                         modelConfig.commit = commit;
                         modelConfig.createTime = (new Date()).toISOString();
 
-                        if (config.workflowGraph) {
-                            modelConfig.workflowGraph = config.workflowGraph;
-
-                            return modelConfig;
-                        }
-
                         // Get latest config
                         return getLatestConfig({
                             pipeline,
                             eventConfig: config
-                        }).then((latestConfig) => {
-                            if (modelConfig.type === 'pr') {
-                                return latestConfig;
-                            }
-                            modelConfig.workflowGraph = latestConfig.workflowGraph;
-                            modelConfig.workflow = latestConfig.workflow; // TODO: deprecate this
-
-                            return modelConfig;
                         });
                     })
-                    .then(pipelineConfig => super.create(pipelineConfig)
-                        .then((event) => {
-                            if (modelConfig.type === 'pipeline') {
-                                pipeline.lastEventId = event.id;
-                            }
+                    .then((latestConfig) => {
+                        if (config.parentEventId) {
+                            modelConfig.parentEventId = config.parentEventId;
+                            modelConfig.workflowGraph = config.workflowGraph;
+                        } else {
+                            modelConfig.workflowGraph = latestConfig.workflowGraph;
+                        }
 
-                            return pipeline.update()
-                                // Start builds
-                                .then(() => createBuilds({
-                                    eventConfig: config,
-                                    eventId: event.id,
-                                    pipeline,
-                                    pipelineConfig
-                                }))
-                                .then(() => event);
-                        })
-                    );
+                        return super.create(modelConfig);
+                    })
+                    .then((event) => {
+                        if (modelConfig.type === 'pipeline') {
+                            pipeline.lastEventId = event.id;
+                        }
+
+                        return pipeline.update()
+                            // Start builds
+                            .then(() => createBuilds({
+                                eventConfig: config,
+                                eventId: event.id,
+                                pipeline,
+                                pipelineConfig: modelConfig
+                            }))
+                            .then(() => event);
+                    });
             });
     }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -288,6 +288,7 @@ class PipelineModel extends BaseModel {
     /**
      * Sync PR by looking up the PR's screwdriver.yaml
      * Update the permutations to be correct
+     * Create missing PR jobs
      * @param   {Number}   prNum        PR Number
      * @method syncPR
      * @return {Promise}
@@ -308,15 +309,44 @@ class PipelineModel extends BaseModel {
             .then(([parsedConfig, jobs]) => {
                 const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}`));
 
-                return prJobs.map((job) => {
-                    // eslint-disable-next-line no-underscore-dangle
-                    const jobName = this._getPartialJobName(job.name, 'job') || 'main';
-
-                    job.archived = false;
-                    job.permutations = parsedConfig.jobs[jobName];
-
-                    return job.update();
+                // Get next jobs for when startFrom is ~pr
+                const nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
+                    trigger: '~pr',
+                    prNum
                 });
+
+                // Get all the missing PR- job names
+                const existingPRJobNames = prJobs.map(p => p.name);
+                const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
+
+                // Get the job name part, e.g. main from PR-1:main
+                const jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
+
+                // Lazy load factory dependency to prevent circular dependency issues
+                // https://nodejs.org/api/modules.html#modules_cycles
+                /* eslint-disable global-require */
+                const JobFactory = require('./jobFactory');
+                /* eslint-enable global-require */
+                const jobFactory = JobFactory.getInstance();
+
+                // Create missing PR jobs
+                return Promise.all(jobsToCreate.map(jobName =>
+                    // Create jobs
+                    jobFactory.create({
+                        permutations: parsedConfig.jobs[jobName],
+                        pipelineId: this.id,
+                        name: `PR-${prNum}:${jobName}`
+                    })))
+                    .then(() => prJobs.map((job) => {
+                        // eslint-disable-next-line no-underscore-dangle
+                        const jobName = this._getPartialJobName(job.name, 'job') || 'main';
+
+                        // unarchived and update the rest of the jobs
+                        job.archived = false;
+                        job.permutations = parsedConfig.jobs[jobName];
+
+                        return job.update();
+                    }));
             })
             .then(() => this);
     }

--- a/test/data/parserWithWorkflowGraphPR.json
+++ b/test/data/parserWithWorkflowGraphPR.json
@@ -16,10 +16,47 @@
                 "environment": {
                     "NODE_ENV": "test",
                     "NODE_VERSION": "4"
-                }
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            },
+            {
+                "image": "node:5",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "5"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            },
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "6"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
             }
         ],
-        "new_main": [
+        "publish": [
             {
                 "image": "node:4",
                 "commands": [
@@ -39,7 +76,20 @@
                 "environment": {
                     "NODE_ENV": "test",
                     "NODE_TAG": "latest"
-                }
+                },
+                "requires": ["main"]
+            }
+        ],
+        "new_pr_job": [
+            {
+                "image": "node:8",
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install test"
+                    }
+                ],
+                "requires": ["~pr"]
             }
         ]
     },
@@ -49,13 +99,17 @@
             { "name": "~pr" },
             { "name": "~commit" },
             { "name": "main" },
-            { "name": "new_main" }
+            { "name": "publish" },
+            { "name": "new_pr_job" }
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
+            { "src": "~pr", "dest": "new_pr_job" },
             { "src": "~commit", "dest": "main" },
-            { "src": "~pr", "dest": "new_main" },
-            { "src": "~commit", "dest": "new_main" }
+            { "src": "main", "dest": "publish" }
         ]
+    },
+    "annotations": {
+        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
     }
 }

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -229,7 +229,7 @@ describe('Base Factory', () => {
                 name: 'component'
             },
             {
-                id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                id: 123,
                 name: 'deploy'
             }
         ];

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -63,7 +63,7 @@ describe('Job Factory', () => {
     });
 
     describe('create', () => {
-        const jobId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+        const jobId = 123;
         const pipelineId = 'cf23df2207d99a74fbe169e3eba035e633b65d94';
         const name = 'main';
         const saveConfig = {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -9,6 +9,7 @@ const schema = require('screwdriver-data-schema');
 sinon.assert.expose(assert, { prefix: '' });
 const PARSED_YAML = require('../data/parser');
 const PARSED_YAML_WITH_REQUIRES = require('../data/parserWithRequires');
+const PARSED_YAML_PR = require('../data/parserWithWorkflowGraphPR');
 
 describe('Pipeline Model', () => {
     let PipelineModel;
@@ -28,7 +29,7 @@ describe('Pipeline Model', () => {
     const dateNow = 1111111111;
     const scmUri = 'github.com:12345:master';
     const scmContext = 'github:github.com';
-    const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+    const testId = 123;
     const admins = { batman: true };
     const paginate = {
         page: 1,
@@ -527,7 +528,7 @@ describe('Pipeline Model', () => {
             prJob = {
                 update: sinon.stub().resolves(null),
                 isPR: sinon.stub().returns(true),
-                name: 'PR-1',
+                name: 'PR-1:main',
                 state: 'ENABLED',
                 archived: false
             };
@@ -550,7 +551,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('update PR config for multiple PR jobs', () => {
+        it('update PR config for multiple PR jobs and create missing PR jobs', () => {
             const firstPRJob = {
                 update: sinon.stub().resolves(null),
                 isPR: sinon.stub().returns(true),
@@ -567,6 +568,7 @@ describe('Pipeline Model', () => {
             };
 
             jobFactoryMock.list.resolves([firstPRJob, secondPRJob]);
+            parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML_PR);
 
             return pipeline.syncPR(1).then(() => {
                 assert.calledWith(scmMock.getFile, {
@@ -578,8 +580,12 @@ describe('Pipeline Model', () => {
                 });
                 assert.calledOnce(firstPRJob.update);
                 assert.calledOnce(secondPRJob.update);
-                assert.deepEqual(firstPRJob.permutations, PARSED_YAML.jobs.main);
-                assert.deepEqual(secondPRJob.permutations, PARSED_YAML.jobs.publish);
+                assert.calledWith(jobFactoryMock.create, sinon.match({
+                    pipelineId: 123,
+                    name: 'PR-1:new_pr_job'
+                }));
+                assert.deepEqual(firstPRJob.permutations, PARSED_YAML_PR.jobs.main);
+                assert.deepEqual(secondPRJob.permutations, PARSED_YAML_PR.jobs.publish);
                 assert.isFalse(firstPRJob.archived);
                 assert.isFalse(secondPRJob.archived);
             });
@@ -761,7 +767,7 @@ describe('Pipeline Model', () => {
         it('Get jobs in workflow in order', () => {
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     archived: false
                 },
                 paginate
@@ -782,7 +788,7 @@ describe('Pipeline Model', () => {
         it('Get PR jobs and sort them by name', () => {
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     archived: false
                 },
                 paginate
@@ -805,7 +811,7 @@ describe('Pipeline Model', () => {
             };
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     archived: false
                 },
                 paginate
@@ -828,7 +834,7 @@ describe('Pipeline Model', () => {
             };
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     archived: false
                 },
                 paginate
@@ -853,7 +859,7 @@ describe('Pipeline Model', () => {
             };
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     archived: true
                 },
                 paginate
@@ -877,7 +883,7 @@ describe('Pipeline Model', () => {
             };
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     archived: false
                 },
                 paginate
@@ -904,7 +910,7 @@ describe('Pipeline Model', () => {
         it('Get list of events', () => {
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     type: 'pipeline'
                 },
                 sort: 'descending',
@@ -922,7 +928,7 @@ describe('Pipeline Model', () => {
         it('Merge the passed in config with the default config', () => {
             const expected = {
                 params: {
-                    pipelineId: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    pipelineId: 123,
                     type: 'pr'
                 },
                 sort: 'descending',
@@ -1024,7 +1030,7 @@ describe('Pipeline Model', () => {
             const expected = {
                 params: {
                     admins: { d2lam: true },
-                    id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    id: 123,
                     scmContext,
                     scmRepo: {
                         branch: 'master',
@@ -1062,7 +1068,7 @@ describe('Pipeline Model', () => {
             const expected = {
                 params: {
                     admins: { d2lam: true },
-                    id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+                    id: 123,
                     scmContext
                 },
                 table: 'pipelines'

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -19,7 +19,7 @@ describe('Pipeline Factory', () => {
     const nowTime = (new Date(dateNow)).toISOString();
     const scmUri = 'github.com:12345:master';
     const scmContext = 'github:github.com';
-    const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+    const testId = 123;
     const admins = ['me'];
     const scmRepo = {
         name: 'foo/bar',

--- a/test/lib/template.test.js
+++ b/test/lib/template.test.js
@@ -41,7 +41,7 @@ describe('Template Model', () => {
             description: 'this is a template',
             labels: ['test', 'beta'],
             config: { image: 'node:6' },
-            pipelineId: '123'
+            pipelineId: 123
         };
         template = new TemplateModel(createConfig);
     });

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -13,7 +13,7 @@ describe('Template Factory', () => {
     const description = 'this is a template';
     const labels = ['test', 'beta'];
     const templateConfig = { image: 'node:6' };
-    const pipelineId = '123';
+    const pipelineId = 123;
     const metaData = {
         name,
         version,

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -61,7 +61,7 @@ describe('User Model', () => {
 
         createConfig = {
             datastore,
-            id: 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c',
+            id: 123,
             username: 'me',
             scmContext,
             token,


### PR DESCRIPTION
## Context
When create the actual event, we need `modelConfig` https://github.com/screwdriver-cd/models/blob/2bf6214146427ff8b71a2f3e8516e157e55a18ab/lib/eventFactory.js#L327

After creating the event, for PR job, `getLatestConfig` returns the latest pipeline config for that prRef and create missing PR jobs: https://github.com/screwdriver-cd/models/blob/2bf6214146427ff8b71a2f3e8516e157e55a18ab/lib/eventFactory.js#L339

This behavior got messed up from this PR: https://github.com/screwdriver-cd/models/pull/224/files 
https://github.com/screwdriver-cd/models/blob/d3cb7e40ab2389e3404500f38a7a41174330fca7/lib/eventFactory.js#L328-L334
because we need return BOTH `modelConfig` and the `latestConfig` (for PRs). For non-PR, it only needs `modelConfig`. 

This behavior requires us to call `getConfiguration` twice for PR jobs, and it's confusing. We only need the `pipelineConfig` because we want to create the missing PR jobs. Ideally, this should happen when we syncPR, since the expected behavior of syncing is to correct the state. So this PR moves the logic there and remove the needs of `pipelineConfig` inside event create.