### PR TITLE
fix: sourcePaths is part of permutations

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -171,7 +171,7 @@ function createBuilds(config) {
                 startBuild({
                     buildConfig: Object.assign({ jobId: j.id, eventId }, eventConfig),
                     changedFiles,
-                    sourcePaths: j.sourcePaths
+                    sourcePaths: j.permutations[0].sourcePaths // TODO: support matrix job
                 })
             )).then((buildsCreated) => {
                 const nobuilds = buildsCreated.every(b => b === null);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -211,25 +211,25 @@ describe('Event Factory', () => {
                     id: 1,
                     pipelineId: 8765,
                     name: 'main',
-                    permutations: {
+                    permutations: [{
                         requires: ['~commit', '~pr', '~sd@123:main']
-                    },
+                    }],
                     state: 'ENABLED'
                 }, {
                     id: 2,
                     pipelineId: 8765,
                     name: 'disabledjob',
-                    permutations: {
+                    permutations: [{
                         requires: ['main']
-                    },
+                    }],
                     state: 'DISABLED'
                 }, {
                     id: 4,
                     pipelineId: 8765,
                     name: 'publish',
-                    permutations: {
+                    permutations: [{
                         requires: ['~pr']
-                    },
+                    }],
                     state: 'ENABLED'
                 }];
 
@@ -242,42 +242,42 @@ describe('Event Factory', () => {
                     id: 1,
                     pipelineId: 8765,
                     name: 'main',
-                    permutations: {
+                    permutations: [{
                         requires: ['~pr']
-                    },
+                    }],
                     state: 'ENABLED'
                 }, {
                     id: 5,
                     pipelineId: 8765,
                     name: 'PR-1:main',
-                    permutations: {
+                    permutations: [{
                         requires: ['~pr']
-                    },
+                    }],
                     state: 'ENABLED'
                 },
                 {
                     id: 7,
                     pipelineId: 8765,
                     name: 'PR-2:main',
-                    permutations: {
+                    permutations: [{
                         requires: ['~pr']
-                    },
+                    }],
                     state: 'ENABLED'
                 },
                 {
                     id: 3,
                     name: 'publish',
-                    permutations: {
+                    permutations: [{
                         requires: ['~pr']
-                    },
+                    }],
                     state: 'ENABLED'
                 },
                 {
                     id: 6,
                     name: 'PR-1:publish',
-                    permutations: {
+                    permutations: [{
                         requires: ['~pr']
-                    },
+                    }],
                     state: 'DISABLED'
                 }];
 
@@ -409,11 +409,11 @@ describe('Event Factory', () => {
                 id: 1,
                 pipelineId: 8765,
                 name: 'main',
-                permutations: {
-                    requires: ['~pr']
-                },
-                state: 'ENABLED',
-                sourcePaths: ['src/test/']
+                permutations: [{
+                    requires: ['~pr'],
+                    sourcePaths: ['src/test/']
+                }],
+                state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
                 jobs: Promise.resolve(jobsMock)
@@ -436,20 +436,20 @@ describe('Event Factory', () => {
                 id: 1,
                 pipelineId: 8765,
                 name: 'PR-1:main',
-                permutations: {
-                    requires: ['~pr']
-                },
-                state: 'ENABLED',
-                sourcePaths: ['src/test/']
+                permutations: [{
+                    requires: ['~pr'],
+                    sourcePaths: ['src/test/']
+                }],
+                state: 'ENABLED'
             }, {
                 id: 2,
                 pipelineId: 8765,
                 name: 'PR-1:test',
-                permutations: {
-                    requires: ['~pr']
-                },
-                state: 'ENABLED',
-                sourcePaths: ['src/test/']
+                permutations: [{
+                    requires: ['~pr'],
+                    sourcePaths: ['src/test/']
+                }],
+                state: 'ENABLED'
             }];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
                 jobs: Promise.resolve(jobsMock)
@@ -471,11 +471,11 @@ describe('Event Factory', () => {
                 id: 1,
                 pipelineId: 8765,
                 name: 'PR-1:main',
-                permutations: {
-                    requires: ['~pr']
-                },
-                state: 'ENABLED',
-                sourcePaths: ['src/test']
+                permutations: [{
+                    requires: ['~pr'],
+                    sourcePaths: ['src/test']
+                }],
+                state: 'ENABLED'
             }];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
                 jobs: Promise.resolve(jobsMock)


### PR DESCRIPTION
The job object will look like this
```
    {
        "id": 3220,
        "name": "job1",
        "permutations": [
            {
                "annotations": {},
                "commands": [
                    {
                        "name": "echo",
                        "command": "echo hi"
                    }
                ],
                "environment": {},
                "image": "node:6",
                "secrets": [],
                "settings": {},
                "requires": [
                    "~commit",
                    "~pr"
                ],
                "sourcePaths": [
                    "README.md"
                ]
            }
        ],
        "pipelineId": 526,
        "state": "ENABLED",
        "archived": false
    }
```

So we need to get it from `permutations` instead
Also, fix the mocks to be more accurate, since `permutations` is an array. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/911