### PR TITLE
fix: set meta for event as {} by default

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -217,7 +217,8 @@ class EventFactory extends BaseFactory {
             pipelineId: config.pipelineId,
             sha: config.sha,
             startFrom: config.startFrom,
-            causeMessage: config.causeMessage || `Started by ${displayName}`
+            causeMessage: config.causeMessage || `Started by ${displayName}`,
+            meta: {}
         };
 
         return pipelineFactory.get(config.pipelineId)

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -157,7 +157,8 @@ describe('Event Factory', () => {
                 causeMessage: 'Started by github:stjohn',
                 createTime: nowTime,
                 creator,
-                commit
+                commit,
+                meta: {}
             };
 
             syncedPipelineMock = {
@@ -392,7 +393,7 @@ describe('Event Factory', () => {
                 });
                 assert.strictEqual(syncedPipelineMock.lastEventId, model.id);
                 Object.keys(expected).forEach((key) => {
-                    if (key === 'workflowGraph') {
+                    if (key === 'workflowGraph' || key === 'meta') {
                         assert.deepEqual(model[key], expected[key]);
                     } else {
                         assert.strictEqual(model[key], expected[key]);


### PR DESCRIPTION
## Context
There is a bug right now that you cannot set or get meta when you try to run a detached pipeline when the parent event doesn't have metadata.

## Objective
This PR will set meta for event as {} by default.

