### PR TITLE
fix: moves syncPR up and returns the new pipeline

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -144,29 +144,24 @@ function createBuilds(config) {
 }
 
 /**
- * Get the latest workflowGraph and pipelineConfig
- * @method getLatestConfig
+ * Get the latest workflowGraph
+ * @method getLatestWorkflowGraph
  * @param  {Object}         config
- * @param  {Pipeline}       pipeline            Pipeline to be synced
+ * @param  {Pipeline}       pipeline            Pipeline
  * @param  {Object}         eventConfig
- * @param  {Number}         [eventConfig.prNum] PR number
  * @param  {String}         [eventConfig.prRef] PR ref
- * @resolves {Object}                           Resolves with object with workflowGraph
+ * @resolves {Object}                           Resolves with workflowGraph
  */
-function getLatestConfig(config) {
+function getLatestWorkflowGraph(config) {
     const { pipeline, eventConfig } = config;
 
-    // For pull request, syncPR then get Configuration
     if (eventConfig.prRef) {
-        return pipeline.syncPR(eventConfig.prNum)
-            .then(() => pipeline.getConfiguration(eventConfig.prRef));
+        return pipeline.getConfiguration(eventConfig.prRef)
+            .then(c => c.workflowGraph);
     }
 
     // For everything else
-    return Promise.resolve({
-        workflow: pipeline.workflow,
-        workflowGraph: pipeline.workflowGraph
-    });
+    return Promise.resolve(pipeline.workflowGraph);
 }
 
 class EventFactory extends BaseFactory {
@@ -220,6 +215,13 @@ class EventFactory extends BaseFactory {
         return pipelineFactory.get(config.pipelineId)
             // Sync pipeline to make sure workflowGraph is generated
             .then(p => p.sync())
+            .then((p) => {
+                if (config.prRef) {
+                    return p.syncPR(config.prNum);
+                }
+
+                return p;
+            })
             .then((pipeline) => {
                 const modelConfig = {
                     type: config.type || 'pipeline',
@@ -252,18 +254,18 @@ class EventFactory extends BaseFactory {
                         modelConfig.commit = commit;
                         modelConfig.createTime = (new Date()).toISOString();
 
-                        // Get latest config
-                        return getLatestConfig({
+                        // Get latest workflow graph
+                        return getLatestWorkflowGraph({
                             pipeline,
                             eventConfig: config
                         });
                     })
-                    .then((latestConfig) => {
+                    .then((workflowGraph) => {
                         if (config.parentEventId) {
                             modelConfig.parentEventId = config.parentEventId;
                             modelConfig.workflowGraph = config.workflowGraph;
                         } else {
-                            modelConfig.workflowGraph = latestConfig.workflowGraph;
+                            modelConfig.workflowGraph = workflowGraph;
                         }
 
                         return super.create(modelConfig);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -348,6 +348,7 @@ class PipelineModel extends BaseModel {
                         return job.update();
                     }));
             })
+            .then(() => delete this.jobs) // so that next time it will not get the cached version of this.jobs
             .then(() => this);
     }
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -123,6 +123,7 @@ describe('Event Factory', () => {
         let expected;
         let jobsMock;
         let syncedPipelineMock;
+        let afterSyncedPRPipelineMock;
 
         beforeEach(() => {
             config = {
@@ -184,10 +185,12 @@ describe('Event Factory', () => {
                     ]
                 },
                 getConfiguration: sinon.stub().resolves(PARSED_YAML),
-                syncPR: sinon.stub().resolves(null),
                 update: sinon.stub().resolves(null),
                 job: Promise.resolve([])
             };
+
+            afterSyncedPRPipelineMock = Object.assign({}, syncedPipelineMock);
+            syncedPipelineMock.syncPR = sinon.stub().resolves(afterSyncedPRPipelineMock);
 
             pipelineMock = {
                 sync: sinon.stub().resolves(syncedPipelineMock)
@@ -276,7 +279,7 @@ describe('Event Factory', () => {
                     state: 'DISABLED'
                 }];
 
-                syncedPipelineMock.jobs = Promise.resolve(jobsMock);
+                afterSyncedPRPipelineMock.jobs = Promise.resolve(jobsMock);
 
                 config.startFrom = '~pr';
                 config.prRef = 'branch';


### PR DESCRIPTION
In https://github.com/screwdriver-cd/models/pull/226, it calls `getLatestConfig` and creates new jobs inside `syncPR`, but this new pipeline needs to return. Otherwise the `pipeline.jobs` is from the previous pipeline before the sync. 

This PR moves the logic outside for `getLatestConfig` and make sure it gets the new pipeline after syncing. 