### PR TITLE
fix(hip): Update screwdriver dependencies that use node:8

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
-    "screwdriver-config-parser": "^3.10.0",
+    "screwdriver-config-parser": "^4.0.0",
     "screwdriver-data-schema": "^18.10.1",
     "screwdriver-workflow-parser": "^1.1.1"
   }


### PR DESCRIPTION
## Context

Some Screwdriver dependencies have been updated to use Node.js 8 features, such as `async/await`. Since this change is breaking (`node:6` doesn't support it), these dependencies need to be updated manually.

## Objective

* Update any dependencies that had a major version bump due to `node:8` upgrades