### PR TITLE
[3] feat(653): support Blockedby

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -13,30 +13,36 @@ const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
 
 /**
  * Get the array of ids for jobs that match the names passed in
- * @param  {[type]} jobs [description]
- * @return {[type]}      [description]
+ * @method findIdsOfMatchedJobs
+ * @param  {Array}   jobs     Array of jobs
+ * @param  {Array}   jobnames Array of job names to find the ids
+ * @return {Array}            Array of job ids that match the job names
  */
-function findIdsOfMatchedJobs(jobs, names) {
-    const matchedJobs = jobs.filter(j => names.includes(j.name));
+function findIdsOfMatchedJobs(jobs, jobnames) {
+    const matchedJobs = jobs.filter(j => jobnames.includes(j.name));
 
     return matchedJobs.map(j => j.id);
 }
 
 /**
- * [getBlockedByIds description]
- * @param  {[type]} pipeline [description]
- * @param  {[type]} job      [description]
- * @return {[type]}          [description]
+ * Get a list of blockedBy jobIds
+ * If the blocking job is from an external pipeline, look up the external pipeline to find the jobId
+ * @method getBlockedByIds
+ * @param  {Pipeline}   pipeline Current Pipeline
+ * @param  {Job}        job      Current Job that contains the blockedBy configuration
+ * @return {Promise}             Array of blockedby JobIds
  */
 function getBlockedByIds(pipeline, job) {
     const blockedByNames = job.permutations[0].blockedBy;
-    let blockedByIds = [job.id]; // blocked by itself
+    let blockedByIds = [job.id]; // always blocked by itself
 
     if (!blockedByNames) {
-        return blockedByIds;
+        return Promise.resolve(blockedByIds);
     }
 
-    return pipeline.jobs((pipelineJobs) => {
+    console.log(pipeline.jobs);
+
+    return pipeline.jobs.then((pipelineJobs) => {
         // Get internal blocked by first
         blockedByIds = blockedByIds.concat(
             findIdsOfMatchedJobs(pipelineJobs, blockedByNames));
@@ -45,21 +51,24 @@ function getBlockedByIds(pipeline, job) {
             name => name.startsWith('~sd@'));
 
         // If there is no external blocked by, just return
-        if (externalBlockedByNames.length > 0) {
-            return blockedByIds;
+        if (externalBlockedByNames.length === 0) {
+            return Promise.resolve(blockedByIds);
         }
 
         // eslint-disable-next-line global-require
         const PipelineFactory = require('./pipelineFactory');
         const pipelineFactory = PipelineFactory.getInstance();
 
-        return Promise.all(externalBlockedByNames.map((fullname) => {
-            const [, pid, jobname] = fullname.match(EXTERNAL_TRIGGER);
+        // Go through the external pipeline Ids and find the matching job id
+        return Promise.all(
+            externalBlockedByNames.map((fullname) => {
+                const [, pid, jobname] = fullname.match(EXTERNAL_TRIGGER);
 
-            return pipelineFactory.get(pid)
-                .then(p => p.jobs)
-                .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));
-        }))
+                return pipelineFactory.get(pid)
+                    .then(p => p.jobs)
+                    .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));
+            }))
+            // Merge the results
             .then(jobIds => blockedByIds.concat(...jobIds));
     });
 }
@@ -208,17 +217,21 @@ class BuildModel extends BaseModel {
         // Make sure that a pipeline and job is associated with the build
         return this.job.then(job =>
             job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
-                .then(blockedBy => this[executor].start({
-                    annotations: hoek.reach(job.permutations[0], 'annotations'),
-                    blockedBy,
-                    apiUri: this[apiUri],
-                    buildId: this.id,
-                    container: this.container,
-                    token: this[tokenGen](this.id, {
-                        isPR: job.isPR(),
-                        jobId: job.id,
-                        pipelineId: pipeline.id
-                    }, pipeline.scmContext) }))
+                .then((blockedBy) => {
+                    console.log('result is ', blockedBy);
+
+                    return this[executor].start({
+                        annotations: hoek.reach(job.permutations[0], 'annotations'),
+                        blockedBy,
+                        apiUri: this[apiUri],
+                        buildId: this.id,
+                        container: this.container,
+                        token: this[tokenGen](this.id, {
+                            isPR: job.isPR(),
+                            jobId: job.id,
+                            pipelineId: pipeline.id
+                        }, pipeline.scmContext) });
+                })
                 .then(() => this.updateCommitStatus(pipeline))) // update github
                 .then(() => this)
         );

--- a/lib/build.js
+++ b/lib/build.js
@@ -15,11 +15,11 @@ const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
  * Get the array of ids for jobs that match the names passed in
  * @method findIdsOfMatchedJobs
  * @param  {Array}   jobs     Array of jobs
- * @param  {Array}   jobnames Array of job names to find the ids
+ * @param  {Array}   jobNames Array of job names to find the ids
  * @return {Array}            Array of job ids that match the job names
  */
-function findIdsOfMatchedJobs(jobs, jobnames) {
-    const matchedJobs = jobs.filter(j => jobnames.includes(j.name));
+function findIdsOfMatchedJobs(jobs, jobNames) {
+    const matchedJobs = jobs.filter(j => jobNames.includes(j.name));
 
     return matchedJobs.map(j => j.id);
 }
@@ -216,6 +216,7 @@ class BuildModel extends BaseModel {
         return this.job.then(job =>
             job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
                 .then(blockedBy => this[executor].start({
+                    jobId: job.id,
                     annotations: hoek.reach(job.permutations[0], 'annotations'),
                     blockedBy,
                     apiUri: this[apiUri],
@@ -280,10 +281,14 @@ class BuildModel extends BaseModel {
      */
     stop() {
         return this.job
-            .then(job => this[executor].stop({
-                annotations: job.permutations[0].annotations,
-                buildId: this.id
-            }))
+            .then(job => job.pipeline
+                .then(pipeline => getBlockedByIds(pipeline, job))
+                .then(blockedBy => this[executor].stop({
+                    annotations: job.permutations[0].annotations,
+                    blockedBy,
+                    buildId: this.id,
+                    jobId: job.id
+                })))
             .then(() => this);
     }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseModel = require('./base');
+const hoek = require('hoek');
 
 // Symbols for private members
 const executor = Symbol('executor');
@@ -151,25 +152,28 @@ class BuildModel extends BaseModel {
      */
     start() {
         // Make sure that a pipeline and job is associated with the build
-        return this.job
-            .then(job =>
-                job.pipeline.then(pipeline =>
-                    this[executor].start({
-                        annotations: job.permutations[0].annotations,
-                        apiUri: this[apiUri],
-                        buildId: this.id,
-                        container: this.container,
-                        token: this[tokenGen](this.id, {
-                            isPR: job.isPR(),
-                            jobId: job.id,
-                            pipelineId: pipeline.id
-                        }, pipeline.scmContext)
-                    })
-                        // update github
-                        .then(() => this.updateCommitStatus(pipeline))
-                        .then(() => this)
-                )
-            );
+        return this.job.then(job =>
+            job.pipeline.then((pipeline) => {
+                const perm = job.permutations[0];
+                const startConfig = {
+                    annotations: hoek.reach(perm, 'annotations'),
+                    apiUri: this[apiUri],
+                    buildId: this.id,
+                    container: this.container,
+                    token: this[tokenGen](this.id, {
+                        isPR: job.isPR(),
+                        jobId: job.id,
+                        pipelineId: pipeline.id
+                    }, pipeline.scmContext)
+                };
+
+                return this[executor].start(
+                    // add blockedBy only if it's there
+                    hoek.applyToDefaults(startConfig, { blockedBy: hoek.reach(perm, 'blockedBy') }))
+                    .then(() => this.updateCommitStatus(pipeline)) // update github
+                    .then(() => this);
+            })
+        );
     }
 
     /**

--- a/lib/build.js
+++ b/lib/build.js
@@ -36,11 +36,9 @@ function getBlockedByIds(pipeline, job) {
     const blockedByNames = job.permutations[0].blockedBy;
     let blockedByIds = [job.id]; // always blocked by itself
 
-    if (!blockedByNames) {
+    if (!blockedByNames || blockedByNames.length === 0) {
         return Promise.resolve(blockedByIds);
     }
-
-    console.log(pipeline.jobs);
 
     return pipeline.jobs.then((pipelineJobs) => {
         // Get internal blocked by first
@@ -64,7 +62,7 @@ function getBlockedByIds(pipeline, job) {
             externalBlockedByNames.map((fullname) => {
                 const [, pid, jobname] = fullname.match(EXTERNAL_TRIGGER);
 
-                return pipelineFactory.get(pid)
+                return pipelineFactory.get(parseInt(pid, 10)) // convert pid from string to number
                     .then(p => p.jobs)
                     .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));
             }))
@@ -217,21 +215,17 @@ class BuildModel extends BaseModel {
         // Make sure that a pipeline and job is associated with the build
         return this.job.then(job =>
             job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
-                .then((blockedBy) => {
-                    console.log('result is ', blockedBy);
-
-                    return this[executor].start({
-                        annotations: hoek.reach(job.permutations[0], 'annotations'),
-                        blockedBy,
-                        apiUri: this[apiUri],
-                        buildId: this.id,
-                        container: this.container,
-                        token: this[tokenGen](this.id, {
-                            isPR: job.isPR(),
-                            jobId: job.id,
-                            pipelineId: pipeline.id
-                        }, pipeline.scmContext) });
-                })
+                .then(blockedBy => this[executor].start({
+                    annotations: hoek.reach(job.permutations[0], 'annotations'),
+                    blockedBy,
+                    apiUri: this[apiUri],
+                    buildId: this.id,
+                    container: this.container,
+                    token: this[tokenGen](this.id, {
+                        isPR: job.isPR(),
+                        jobId: job.id,
+                        pipelineId: pipeline.id
+                    }, pipeline.scmContext) }))
                 .then(() => this.updateCommitStatus(pipeline))) // update github
                 .then(() => this)
         );

--- a/lib/build.js
+++ b/lib/build.js
@@ -2,6 +2,7 @@
 
 const BaseModel = require('./base');
 const hoek = require('hoek');
+const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 
 // Symbols for private members
 const executor = Symbol('executor');
@@ -9,6 +10,59 @@ const apiUri = Symbol('apiUri');
 const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
 const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
+
+/**
+ * Get the array of ids for jobs that match the names passed in
+ * @param  {[type]} jobs [description]
+ * @return {[type]}      [description]
+ */
+function findIdsOfMatchedJobs(jobs, names) {
+    const matchedJobs = jobs.filter(j => names.includes(j.name));
+
+    return matchedJobs.map(j => j.id);
+}
+
+/**
+ * [getBlockedByIds description]
+ * @param  {[type]} pipeline [description]
+ * @param  {[type]} job      [description]
+ * @return {[type]}          [description]
+ */
+function getBlockedByIds(pipeline, job) {
+    const blockedByNames = job.permutations[0].blockedBy;
+    let blockedByIds = [job.id]; // blocked by itself
+
+    if (!blockedByNames) {
+        return blockedByIds;
+    }
+
+    return pipeline.jobs((pipelineJobs) => {
+        // Get internal blocked by first
+        blockedByIds = blockedByIds.concat(
+            findIdsOfMatchedJobs(pipelineJobs, blockedByNames));
+
+        const externalBlockedByNames = blockedByNames.filter(
+            name => name.startsWith('~sd@'));
+
+        // If there is no external blocked by, just return
+        if (externalBlockedByNames.length > 0) {
+            return blockedByIds;
+        }
+
+        // eslint-disable-next-line global-require
+        const PipelineFactory = require('./pipelineFactory');
+        const pipelineFactory = PipelineFactory.getInstance();
+
+        return Promise.all(externalBlockedByNames.map((fullname) => {
+            const [, pid, jobname] = fullname.match(EXTERNAL_TRIGGER);
+
+            return pipelineFactory.get(pid)
+                .then(p => p.jobs)
+                .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));
+        }))
+            .then(jobIds => blockedByIds.concat(...jobIds));
+    });
+}
 
 class BuildModel extends BaseModel {
     /**
@@ -153,10 +207,10 @@ class BuildModel extends BaseModel {
     start() {
         // Make sure that a pipeline and job is associated with the build
         return this.job.then(job =>
-            job.pipeline.then((pipeline) => {
-                const perm = job.permutations[0];
-                const startConfig = {
-                    annotations: hoek.reach(perm, 'annotations'),
+            job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
+                .then(blockedBy => this[executor].start({
+                    annotations: hoek.reach(job.permutations[0], 'annotations'),
+                    blockedBy,
                     apiUri: this[apiUri],
                     buildId: this.id,
                     container: this.container,
@@ -164,15 +218,9 @@ class BuildModel extends BaseModel {
                         isPR: job.isPR(),
                         jobId: job.id,
                         pipelineId: pipeline.id
-                    }, pipeline.scmContext)
-                };
-
-                return this[executor].start(
-                    // add blockedBy only if it's there
-                    hoek.applyToDefaults(startConfig, { blockedBy: hoek.reach(perm, 'blockedBy') }))
-                    .then(() => this.updateCommitStatus(pipeline)) // update github
-                    .then(() => this);
-            })
+                    }, pipeline.scmContext) }))
+                .then(() => this.updateCommitStatus(pipeline))) // update github
+                .then(() => this)
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
-    "screwdriver-config-parser": "^4.0.0",
-    "screwdriver-data-schema": "^18.13.7",
+    "screwdriver-config-parser": "^4.1.0",
+    "screwdriver-data-schema": "^18.19.0",
     "screwdriver-workflow-parser": "^1.4.1"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -377,7 +377,7 @@ describe('Build Model', () => {
         );
 
         it('pass in blockedBy to executor start', () => {
-            const blockedBy = 'test';
+            const blockedBy = [111, 222];
 
             jobFactoryMock.get.resolves({
                 id: jobId,

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -202,7 +202,9 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.stop, {
                         buildId,
-                        annotations
+                        jobId,
+                        annotations,
+                        blockedBy: [jobId]
                     });
 
                     // Completed step is not modified
@@ -233,7 +235,9 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.stop, {
                         buildId,
-                        annotations
+                        jobId,
+                        annotations,
+                        blockedBy: [jobId]
                     });
 
                     // Completed step is not modified
@@ -296,7 +300,9 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.stop, {
                         buildId,
-                        annotations
+                        jobId,
+                        annotations,
+                        blockedBy: [jobId]
                     });
                 })
         );
@@ -357,6 +363,7 @@ describe('Build Model', () => {
             build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        jobId,
                         annotations,
                         blockedBy: [jobId],
                         apiUri,
@@ -420,6 +427,7 @@ describe('Build Model', () => {
             return build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        jobId,
                         blockedBy: [jobId, blocking1.id, blocking2.id],
                         annotations,
                         apiUri,
@@ -491,6 +499,7 @@ describe('Build Model', () => {
             return build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        jobId,
                         blockedBy: [jobId, internalJob.id, externalJob1.id, externalJob2.id],
                         annotations,
                         apiUri,
@@ -519,6 +528,7 @@ describe('Build Model', () => {
             return build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        jobId,
                         annotations: { 'beta.screwdriver.cd/executor:': 'k8s-vm' },
                         blockedBy: [jobId],
                         apiUri,

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -376,6 +376,39 @@ describe('Build Model', () => {
                 })
         );
 
+        it('pass in blockedBy to executor start', () => {
+            const blockedBy = 'test';
+
+            jobFactoryMock.get.resolves({
+                id: jobId,
+                name: 'main',
+                pipeline: Promise.resolve({
+                    id: pipelineId,
+                    scmUri,
+                    scmContext,
+                    admin: Promise.resolve(adminUser),
+                    token: Promise.resolve('foo')
+                }),
+                permutations: [{
+                    annotations,
+                    blockedBy
+                }],
+                isPR: () => false
+            });
+
+            return build.start()
+                .then(() => {
+                    assert.calledWith(executorMock.start, {
+                        blockedBy,
+                        annotations,
+                        apiUri,
+                        buildId,
+                        container,
+                        token
+                    });
+                });
+        });
+
         it('promises to start a build with the executor specified in job annotations', () => {
             jobFactoryMock.get.resolves({
                 id: jobId,


### PR DESCRIPTION
`blockedBy` is a list of job names including external jobs.
This PR converts job names to job ids. For external jobs, it will get the external pipeline to look up the job ids. 
This list of job ids will be passed to the executor `start`

Blocked by: 
- https://github.com/screwdriver-cd/data-schema/pull/234
- https://github.com/screwdriver-cd/config-parser/pull/63

Related: https://github.com/screwdriver-cd/screwdriver/issues/653