### PR TITLE
fix(926): do not pass undefined value as get params

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -73,7 +73,9 @@ class BaseFactory {
         if (typeof config === 'object' && !config.id) {
             // Reduce to unique properties
             this.model.keys.forEach((key) => {
-                params[key] = config[key];
+                if (config[key] !== undefined) {
+                    params[key] = config[key];
+                }
             });
         } else {
             const id = parseInt(config.id || config, 10);

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -41,7 +41,7 @@ describe('Base Factory', () => {
             models: {
                 base: {
                     tableName: 'base',
-                    keys: ['foo'],
+                    keys: ['foo', 'bar'],
                     allKeys: ['id', 'foo', 'bar']
                 }
             }
@@ -149,6 +149,13 @@ describe('Base Factory', () => {
                     foo: 'foo'
                 }
             }).resolves(baseData);
+            datastore.get.withArgs({
+                table: 'base',
+                params: {
+                    foo: 'foo',
+                    bar: 'bar'
+                }
+            }).resolves(baseData);
         });
 
         it('calls datastore get with id and returns correct values', () =>
@@ -186,6 +193,17 @@ describe('Base Factory', () => {
                 .then((model) => {
                     assert.instanceOf(model, Base);
                     assert.isTrue(datastore.get.calledOnce);
+                    assert.deepEqual(model.datastore, datastore);
+                    assert.deepEqual(model.scm, scm);
+                })
+        );
+
+        it('calls datastore get with config object with valid values', () =>
+            factory.get({ foo: 'foo' })
+                .then((model) => {
+                    assert.instanceOf(model, Base);
+                    assert.isTrue(datastore.get.calledOnce);
+                    assert.calledWith(datastore.get, { params: { foo: 'foo' }, table: 'base' });
                     assert.deepEqual(model.datastore, datastore);
                     assert.deepEqual(model.scm, scm);
                 })


### PR DESCRIPTION
This is a problem introduced by template namesake feature:

When we don't have the extra check, `getTemplate` will be broken for old templates without namespace. When we call `super.get({ name: 'foo/bar', version: '1.0.0' })` , it will add `namespace: undefined` to the params inside `baseFactory.get` since `namespace` is now part of keys.

https://github.com/screwdriver-cd/data-schema/blob/master/models/template.js#L78