### PR TITLE
fix: pass in api uri to startPeriodic

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -8,6 +8,7 @@ const PAGINATE_COUNT = 50;
 const START_INDEX = 3;
 const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
+const apiUri = Symbol('apiUri');
 
 class Job extends BaseModel {
     /**
@@ -17,6 +18,7 @@ class Job extends BaseModel {
      * @param  {Datastore}  config.datastore    Datastore instance
      * @param  {Object}     config.executor     Object that will perform executor operations
      * @param  {String}     config.tokenGen     Generator for tokens
+     * @param  {String}     config.apiUri       URI back to the API
      * See model schema
      * @constructor
      */
@@ -24,6 +26,7 @@ class Job extends BaseModel {
         super('job', config);
         this[executor] = config.executor;
         this[tokenGen] = config.tokenGen;
+        this[apiUri] = config.apiUri;
     }
 
     /**
@@ -183,6 +186,7 @@ class Job extends BaseModel {
                     pipeline,
                     job: newJob,
                     tokenGen: this[tokenGen],
+                    apiUri: this[apiUri],
                     isUpdate: true
                 }))
                 .then(() => this));

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -17,6 +17,7 @@ class JobFactory extends BaseFactory {
         super('job', config);
         this.executor = config.executor;
         this.tokenGen = null;
+        this.apiUri = null;
     }
 
     /**
@@ -37,6 +38,7 @@ class JobFactory extends BaseFactory {
 
         c.executor = this.executor;
         c.tokenGen = this.tokenGen;
+        c.apiUri = this.apiUri;
 
         return new Job(c);
     }
@@ -66,7 +68,8 @@ class JobFactory extends BaseFactory {
                     .then(pipeline => this.executor.startPeriodic({
                         pipeline,
                         job,
-                        tokenGen: this.tokenGen
+                        tokenGen: this.tokenGen,
+                        apiUri: this.apiUri
                     }))
                     .then(() => job);
             }

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -10,6 +10,7 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('Job Model', () => {
     const token = 'tokengenerated';
+    const apiUri = 'https://notify.com/some/endpoint';
     let pipelineFactoryMock;
     let buildFactoryMock;
     let JobModel;
@@ -126,6 +127,7 @@ describe('Job Model', () => {
                     ]
                 }
             ],
+            apiUri,
             state: 'ENABLED'
         };
 
@@ -145,6 +147,8 @@ describe('Job Model', () => {
     it('is constructed properly', () => {
         assert.instanceOf(job, BaseModel);
         assert.isFunction(job.update);
+        assert.isUndefined(job.apiUri);
+        assert.isUndefined(job.tokenGen);
 
         schema.models.job.allKeys.forEach((key) => {
             assert.strictEqual(job[key], config[key]);
@@ -346,6 +350,7 @@ describe('Job Model', () => {
                         pipeline: pipelineMock,
                         job,
                         tokenGen,
+                        apiUri,
                         isUpdate: true
                     });
                     assert.calledOnce(datastore.update);

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -5,7 +5,13 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 const schema = require('screwdriver-data-schema');
 
-class Job {}
+class Job {
+    constructor(config) {
+        this.apiUri = config.apiUri;
+        this.executor = config.executor;
+        this.tokenGen = config.tokenGen;
+    }
+}
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -15,6 +21,8 @@ describe('Job Factory', () => {
     let factory;
     let executor;
     let pipelineFactoryMock;
+    let apiUri;
+    const tokenGen = sinon.stub();
 
     before(() => {
         mockery.enable({
@@ -35,6 +43,7 @@ describe('Job Factory', () => {
         executor = {
             startPeriodic: sinon.stub().resolves()
         };
+        apiUri = 'https://notify.com/some/endpoint';
 
         // Fixing mockery issue with duplicate file names
         // by re-registering data-schema with its own implementation
@@ -49,6 +58,8 @@ describe('Job Factory', () => {
         JobFactory = require('../../lib/jobFactory');
 
         factory = new JobFactory({ datastore, executor });
+        factory.apiUri = apiUri;
+        factory.tokenGen = tokenGen;
     });
 
     afterEach(() => {
@@ -71,6 +82,9 @@ describe('Job Factory', () => {
             });
 
             assert.instanceOf(model, Job);
+            assert.deepEqual(model.executor, executor);
+            assert.strictEqual(model.apiUri, apiUri);
+            assert.deepEqual(model.tokenGen, tokenGen);
         });
     });
 
@@ -151,7 +165,8 @@ describe('Job Factory', () => {
                 assert.calledWith(executor.startPeriodic, {
                     pipeline: { id: 9999 },
                     job: model,
-                    tokenGen: tokenGenFunc
+                    tokenGen: tokenGenFunc,
+                    apiUri
                 });
             });
         });


### PR DESCRIPTION
pass in API URI to startPeriodic. 
Blocked by https://github.com/screwdriver-cd/screwdriver/pull/1048
Related: https://github.com/screwdriver-cd/screwdriver/issues/688