### PR TITLE
fix: archived ghost PR jobs

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -30,7 +30,7 @@ function getJobsFromTrigger(config) {
         trigger: startFrom
     });
 
-    return jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED');
+    return jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED' && !j.archived);
 }
 
 /**
@@ -48,7 +48,7 @@ function getJobsFromJobName(config) {
         return [];
     }
 
-    return jobs.filter(j => j.name === startFrom && j.state === 'ENABLED');
+    return jobs.filter(j => j.name === startFrom && j.state === 'ENABLED' && !j.archived);
 }
 
 /**
@@ -68,7 +68,7 @@ function getJobsFromPR(config) {
     }
 
     const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
-    const jobsToStart = PRJobArray.filter(j => j.state === 'ENABLED');
+    const jobsToStart = PRJobArray.filter(j => j.state === 'ENABLED' && !j.archived);
 
     return jobsToStart;
 }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -184,16 +184,23 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Go through the job list and archive/unarchive it
-     * @method _updateJobArchive
-     * @param  {Array}        jobList     List of job objects
-     * @param  {boolean}      archived    Archived value to update to
-     * @return {Promise}
-     */
-    _updateJobArchive(jobList, archived) {
+      * Go through the job list to archive/unarchive it and update job config if parsedConfig passed in
+      * @method _updateJobArchive
+      * @param  {Array}        jobList              List of job objects
+      * @param  {boolean}      archived             Archived value to update to
+      * @param  {Object}       [parsedConfig]       Parsed job configuration
+      * @return {Promise}
+      */
+    _updateJobArchive(jobList, archived, parsedConfig) {
         const jobsToUpdate = [];
 
         jobList.forEach((j) => {
+            // eslint-disable-next-line no-underscore-dangle
+            const jobName = this._getPartialJobName(j.name, 'job') || 'main';
+
+            if (parsedConfig) {
+                j.permutations = parsedConfig.jobs[jobName];
+            }
             j.archived = archived;
             jobsToUpdate.push(j.update());
         });
@@ -319,8 +326,10 @@ class PipelineModel extends BaseModel {
                 const existingPRJobNames = prJobs.map(p => p.name);
                 const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
 
-                // Get the job name part, e.g. main from PR-1:main
+                // Get the job name part, e.g. main from PR-1:main to create job
                 const jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
+                const jobsToArchive = prJobs.filter(p => !nextJobs.includes(p.name));
+                const jobsToUnarchive = prJobs.filter(p => nextJobs.includes(p.name));
 
                 // Lazy load factory dependency to prevent circular dependency issues
                 // https://nodejs.org/api/modules.html#modules_cycles
@@ -337,16 +346,10 @@ class PipelineModel extends BaseModel {
                         pipelineId: this.id,
                         name: `PR-${prNum}:${jobName}`
                     })))
-                    .then(() => prJobs.map((job) => {
-                        // eslint-disable-next-line no-underscore-dangle
-                        const jobName = this._getPartialJobName(job.name, 'job') || 'main';
-
-                        // unarchived and update the rest of the jobs
-                        job.archived = false;
-                        job.permutations = parsedConfig.jobs[jobName];
-
-                        return job.update();
-                    }));
+                    .then(() => Promise.all([
+                        this._updateJobArchive(jobsToArchive, true),
+                        this._updateJobArchive(jobsToUnarchive, false, parsedConfig)
+                    ]));
             })
             .then(() => delete this.jobs) // so that next time it will not get the cached version of this.jobs
             .then(() => this);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -237,7 +237,7 @@ describe('Event Factory', () => {
                 buildFactoryMock.create.resolves('a build object');
             });
 
-            it('should start existing pr jobs without creating duplicates', () => {
+            it('should start existing unarchived pr jobs without creating duplicates', () => {
                 jobsMock = [{
                     id: 1,
                     pipelineId: 8765,
@@ -254,6 +254,15 @@ describe('Event Factory', () => {
                         requires: ['~pr']
                     }],
                     state: 'ENABLED'
+                }, {
+                    id: 6,
+                    pipelineId: 8765,
+                    name: 'PR-1:outdated',
+                    permutations: [{
+                        requires: ['~pr']
+                    }],
+                    state: 'ENABLED',
+                    archived: true
                 },
                 {
                     id: 7,


### PR DESCRIPTION
### context
An old PR job runs even though it is not in the config.

### objective
This PR will archived outdated jobs in `syncPR(prNum)` function and eventFactory will filter out archived jobs.

Related to https://github.com/screwdriver-cd/screwdriver/issues/824