### PR TITLE
fix(911): Only check for source paths if webhook

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -80,6 +80,7 @@ function getJobsFromPR(config) {
  * @param  {Object}   config.buildConfig    Build Config to create the build with
  * @param  {Array}    config.changedFiles   List of files that were changed
  * @param  {Array}    config.sourcePaths    List of soure paths
+ * @param  {Boolean}  [config.webhooks]     If the create came from a webhook (pr or push) or not
  * @return {Promise}
  */
 function startBuild(config) {
@@ -87,11 +88,11 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, sourcePaths } = config;
+    const { buildConfig, changedFiles, sourcePaths, webhooks } = config;
     let hasChangeInSourcePaths = true;
 
     // Only check if sourcePaths exists
-    if (sourcePaths) {
+    if (webhooks && sourcePaths) {
         if (!changedFiles) {
             throw new Error('Your SCM does not support Source Paths');
         }
@@ -131,9 +132,10 @@ function startBuild(config) {
  * @param  {Array}    [config.pipelineConfig.workflow]       Job names that will be executed for this event
  * @param  {Object}   [config.pipelineConfig.workflowGraph]  Object with nodes and edges that represent the order of jobs
  * @param  {Array}    [config.changedFiles]                  Array of files that were changed
+ * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
  */
 function createBuilds(config) {
-    const { eventConfig, eventId, pipeline, pipelineConfig, changedFiles } = config;
+    const { eventConfig, eventId, pipeline, pipelineConfig, changedFiles, webhooks } = config;
     const startFrom = eventConfig.startFrom;
 
     // If no startFrom, then do nothing. Remove once we switch to new workflow design
@@ -174,7 +176,8 @@ function createBuilds(config) {
                 startBuild({
                     buildConfig: Object.assign({ jobId: j.id, eventId }, eventConfig),
                     changedFiles,
-                    sourcePaths: j.permutations[0].sourcePaths // TODO: support matrix job
+                    sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
+                    webhooks
                 })
             )).then((buildsCreated) => {
                 const nobuilds = buildsCreated.every(b => b === null);
@@ -248,6 +251,7 @@ class EventFactory extends BaseFactory {
      * @param  {String}  [config.parentEventId]     Id of the parent event
      * @param  {String}  [config.workflowGraph]     workflowGraph of parentEvent if there is a parentEvent
      * @param  {Array}   [config.changedFiles]      Array of files that were changed
+     * @param  {Boolean} [config.webhooks]          If the create came from a webhook (pr or push) or not
      * @return {Promise}
      */
     create(config) {
@@ -329,7 +333,8 @@ class EventFactory extends BaseFactory {
                             eventId: event.id,
                             pipeline: p,
                             pipelineConfig: modelConfig,
-                            changedFiles: config.changedFiles
+                            changedFiles: config.changedFiles,
+                            webhooks: config.webhooks
                         }))
                         .then(() => event);
                 })


### PR DESCRIPTION
## Context

Restarting builds is broken right now after adding source paths feature. If a user has defined `sourcePaths` and they are trying to rerun a build from a past event, we get this error: `Cannot read property 'some' of undefined`, which is probably because `changedFiles` is undefined in that case (https://github.com/screwdriver-cd/models/blob/master/lib/eventFactory.js#L98).

## Objective

This PR will use a `webhooks` flag to determine if `sourcePaths` needs to be checked when starting a build or not.

## Related links
Related to:  https://github.com/screwdriver-cd/screwdriver/pull/975
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911