### PR TITLE
fix: add SD_SOURCE_PATH env variable for passing matched source path

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -149,6 +149,7 @@ class BuildFactory extends BaseFactory {
      * @param  {String}    [config.prRef]           The PR branch or reference
      * @param  {String}    [config.parentBuildId]   Id of the build that triggers this build
      * @param  {Boolean}   [config.start]           Whether to start the build after creating
+     * @param  {Object}    [config.environment]     Dynamically injected environment variables
      * @return {Promise}
      */
     create(config) {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -192,7 +192,12 @@ class BuildFactory extends BaseFactory {
                         container: permutation.image,
                         dockerRegistry: this.dockerRegistry
                     });
-                    modelConfig.environment = permutation.environment;
+
+                    modelConfig.environment = Object.assign({},
+                        modelConfig.environment,
+                        permutation.environment
+                    );
+
                     modelConfig.steps = permutation.commands.map(command => ({
                         name: command.name,
                         command: command.command

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -90,6 +90,8 @@ function startBuild(config) {
     const { buildConfig, changedFiles, sourcePaths, webhooks } = config;
     let hasChangeInSourcePaths = true;
 
+    buildConfig.environment = {};
+
     // Only check if sourcePaths exists
     if (webhooks && sourcePaths) {
         if (!changedFiles) {
@@ -97,13 +99,21 @@ function startBuild(config) {
         }
         hasChangeInSourcePaths = changedFiles.some(file =>
             sourcePaths.some((source) => {
-                // source path is a file
+                let isMatch = false;
+
                 if (source.slice(-1) !== '/') {
-                    return file === source;
+                    // source path is a file
+                    isMatch = file === source;
+                } else {
+                    // source path is directory
+                    isMatch = file.startsWith(source);
                 }
 
-                // source path is directory
-                return file.startsWith(source);
+                if (isMatch) {
+                    buildConfig.environment.SD_SOURCE_PATH = source;
+                }
+
+                return isMatch;
             }));
     }
 

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -420,6 +420,32 @@ describe('Build Factory', () => {
                 assert.strictEqual(model.container, 'registry.com:1234/library/node:4');
             });
         });
+
+        it('combines environment from input config', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            saveConfig.params.status = 'CREATED';
+
+            return factory.create({
+                username,
+                jobId,
+                eventId,
+                parentBuildId: 12345,
+                start: false,
+                environment: { EXTRA: true }
+            }).then(() => {
+                assert.notCalled(startStub);
+                saveConfig.params.environment.EXTRA = true;
+                assert.calledWith(datastore.save, saveConfig);
+                delete saveConfig.params.environment.EXTRA;
+            });
+        });
     });
 
     describe('getInstance', () => {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -492,6 +492,10 @@ describe('Event Factory', () => {
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledOnce(buildFactoryMock.create);
+                assert.deepEqual(
+                    buildFactoryMock.create.args[0][0].environment,
+                    {}
+                );
             });
         });
 
@@ -519,6 +523,7 @@ describe('Event Factory', () => {
                 jobs: Promise.resolve(jobsMock)
             });
 
+            config.webhooks = true;
             config.startFrom = '~pr';
             config.prRef = 'branch';
             config.prNum = 1;
@@ -527,6 +532,14 @@ describe('Event Factory', () => {
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledTwice(buildFactoryMock.create);
+                assert.deepEqual(
+                    buildFactoryMock.create.args[0][0].environment,
+                    { SD_SOURCE_PATH: 'src/test/' }
+                );
+                assert.deepEqual(
+                    buildFactoryMock.create.args[1][0].environment,
+                    { SD_SOURCE_PATH: 'src/test/' }
+                );
             });
         });
 


### PR DESCRIPTION
## Context

`sourcePaths` allows users to selectively run jobs if commit files happens to be on the paths/files mentioned in `sourcePaths`. But users have no means to programmatically find the actual source which was matched when `sourcePaths` is used.

This ENV variable allows users to write scripts which makes use of the actual source which was matched.

## References
Sub-directory support https://github.com/screwdriver-cd/screwdriver/issues/911