### PR TITLE
fix(926): Add default namespace

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -77,6 +77,8 @@ class TemplateFactory extends BaseFactory {
 
         // If fullTemplateName has no '/', don't need to bother to grep for namespace
         if (fullTemplateName.indexOf('/') <= -1) {
+            parsedTemplate.namespace = 'default';
+
             return Promise.resolve(parsedTemplate);
         }
 
@@ -115,12 +117,27 @@ class TemplateFactory extends BaseFactory {
     create(config) {
         const [, major, minor] = VERSION_REGEX.exec(config.version);
         const searchVersion = minor ? `${major}${minor}` : major;
-        // Construct full template name
-        const templateNameAndVersion = `${config.name}@${searchVersion}`;
-        const templateName = config.namespace ?
-            `${config.namespace}/${templateNameAndVersion}` : `${templateNameAndVersion}`;
 
-        return this.getTemplate(templateName)
+        // Set namespace if it doesn't already exist
+        if (!config.namespace) {
+            const slashIndex = config.name.indexOf('/');
+
+            // Use string in front of slash for namespace if there is a slash
+            if (slashIndex > -1) {
+                const [, namespace, name]
+                    = TEMPLATE_NAME_REGEX_WITH_NAMESPACE.exec(config.name);
+
+                config.namespace = namespace;
+                config.name = name;
+            // Set namespace to default if there is no slash
+            } else {
+                config.namespace = 'default';
+            }
+        }
+
+        const fullTemplateName = `${config.namespace}/${config.name}@${searchVersion}`;
+
+        return this.getTemplate(fullTemplateName)
             .then((latest) => {
                 if (!latest) {
                     config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;

--- a/lib/templateTagFactory.js
+++ b/lib/templateTagFactory.js
@@ -51,6 +51,8 @@ class TemplateTagFactory extends BaseFactory {
 
         // If fullTemplateName has no '/', don't need to bother to grep for namespace
         if (fullTemplateName.indexOf('/') <= -1) {
+            parsedTemplate.namespace = 'default';
+
             return Promise.resolve(parsedTemplate);
         }
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "screwdriver-config-parser": "^4.1.0",
-    "screwdriver-data-schema": "^18.20.1",
+    "screwdriver-data-schema": "^18.21.0",
     "screwdriver-workflow-parser": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "screwdriver-config-parser": "^4.1.0",
-    "screwdriver-data-schema": "^18.21.0",
+    "screwdriver-data-schema": "^18.21.1",
     "screwdriver-workflow-parser": "^1.4.1"
   }
 }

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -94,7 +94,9 @@ describe('Template Factory', () => {
             };
         });
 
-        it('creates a Template with the namespace when it exists', () => {
+        // namespace: namespace
+        // name: testTemplate
+        it('creates a Template with the namespace when it is passed in explicitly', () => {
             expected.version = `${version}.0`;
             expected.namespace = namespace;
             datastore.save.resolves(expected);
@@ -103,6 +105,52 @@ describe('Template Factory', () => {
             return factory.create({
                 name,
                 namespace,
+                version,
+                maintainer,
+                description,
+                labels,
+                config: templateConfig,
+                pipelineId
+            }).then((model) => {
+                assert.instanceOf(model, Template);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        // name: namespace/testTemplate
+        it('creates a Template with the namespace when it is passed in implicitly', () => {
+            expected.version = `${version}.0`;
+            expected.namespace = namespace;
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([]);
+
+            return factory.create({
+                name: 'namespace/testTemplate',
+                version,
+                maintainer,
+                description,
+                labels,
+                config: templateConfig,
+                pipelineId
+            }).then((model) => {
+                assert.instanceOf(model, Template);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        // name: testTemplate
+        it('creates a Template with default namespace when no namespace passed in', () => {
+            expected.version = `${version}.0`;
+            expected.namespace = 'default';
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([]);
+
+            return factory.create({
+                name,
                 version,
                 maintainer,
                 description,

--- a/test/lib/templateTagFactory.test.js
+++ b/test/lib/templateTagFactory.test.js
@@ -75,7 +75,10 @@ describe('TemplateTag Factory', () => {
             };
         });
 
+        // namespace should be default
+        // name: testTemplateTag
         it('creates a Template Tag given name, tag, and version', () => {
+            expected.namespace = 'default';
             datastore.save.resolves(expected);
 
             return factory.create({
@@ -90,6 +93,7 @@ describe('TemplateTag Factory', () => {
             });
         });
 
+        // name: namespace/testTemplateTag
         // eslint-disable-next-line max-len
         it('creates a Template Tag given name with namespace, tag, and version and namespace does not exist', () => {
             datastore.save.resolves(expected);


### PR DESCRIPTION
## Context
See https://github.com/screwdriver-cd/screwdriver/issues/926#issuecomment-391907638

## Objective
Setting template namespace to `default` when there is no explicit or implicit namespace defined.

## Related links
Related to https://github.com/screwdriver-cd/models/pull/249
Related to https://github.com/screwdriver-cd/screwdriver/issues/926