### PR TITLE
fix: return error if the SCM does not support sourcepaths

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -92,6 +92,9 @@ function startBuild(config) {
 
     // Only check if sourcePaths exists
     if (sourcePaths) {
+        if (!changedFiles) {
+            throw new Error('Your SCM does not support Source Paths');
+        }
         hasChangeInSourcePaths = changedFiles.some(file =>
             sourcePaths.some((source) => {
                 // source path is a file

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -404,6 +404,32 @@ describe('Event Factory', () => {
             })
         );
 
+        it('throw error if sourcepaths is not supported', () => {
+            jobsMock = [{
+                id: 1,
+                pipelineId: 8765,
+                name: 'main',
+                permutations: [{
+                    requires: ['~pr'],
+                    sourcePaths: ['src/test/']
+                }],
+                state: 'ENABLED'
+            }];
+            syncedPipelineMock.update = sinon.stub().resolves({
+                jobs: Promise.resolve(jobsMock)
+            });
+
+            config.startFrom = 'main';
+
+            return eventFactory.create(config).then(() => {
+                throw new Error('Should not get here');
+            }, (err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.message, 'Your SCM does not support Source Paths');
+                assert.notCalled(buildFactoryMock.create);
+            });
+        });
+
         it('should not start build if changed file is not in sourcePaths', () => {
             jobsMock = [{
                 id: 1,


### PR DESCRIPTION
Because it's harder for some SCMs to support this feature: https://github.com/screwdriver-cd/screwdriver/issues/911, this PR makes it optional. 

For SCMs that do not support the feature, `getChangedFiles` will return null. In such case, if `sourcePaths` is configured, then it will throw an error. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/911