### PR TITLE
fix(653): Handle ~jobName for blockedBy

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -33,8 +33,8 @@ function findIdsOfMatchedJobs(jobs, jobNames) {
  * @return {Promise}             Array of blockedby JobIds
  */
 function getBlockedByIds(pipeline, job) {
-    const blockedByNames = job.permutations[0].blockedBy;
-    let blockedByIds = [job.id]; // always blocked by itself
+    let blockedByNames = job.permutations[0].blockedBy;
+    let blockedByIds = [job.id]; // Always blocked by itself
 
     if (!blockedByNames || blockedByNames.length === 0) {
         return Promise.resolve(blockedByIds);
@@ -43,9 +43,8 @@ function getBlockedByIds(pipeline, job) {
     const externalBlockedByNames = blockedByNames.filter(
         name => name.startsWith('~sd@'));
 
-    for (let i = 0; i < blockedByNames.length; i += 1) {
-        blockedByNames[i] = blockedByNames[i].replace('~', '');
-    }
+    // Remove ~ prefix for job names
+    blockedByNames = blockedByNames.map(name => name.replace('~', ''));
 
     return pipeline.jobs.then((pipelineJobs) => {
         // Get internal blocked by first

--- a/lib/build.js
+++ b/lib/build.js
@@ -40,13 +40,17 @@ function getBlockedByIds(pipeline, job) {
         return Promise.resolve(blockedByIds);
     }
 
+    const externalBlockedByNames = blockedByNames.filter(
+        name => name.startsWith('~sd@'));
+
+    for (let i = 0; i < blockedByNames.length; i += 1) {
+        blockedByNames[i] = blockedByNames[i].replace('~', '');
+    }
+
     return pipeline.jobs.then((pipelineJobs) => {
         // Get internal blocked by first
         blockedByIds = blockedByIds.concat(
             findIdsOfMatchedJobs(pipelineJobs, blockedByNames));
-
-        const externalBlockedByNames = blockedByNames.filter(
-            name => name.startsWith('~sd@'));
 
         // If there is no external blocked by, just return
         if (externalBlockedByNames.length === 0) {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "screwdriver-config-parser": "^4.1.0",
-    "screwdriver-data-schema": "^18.21.1",
+    "screwdriver-data-schema": "^18.21.2",
     "screwdriver-workflow-parser": "^1.4.1"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -489,7 +489,7 @@ describe('Build Model', () => {
                     annotations,
                     blockedBy: [
                         `~sd@${externalPid1}:externalJob1`,
-                        internalJob.name,
+                        `~${internalJob.name}`,
                         `~sd@${externalPid2}:externalJob2`
                     ]
                 }],


### PR DESCRIPTION
## Context
Since blockedBy is always using OR logic, we should at least make it consistent with previous workflow syntax by requiring a tilde before all the job names.

## Objective
This PR handles `blockedBy` when jobNames start with a tilde (`~`).

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/653
Blocked by https://github.com/screwdriver-cd/data-schema/pull/242