### PR TITLE
fix(926): set namespace to null when not exist for get

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -196,10 +196,9 @@ class TemplateFactory extends BaseFactory {
             return this._getNameAndNamespace(config.name).then((parsedTemplateName) => {
                 const { namespace, name } = parsedTemplateName;
 
-                if (namespace) {
-                    config.namespace = namespace;
-                    config.name = name;
-                }
+                // Always need to pass in namespace since it's a unique key
+                config.namespace = namespace || null;
+                config.name = name;
 
                 return super.get(config);
             });

--- a/lib/templateTagFactory.js
+++ b/lib/templateTagFactory.js
@@ -157,10 +157,8 @@ class TemplateTagFactory extends BaseFactory {
             return this._getNameAndNamespace(config.name).then((parsedTemplateName) => {
                 const { namespace, name } = parsedTemplateName;
 
-                if (namespace) {
-                    config.namespace = namespace;
-                    config.name = name;
-                }
+                config.namespace = namespace || null;
+                config.name = name;
 
                 return super.get(config);
             });

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -310,6 +310,9 @@ describe('Template Factory', () => {
             expected = Object.assign({}, returnValue[2]);
 
             return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name: 'testTemplate', namespace, version: '1.0.2' }
+                }));
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);
@@ -317,12 +320,33 @@ describe('Template Factory', () => {
             });
         });
 
-        it('should get a template when no namespace is passed in', () => {
+        it('should get template from default namespace when no namespace is passed in', () => {
             datastore.get.resolves(returnValue[3]);
             expected = Object.assign({}, returnValue[3]);
             delete config.namespace;
 
             return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name: 'testTemplate', namespace: 'default', version: '1.0.2' }
+                }));
+                assert.instanceOf(model, Template);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        it('should get a template with implicit namespace in name', () => {
+            datastore.get.resolves(returnValue[3]);
+            datastore.scan.resolves([]);
+            expected = Object.assign({}, returnValue[3]);
+            delete config.namespace;
+            config.name = 'namespace/testTemplate';
+
+            return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name: 'namespace/testTemplate', namespace: null, version: '1.0.2' }
+                }));
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);

--- a/test/lib/templateTagFactory.test.js
+++ b/test/lib/templateTagFactory.test.js
@@ -163,16 +163,20 @@ describe('TemplateTag Factory', () => {
                 version
             }];
             config = {
-                name
+                name,
+                tag
             };
         });
 
-        it('gets a Template Tag given a name when namespace does not exist', () => {
+        it('gets a Template Tag given tag and name without implicit namespace', () => {
             datastore.scan.resolves(returnValue);
             datastore.get.resolves(returnValue);
             expected = Object.assign({}, expected);
 
             return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name, namespace: 'default', tag }
+                }));
                 assert.instanceOf(model, TemplateTag);
                 Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);
@@ -180,13 +184,33 @@ describe('TemplateTag Factory', () => {
             });
         });
 
-        it('gets a Template Tag given a name when namespace exists', () => {
+        it('gets a Template Tag given name and tag with non-existent implicit namespace', () => {
+            datastore.scan.resolves([]);
+            datastore.get.resolves(returnValue);
+            expected = Object.assign({}, expected);
+            config.name = fullTemplateName;
+
+            return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name: fullTemplateName, namespace: null, tag }
+                }));
+                assert.instanceOf(model, TemplateTag);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        it('gets a Template Tag given tag and name with existent implicit namespace', () => {
             datastore.scan.resolves(returnValue);
             datastore.get.resolves(returnValue);
             expected = Object.assign({}, expected);
             config.name = fullTemplateName;
 
             return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name, namespace, tag }
+                }));
                 assert.instanceOf(model, TemplateTag);
                 Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);
@@ -201,6 +225,9 @@ describe('TemplateTag Factory', () => {
             config.namespace = namespace;
 
             return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name, namespace, tag }
+                }));
                 assert.instanceOf(model, TemplateTag);
                 Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);


### PR DESCRIPTION
This is a problem introduced by template namespace feature:

`getTemplate` is broken for old templates with implicit namespace. When we call `super.get({ name: 'foo/bar', version: '1.0.0' })` , it will add `namespace: undefined` to the params inside `baseFactory.get` since namespace is now part of unique keys. We're assuming a `get` should always contain all unique keys. 
https://github.com/screwdriver-cd/models/blob/master/lib/baseFactory.js#L75

To be able to get old templates with name like `foo/bar`, we need to set namespace explicitly to `null` when fetching it.
