### PR TITLE
feat(911): Support subdirectory [6]

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -173,7 +173,15 @@ function createBuilds(config) {
                     changedFiles,
                     sourcePaths: j.sourcePaths
                 })
-            ));
+            )).then((buildsCreated) => {
+                const nobuilds = buildsCreated.every(b => b === null);
+
+                if (nobuilds) {
+                    throw new Error('No jobs to start');
+                }
+
+                return buildsCreated;
+            });
         });
 }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -100,7 +100,7 @@ function startBuild(config) {
                 }
 
                 // source path is directory
-                return file.includes(source);
+                return file.startsWith(source);
             }));
     }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -74,10 +74,13 @@ function getJobsFromPR(config) {
 }
 
 /**
- * [createBuild description]
+ * Starts the build if the changed file is part of the sourcePaths, or if there is no sourcePaths
  * @method startBuild
- * @param  {[type]}    config [description]
- * @return {[type]}           [description]
+ * @param  {Object}   config                configuration object
+ * @param  {Object}   config.buildConfig    Build Config to create the build with
+ * @param  {Array}    config.changedFiles   List of files that were changed
+ * @param  {Array}    config.sourcePaths    List of soure paths
+ * @return {Promise}
  */
 function startBuild(config) {
     /* eslint-disable global-require */
@@ -85,13 +88,12 @@ function startBuild(config) {
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
     const { buildConfig, changedFiles, sourcePaths } = config;
-    let hasChangeInSourcePaths = true; // if no sourcePaths, then always start
+    let hasChangeInSourcePaths = true;
 
-    console.log(changedFiles);
-    console.log(sourcePaths);
-
-    if (config.sourcePaths) {
-        hasChangeInSourcePaths = changedFiles.some(f => sourcePaths.includes(f));
+    // Only check if sourcePaths exists
+    if (sourcePaths) {
+        hasChangeInSourcePaths = changedFiles.some(file =>
+            sourcePaths.some(source => file.includes(source)));
     }
 
     return hasChangeInSourcePaths ? buildFactory.create(buildConfig) : null;
@@ -128,10 +130,6 @@ function createBuilds(config) {
         return null;
     }
 
-    console.log('-----');
-    console.log(pipeline);
-    console.log('-----');
-
     return pipeline.jobs.then((jobs) => {
         // When startFrom is ~commit
         const jobsFromTrigger = getJobsFromTrigger({
@@ -152,8 +150,7 @@ function createBuilds(config) {
         });
 
         return Promise.all([jobsFromTrigger, jobsFromJobName, jobsFromPR])
-            .then(result => result.reduce((a, b) => a.concat(b))
-            );
+            .then(result => result.reduce((a, b) => a.concat(b)));
     })
         .then((jobsToStart) => {
             // No jobs to start (eg: when jobs are disabled or startFrom is not valid)

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -87,6 +87,9 @@ function startBuild(config) {
     const { buildConfig, changedFiles, sourcePaths } = config;
     let hasChangeInSourcePaths = true; // if no sourcePaths, then always start
 
+    console.log(changedFiles);
+    console.log(sourcePaths);
+
     if (config.sourcePaths) {
         hasChangeInSourcePaths = changedFiles.some(f => sourcePaths.includes(f));
     }
@@ -125,6 +128,10 @@ function createBuilds(config) {
         return null;
     }
 
+    console.log('-----');
+    console.log(pipeline);
+    console.log('-----');
+
     return pipeline.jobs.then((jobs) => {
         // When startFrom is ~commit
         const jobsFromTrigger = getJobsFromTrigger({
@@ -145,7 +152,8 @@ function createBuilds(config) {
         });
 
         return Promise.all([jobsFromTrigger, jobsFromJobName, jobsFromPR])
-            .then(result => result.reduce((a, b) => a.concat(b)));
+            .then(result => result.reduce((a, b) => a.concat(b))
+            );
     })
         .then((jobsToStart) => {
             // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
@@ -299,10 +307,10 @@ class EventFactory extends BaseFactory {
 
                     return pipeline.update()
                         // Start builds
-                        .then(() => createBuilds({
+                        .then(p => createBuilds({
                             eventConfig: config,
                             eventId: event.id,
-                            pipeline,
+                            pipeline: p,
                             pipelineConfig: modelConfig,
                             changedFiles: config.changedFiles
                         }))

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -94,15 +94,13 @@ function startBuild(config) {
     if (sourcePaths) {
         hasChangeInSourcePaths = changedFiles.some(file =>
             sourcePaths.some((source) => {
-                let path = source;
-
-                // make sure it's in this format foo/bar/
-                // because with changedFile as 'foo/barTest.md', it should return false
-                if (path.slice(-1) !== '/') {
-                    path += '/';
+                // source path is a file
+                if (source.slice(-1) !== '/') {
+                    return file === source;
                 }
 
-                return file.includes(path);
+                // source path is directory
+                return file.includes(source);
             }));
     }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -93,7 +93,17 @@ function startBuild(config) {
     // Only check if sourcePaths exists
     if (sourcePaths) {
         hasChangeInSourcePaths = changedFiles.some(file =>
-            sourcePaths.some(source => file.includes(source)));
+            sourcePaths.some((source) => {
+                let path = source;
+
+                // make sure it's in this format foo/bar/
+                // because with changedFile as 'foo/barTest.md', it should return false
+                if (path.slice(-1) !== '/') {
+                    path += '/';
+                }
+
+                return file.includes(path);
+            }));
     }
 
     return hasChangeInSourcePaths ? buildFactory.create(buildConfig) : null;

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -74,6 +74,27 @@ function getJobsFromPR(config) {
 }
 
 /**
+ * [createBuild description]
+ * @method startBuild
+ * @param  {[type]}    config [description]
+ * @return {[type]}           [description]
+ */
+function startBuild(config) {
+    /* eslint-disable global-require */
+    const BuildFactory = require('./buildFactory');
+    const buildFactory = BuildFactory.getInstance();
+    /* eslint-enable global-require */
+    const { buildConfig, changedFiles, sourcePaths } = config;
+    let hasChangeInSourcePaths = true; // if no sourcePaths, then always start
+
+    if (config.sourcePaths) {
+        hasChangeInSourcePaths = changedFiles.some(f => sourcePaths.includes(f));
+    }
+
+    return hasChangeInSourcePaths ? buildFactory.create(buildConfig) : null;
+}
+
+/**
  * Create builds associated with this event
  * For example, if startFrom ~commit, then create builds with jobs that have requires: ~commit
  * @method createBuilds
@@ -93,20 +114,16 @@ function getJobsFromPR(config) {
  * @param  {Object}   config.pipelineConfig
  * @param  {Array}    [config.pipelineConfig.workflow]       Job names that will be executed for this event
  * @param  {Object}   [config.pipelineConfig.workflowGraph]  Object with nodes and edges that represent the order of jobs
+ * @param  {Array}    [config.changedFiles]                  Array of files that were changed
  */
 function createBuilds(config) {
-    const { eventConfig, eventId, pipeline, pipelineConfig } = config;
+    const { eventConfig, eventId, pipeline, pipelineConfig, changedFiles } = config;
     const startFrom = eventConfig.startFrom;
 
     // If no startFrom, then do nothing. Remove once we switch to new workflow design
     if (!startFrom) {
         return null;
     }
-
-    /* eslint-disable global-require */
-    const BuildFactory = require('./buildFactory');
-    const buildFactory = BuildFactory.getInstance();
-    /* eslint-enable global-require */
 
     return pipeline.jobs.then((jobs) => {
         // When startFrom is ~commit
@@ -138,7 +155,11 @@ function createBuilds(config) {
 
             // Start builds
             return Promise.all(jobsToStart.map(j =>
-                buildFactory.create(Object.assign({ jobId: j.id, eventId }, eventConfig))
+                startBuild({
+                    buildConfig: Object.assign({ jobId: j.id, eventId }, eventConfig),
+                    changedFiles,
+                    sourcePaths: j.sourcePaths
+                })
             ));
         });
 }
@@ -202,6 +223,7 @@ class EventFactory extends BaseFactory {
      * @param  {String}  [config.parentBuildId]     Id of the build that starts this event
      * @param  {String}  [config.parentEventId]     Id of the parent event
      * @param  {String}  [config.workflowGraph]     workflowGraph of parentEvent if there is a parentEvent
+     * @param  {Array}   [config.changedFiles]      Array of files that were changed
      * @return {Promise}
      */
     create(config) {
@@ -281,7 +303,8 @@ class EventFactory extends BaseFactory {
                             eventConfig: config,
                             eventId: event.id,
                             pipeline,
-                            pipelineConfig: modelConfig
+                            pipelineConfig: modelConfig,
+                            changedFiles: config.changedFiles
                         }))
                         .then(() => event);
                 })

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -234,7 +234,7 @@ describe('Event Factory', () => {
                 }];
 
                 syncedPipelineMock.jobs = Promise.resolve(jobsMock);
-                buildFactoryMock.create.resolves(null);
+                buildFactoryMock.create.resolves('a build object');
             });
 
             it('should start existing pr jobs without creating duplicates', () => {
@@ -422,8 +422,11 @@ describe('Event Factory', () => {
             config.startFrom = 'main';
             config.changedFiles = ['README.md', 'root/src/test/file'];
 
-            return eventFactory.create(config).then((model) => {
-                assert.instanceOf(model, Event);
+            return eventFactory.create(config).then(() => {
+                throw new Error('Should not get here');
+            }, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.message, 'No jobs to start');
                 assert.notCalled(buildFactoryMock.create);
             });
         });

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -413,7 +413,7 @@ describe('Event Factory', () => {
                     requires: ['~pr']
                 },
                 state: 'ENABLED',
-                sourcePaths: ['src/test']
+                sourcePaths: ['src/test/']
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
                 jobs: Promise.resolve(jobsMock)
@@ -446,7 +446,7 @@ describe('Event Factory', () => {
                     requires: ['~pr']
                 },
                 state: 'ENABLED',
-                sourcePaths: ['src/test']
+                sourcePaths: ['src/test/']
             }];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
                 jobs: Promise.resolve(jobsMock)
@@ -463,7 +463,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should not start builds if changed file is not in sourcePaths dir', () => {
+        it('should start build when sourcePath is a file, and is the same as changedFile', () => {
             jobsMock = [{
                 id: 1,
                 pipelineId: 8765,
@@ -481,11 +481,11 @@ describe('Event Factory', () => {
             config.startFrom = '~pr';
             config.prRef = 'branch';
             config.prNum = 1;
-            config.changedFiles = ['src/testfolder.md', 'NOTINSOURCEPATH.md'];
+            config.changedFiles = ['src/test', 'NOTINSOURCEPATH.md'];
 
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
-                assert.notCalled(buildFactoryMock.create);
+                assert.calledOnce(buildFactoryMock.create);
             });
         });
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -437,7 +437,7 @@ describe('Event Factory', () => {
                     requires: ['~pr']
                 },
                 state: 'ENABLED',
-                sourcePaths: ['src/test']
+                sourcePaths: ['src/test/']
             }, {
                 id: 2,
                 pipelineId: 8765,
@@ -460,6 +460,32 @@ describe('Event Factory', () => {
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledTwice(buildFactoryMock.create);
+            });
+        });
+
+        it('should not start builds if changed file is not in sourcePaths dir', () => {
+            jobsMock = [{
+                id: 1,
+                pipelineId: 8765,
+                name: 'PR-1:main',
+                permutations: {
+                    requires: ['~pr']
+                },
+                state: 'ENABLED',
+                sourcePaths: ['src/test']
+            }];
+            afterSyncedPRPipelineMock.update = sinon.stub().resolves({
+                jobs: Promise.resolve(jobsMock)
+            });
+
+            config.startFrom = '~pr';
+            config.prRef = 'branch';
+            config.prNum = 1;
+            config.changedFiles = ['src/testfolder.md', 'NOTINSOURCEPATH.md'];
+
+            return eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.notCalled(buildFactoryMock.create);
             });
         });
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -420,7 +420,7 @@ describe('Event Factory', () => {
             });
 
             config.startFrom = 'main';
-            config.changedFiles = ['README.md'];
+            config.changedFiles = ['README.md', 'root/src/test/file'];
 
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);


### PR DESCRIPTION
Instead of starting builds right after we get the `jobsToStart`, it will need to check if `sourcePaths` exists. If it exists, then check if the `changedFiles` is in `sourcePaths`. Only then, it will start the job.

Related: https://github.com/screwdriver-cd/screwdriver/issues/911
Blocked by: 
- https://github.com/screwdriver-cd/scm-github/pull/83
- https://github.com/screwdriver-cd/config-parser/pull/56
- https://github.com/screwdriver-cd/screwdriver/pull/940