### PR TITLE
[3] feat(937): support external config

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -211,7 +211,10 @@ function getLatestWorkflowGraph(config) {
     const { pipeline, eventConfig } = config;
 
     if (eventConfig.prRef) {
-        return pipeline.getConfiguration(eventConfig.prRef)
+        return pipeline.getConfiguration({
+            ref: eventConfig.prRef,
+            isPR: true
+        })
             .then(c => c.workflowGraph);
     }
 
@@ -285,7 +288,12 @@ class EventFactory extends BaseFactory {
                 if (config.parentEventId) {
                     modelConfig.parentEventId = config.parentEventId;
 
-                    // Sync pipeline with the parentEvent sha and create jobs based on that sha
+                    // for child pipepine restart event, get the sha from config pipeline to fetch jobs
+                    if (config.configPipelineSha) {
+                        // Sync pipeline with the parentEvent sha and create jobs based on that sha
+                        return p.sync(config.configPipelineSha);
+                    }
+
                     return p.sync(config.sha);
                 }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -244,6 +244,27 @@ class EventFactory extends BaseFactory {
     }
 
     /**
+     * Get latest commit sha given pipelineId
+     * @method _getCommitSha
+     * @param  {Number}     pipelineId
+     * @return {Promise}
+     */
+    async _getCommitSha(pipelineId) {
+        // eslint-disable-next-line global-require
+        const PipelineFactory = require('./pipelineFactory');
+        const pipelineFactory = PipelineFactory.getInstance();
+        const pipeline = await pipelineFactory.get(pipelineId);
+        const token = await pipeline.token;
+        const scmConfig = {
+            scmContext: pipeline.scmContext,
+            scmUri: pipeline.scmUri,
+            token
+        };
+
+        return pipelineFactory.scm.getCommitSha(scmConfig);
+    }
+
+    /**
      * Create an event model
      * @method create
      * @param  {Object}  config
@@ -285,16 +306,27 @@ class EventFactory extends BaseFactory {
         return pipelineFactory.get(config.pipelineId)
             // Sync pipeline to make sure workflowGraph is generated
             .then((p) => {
+                // Sync pipeline with the parentEvent sha and create jobs based on that sha
                 if (config.parentEventId) {
                     modelConfig.parentEventId = config.parentEventId;
 
-                    // for child pipepine restart event, get the sha from config pipeline to fetch jobs
+                    // for child pipelines restart event, sync with configPipelineSha
                     if (config.configPipelineSha) {
-                        // Sync pipeline with the parentEvent sha and create jobs based on that sha
                         return p.sync(config.configPipelineSha);
                     }
 
                     return p.sync(config.sha);
+                }
+
+                // for child pipelines, get config pipeline sha and sync with that
+                if (p.configPipelineId) {
+                    // eslint-disable-next-line no-underscore-dangle
+                    return this._getCommitSha(p.configPipelineId)
+                        .then((sha) => {
+                            modelConfig.configPipelineSha = sha;
+
+                            return p.sync(sha);
+                        });
                 }
 
                 return p.sync();

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -271,6 +271,7 @@ class EventFactory extends BaseFactory {
      * @param  {String}  [config.type = 'pipeline'] Type of event (pipeline or pr)
      * @param  {Number}  config.pipelineId          Unique id of the pipeline
      * @param  {String}  config.sha                 SHA this project was built on
+     * @param  {String}  [config.configPipelineSha] SHA of the config pipeline with screwdriver.yaml
      * @param  {String}  config.username            Username of the user that creates this event
      * @param  {String}  config.scmContext          The scm context to which user belongs
      * @param  {String}  [config.prNum]             PR number if it's a PR event

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -421,7 +421,7 @@ class PipelineModel extends BaseModel {
     /**
      * Get a pipeline given a scmUrl
      * @method getPipeline
-     * @param {Array} scmUrl  checkout url for a repository
+     * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
      */
     async _getScmUri(scmUrl) {
@@ -441,7 +441,7 @@ class PipelineModel extends BaseModel {
     /**
      * Update or create a pipeline given a scmUrl
      * @method createOrUpdatePipeine
-     * @param {Array} scmUrl  checkout url for a repository
+     * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
      */
     async _createOrUpdatePipeine(scmUrl) {
@@ -454,7 +454,7 @@ class PipelineModel extends BaseModel {
         if (!hasAdminPermission) {
             // need to figure out how to bubble up this err to user
             // eslint-disable-next-line no-console
-            console.log(`Admins of pipeline:${this.id} has no admin permission to ${scmUrl}`);
+            console.log(`No admins of pipeline:${this.id} have admin permissions on ${scmUrl}`);
 
             return null;
         }
@@ -471,7 +471,7 @@ class PipelineModel extends BaseModel {
 
             // Child pipline does not belong to this parent, return
             // eslint-disable-next-line no-console
-            console.log(`Pipeline ${scmUrl} already exist: ${pipeline.id}`);
+            console.log(`Pipeline ${scmUrl} already exists: ${pipeline.id}`);
 
             return null;
         }
@@ -487,7 +487,7 @@ class PipelineModel extends BaseModel {
     /**
      * Remove a pipeline given a scmUrl
      * @method _removePipeine
-     * @param {Array} scmUrl  checkout url for a repository
+     * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
      */
     async _removePipeine(scmUrl) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -88,14 +88,14 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Get the screwdriver configuration for the pipeline at the given ref
+     * Get a pipeline factory instance
      * @method _getPipelineFactory
      * @return {Object}         PipelineFactory instance
      */
     _getPipelineFactory() {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
-        /* eslint-disable global-require */
+        // eslint-disable-next-line global-require
         const PipelineFactory = require('./pipelineFactory');
 
         return PipelineFactory.getInstance();
@@ -123,7 +123,7 @@ class PipelineModel extends BaseModel {
         if (this.configPipelineId) {
             return pipelineFactory.get(this.configPipelineId)
                 .then((configPipeline) => {
-                    // If it is a PR on child pipeine, use config from config pipeline
+                    // If it is a PR on child pipeline, use config from config pipeline
                     if (isPR) {
                         return configPipeline.getConfiguration({});
                     }
@@ -420,7 +420,7 @@ class PipelineModel extends BaseModel {
 
     /**
      * Get a pipeline given a scmUrl
-     * @method getPipeline
+     * @method _getScmUri
      * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
      */
@@ -440,11 +440,11 @@ class PipelineModel extends BaseModel {
 
     /**
      * Update or create a pipeline given a scmUrl
-     * @method createOrUpdatePipeine
+     * @method _createOrUpdatePipeline
      * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
      */
-    async _createOrUpdatePipeine(scmUrl) {
+    async _createOrUpdatePipeline(scmUrl) {
         const pipelineFactory = this._getPipelineFactory();
         const admins = this.admins;
         const scmContext = this.scmContext;
@@ -486,11 +486,11 @@ class PipelineModel extends BaseModel {
 
     /**
      * Remove a pipeline given a scmUrl
-     * @method _removePipeine
+     * @method _removePipeline
      * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
      */
-    async _removePipeine(scmUrl) {
+    async _removePipeline(scmUrl) {
         const pipelineFactory = this._getPipelineFactory();
         const scmUri = await this._getScmUri(scmUrl);
 
@@ -519,13 +519,14 @@ class PipelineModel extends BaseModel {
         const toCreateOrUpdate = [];
         const toRemove = [];
         const oldScmUrls = this.scmUrls || [];
+        const newScmUrls = scmUrls || [];
         // scmUrls in the old list but not the new list should be removed
-        const scmUrlsToRemove = oldScmUrls.filter(scmUrl => !scmUrls.includes(scmUrl));
+        const scmUrlsToRemove = oldScmUrls.filter(scmUrl => !newScmUrls.includes(scmUrl));
 
         // create or update child pipelines
-        scmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeine(scmUrl)));
+        newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl)));
         // remove child pipelines
-        scmUrlsToRemove.forEach(scmUrl => toRemove.push(this._removePipeine(scmUrl)));
+        scmUrlsToRemove.forEach(scmUrl => toRemove.push(this._removePipeline(scmUrl)));
 
         return Promise.all([
             toCreateOrUpdate,
@@ -553,10 +554,10 @@ class PipelineModel extends BaseModel {
         return this.getConfiguration({ ref })
             .then((parsedConfig) => {
                 // If it is an external config pipeline, sync all children
-                if (parsedConfig.scmUrls && !this.configPipelineId) {
+                if ((this.scmUrls || parsedConfig.scmUrls) && !this.configPipelineId) {
                     return this._syncChildPipelines(parsedConfig.scmUrls)
                         .then(() => {
-                            this.scmUrls = parsedConfig.scmUrls;
+                            this.scmUrls = parsedConfig.scmUrls || null;
 
                             return parsedConfig;
                         });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -379,11 +379,43 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     *
+     * Checks if any admin from this.admins has github permission to given scmUri
+     * @method _hasAdminPermission
+     * @return {Promise}
      */
-    async getPipeline(scmUrl) {
-        // Lazy load factory dependency to prevent circular dependency issues
-        // https://nodejs.org/api/modules.html#modules_cycles
+    async _hasAdminPermission(scmUri) {
+        /* eslint-disable no-restricted-syntax */
+        for (const username of Object.keys(this.admins)) {
+            /* eslint-disable global-require */
+            const UserFactory = require('./userFactory');
+            /* eslint-enable global-require */
+            const factory = UserFactory.getInstance();
+
+            // eslint-disable-next-line no-await-in-loop
+            const user = await factory.get({
+                username,
+                scmContext: this.scmContext
+            });
+
+            // eslint-disable-next-line no-await-in-loop
+            const permission = await user.getPermissions(scmUri);
+
+            if (permission.admin) {
+                return true;
+            }
+        }
+        /* eslint-enable no-restricted-syntax */
+
+        return false;
+    }
+
+    /**
+     * Get a pipeline given a scmUrl
+     * @method getPipeline
+     * @param {Array} scmUrl  checkout url for a repository
+     * @return {Promise}
+     */
+    async _getPipeline(scmUrl) {
         /* eslint-disable global-require */
         const PipelineFactory = require('./pipelineFactory');
         /* eslint-enable global-require */
@@ -396,27 +428,30 @@ class PipelineModel extends BaseModel {
             scmUrl,
             token
         });
-        const permissions = await admin.getPermissions(scmUri);
 
-        if (!permissions.admin) {
-            throw new Error(
-                `User ${admin.getFullDisplayName()} is not an admin of this repo`
-            );
+        const hasAdminPermission = await this._hasAdminPermission(scmUri);
+
+        if (!hasAdminPermission) {
+            // need to figure out how to bubble up this err to user
+            // eslint-disable-next-line no-console
+            console.log(`Admins of ${this.pipelineId} has no admin permission to ${scmUrl}`);
         }
 
         return pipelineFactory.get({ scmUri });
     }
 
     /**
-     *
+     * Update or create a pipeline given a scmUrl
+     * @method createOrUpdatePipeine
+     * @param {Array} scmUrl  checkout url for a repository
+     * @return {Promise}
      */
-    async createPipeine(scmUrl) {
-        // Lazy load factory dependency to prevent circular dependency issues
-        // https://nodejs.org/api/modules.html#modules_cycles
+    async _createOrUpdatePipeine(scmUrl) {
         /* eslint-disable global-require */
         const PipelineFactory = require('./pipelineFactory');
         /* eslint-enable global-require */
         const pipelineFactory = PipelineFactory.getInstance();
+        const admins = this.admins;
         const token = await this.token;
         const admin = await this.admin;
         const scmContext = admin.scmContext;
@@ -425,16 +460,18 @@ class PipelineModel extends BaseModel {
             scmUrl,
             token
         });
-        const pipeline = await this.getPipeline(scmUrl);
 
+        const pipeline = await this._getPipeline(scmUrl);
+
+        // Pipelien exists, update admins
         if (pipeline) {
-            return pipeline;
+            pipeline.admins = admins;
+
+            return pipeline.update();
         }
 
         return pipelineFactory.create({
-            admins: {
-                [admin.username]: true
-            },
+            admins,
             scmContext,
             scmUri,
             configPipelineId: this.id
@@ -442,9 +479,12 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     *
+     * Remove a pipeline given a scmUrl
+     * @method _removePipeine
+     * @param {Array} scmUrl  checkout url for a repository
+     * @return {Promise}
      */
-    async removePipeine(scmUrl) {
+    async _removePipeine(scmUrl) {
         const pipeline = await this.getPipeline(scmUrl);
 
         if (!pipeline) {
@@ -455,27 +495,25 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Sync the pipeline by looking up screwdriver.yaml
-     * Create, update, or disable jobs if necessary.
-     * Store/update the pipeline workflowGraph
-     * @method sync
-     * @param {String} [ref]  A reference to fetch the screwdriver.yaml, can be branch/tag/commit
+     * Sync child pipelines given scmUrls
+     * @method syncChildPipelines
+     * @param {Array} scmUrls  An array of scmUrls for child pipelines
      * @return {Promise}
      */
-    async syncConfigPipeline(scmUrls) {
-        const pipelinesToCreate = [];
-        const pipelinesToRemove = [];
+    async _syncChildPipelines(scmUrls) {
+        const toCreateOrUpdate = [];
+        const toRemove = [];
+        // scmUrls in the old list but not the new list should be removed
+        const scmUrlsToRemove = this.scmUrls.filtered(scmUrl => !scmUrls.includes(scmUrl));
 
-        // eslind does not like await in loop, follow eslint example: https://eslint.org/docs/rules/no-await-in-loop
-        // add child pipelines
-        scmUrls.forEach(scmUrl => pipelinesToCreate.push(this.createPipeine(scmUrl)));
-
+        // create or update child pipelines
+        scmUrls.forEach(scmUrl => toCreateOrUpdate.push(this.createOrUpdatePipeine(scmUrl)));
         // remove child pipelines
-        scmUrls.forEach(scmUrl => pipelinesToRemove.push(this.removePipeine(scmUrl)));
+        scmUrlsToRemove.forEach(scmUrl => toRemove.push(this.removePipeine(scmUrl)));
 
         return Promise.all([
-            pipelinesToCreate,
-            pipelinesToRemove
+            toCreateOrUpdate,
+            toRemove
         ]);
     }
 
@@ -500,7 +538,7 @@ class PipelineModel extends BaseModel {
 
         // get the pipeline configuration
         return new Promise((resolve) => {
-            // if using external config, get job config from config pipeine
+            // If it is a child pipeline, get job config from config pipeline
             if (this.configPipelineId) {
                 const conf = pipelineFactory.get(this.configPipelineId)
                     .then(configPipeline => configPipeline.getConfiguration({ ref }));
@@ -513,10 +551,12 @@ class PipelineModel extends BaseModel {
             .then((parsedConfig) => {
                 // If it is an external config pipeline, sync all children
                 if (parsedConfig.scmUrls && !this.configPipelineId) {
-                    this.scmUrls = parsedConfig.scmUrls;
+                    return this._syncChildPipelines(parsedConfig.scmUrls)
+                        .then(() => {
+                            this.scmUrls = parsedConfig.scmUrls;
 
-                    return this.syncConfigPipeline(this.scmUrls)
-                        .then(() => parsedConfig);
+                            return parsedConfig;
+                        });
                 }
 
                 return parsedConfig;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -511,9 +511,6 @@ class PipelineModel extends BaseModel {
             return resolve(this.getConfiguration({ ref }));
         })
             .then((parsedConfig) => {
-                this.workflowGraph = parsedConfig.workflowGraph;
-                this.annotations = parsedConfig.annotations;
-
                 // If it is an external config pipeline, sync all children
                 if (parsedConfig.scmUrls && !this.configPipelineId) {
                     this.scmUrls = parsedConfig.scmUrls;
@@ -523,70 +520,75 @@ class PipelineModel extends BaseModel {
                 }
 
                 return parsedConfig;
-            }).then(parsedConfig => this.jobs
-                .then((existingJobs) => {
-                    const jobsToSync = [];
-                    const jobsProcessed = [];
-                    const triggersToSync = [];
-                    const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
-                    const pipelineId = this.id;
+            }).then((parsedConfig) => {
+                this.workflowGraph = parsedConfig.workflowGraph;
+                this.annotations = parsedConfig.annotations;
 
-                    // Loop through all existing jobs
-                    existingJobs.forEach((job) => {
-                        const jobName = job.name;
-                        let requiresList = [];
+                return this.jobs
+                    .then((existingJobs) => {
+                        const jobsToSync = [];
+                        const jobsProcessed = [];
+                        const triggersToSync = [];
+                        const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
+                        const pipelineId = this.id;
 
-                        // if it's in the yaml, update it
-                        if (parsedConfigJobNames.includes(jobName)) {
-                            const permutations = parsedConfig.jobs[jobName];
+                        // Loop through all existing jobs
+                        existingJobs.forEach((job) => {
+                            const jobName = job.name;
+                            let requiresList = [];
 
-                            requiresList = permutations[0].requires || [];
-                            job.permutations = permutations;
-                            job.archived = false;
-                            jobsToSync.push(job.update());
-                        // if it's not in the yaml then archive it
-                        } else if (!job.isPR()) {
-                            job.archived = true;
-                            jobsToSync.push(job.update());
-                        }
+                            // if it's in the yaml, update it
+                            if (parsedConfigJobNames.includes(jobName)) {
+                                const permutations = parsedConfig.jobs[jobName];
 
-                        // sync external triggers for existing jobs
-                        triggersToSync.push(syncExternalTriggers({
-                            pipelineId,
-                            jobName,
-                            requiresList
-                        }));
+                                requiresList = permutations[0].requires || [];
+                                job.permutations = permutations;
+                                job.archived = false;
+                                jobsToSync.push(job.update());
+                            // if it's not in the yaml then archive it
+                            } else if (!job.isPR()) {
+                                job.archived = true;
+                                jobsToSync.push(job.update());
+                            }
 
-                        // if it's a PR, leave it alone
-                        jobsProcessed.push(job.name);
-                    });
-
-                    // Loop through all defined jobs in the yaml
-                    Object.keys(parsedConfig.jobs).forEach((jobName) => {
-                        const permutations = parsedConfig.jobs[jobName];
-                        const jobConfig = {
-                            pipelineId,
-                            name: jobName,
-                            permutations
-                        };
-                        const requiresList = permutations[0].requires || [];
-
-                        // If the job has not been processed, create it (new jobs)
-                        if (!jobsProcessed.includes(jobName)) {
-                            jobsToSync.push(factory.create(jobConfig));
-
-                            // sync external triggers for new jobs
+                            // sync external triggers for existing jobs
                             triggersToSync.push(syncExternalTriggers({
-                                pipelineId: this.id,
+                                pipelineId,
                                 jobName,
                                 requiresList
                             }));
-                        }
-                    });
 
-                    return Promise.all(triggersToSync)
-                        .then(() => Promise.all(jobsToSync));
-                }))
+                            // if it's a PR, leave it alone
+                            jobsProcessed.push(job.name);
+                        });
+
+                        // Loop through all defined jobs in the yaml
+                        Object.keys(parsedConfig.jobs).forEach((jobName) => {
+                            const permutations = parsedConfig.jobs[jobName];
+                            const jobConfig = {
+                                pipelineId,
+                                name: jobName,
+                                permutations
+                            };
+                            const requiresList = permutations[0].requires || [];
+
+                            // If the job has not been processed, create it (new jobs)
+                            if (!jobsProcessed.includes(jobName)) {
+                                jobsToSync.push(factory.create(jobConfig));
+
+                                // sync external triggers for new jobs
+                                triggersToSync.push(syncExternalTriggers({
+                                    pipelineId: this.id,
+                                    jobName,
+                                    requiresList
+                                }));
+                            }
+                        });
+
+                        return Promise.all(triggersToSync)
+                            .then(() => Promise.all(jobsToSync));
+                    });
+            })
             // wait until all promises have resolved
             .then((updatedJobs) => {
                 // Add jobId to workflowGraph.nodes

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,4 +1,5 @@
 /* eslint no-param-reassign: ["error", { "props": false }] */
+/* eslint-disable no-underscore-dangle */
 
 'use strict';
 
@@ -88,22 +89,35 @@ class PipelineModel extends BaseModel {
 
     /**
      * Get the screwdriver configuration for the pipeline at the given ref
-     * @method getConfiguration
-     * @param  {String}  [ref]   Reference to the branch or PR
-     * @return {Promise}         Resolves to parsed and flattened configuration
+     * @method _getPipelineFactory
+     * @return {Object}         PipelineFactory instance
      */
-    getConfiguration(configuration) {
-        const ref = hoek.reach(configuration, 'ref') || undefined;
-        const isPR = hoek.reach(configuration, 'isPR') || false;
+    _getPipelineFactory() {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
         const PipelineFactory = require('./pipelineFactory');
-        const TemplateFactory = require('./templateFactory');
-        /* eslint-enable global-require */
 
+        return PipelineFactory.getInstance();
+    }
+
+    /**
+     * Get the screwdriver configuration for the pipeline at the given ref
+     * @method getConfiguration
+     * @param  {Object}  [configuration]       Config object
+     * @param  {String}  [configuration.ref]   Reference to get screwdriver.yaml, e.g.sha, prRef, branch
+     * @param  {String}  [configuration.isPR]  Flag to indicate if it is getting config for PR
+     * @return {Promise}         Resolves to parsed and flattened configuration
+     */
+    getConfiguration(configuration) {
+        const ref = hoek.reach(configuration, 'ref');
+        const isPR = hoek.reach(configuration, 'isPR') || false;
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        // eslint-disable-next-line global-require
+        const TemplateFactory = require('./templateFactory');
         const templateFactory = TemplateFactory.getInstance();
-        const pipelineFactory = PipelineFactory.getInstance();
+        const pipelineFactory = this._getPipelineFactory();
 
         // If it is a child pipeline, use config pipeline's getConfiguration
         if (this.configPipelineId) {
@@ -172,7 +186,6 @@ class PipelineModel extends BaseModel {
 
         existingPRs.forEach((job) => {
             // getting PR and number e.g. PR-1
-            // eslint-disable-next-line no-underscore-dangle
             const prName = this._getPartialJobName(job.name, 'pr');
 
             // if PR is closed, add it to archive list
@@ -212,7 +225,6 @@ class PipelineModel extends BaseModel {
         const jobsToUpdate = [];
 
         jobList.forEach((j) => {
-            // eslint-disable-next-line no-underscore-dangle
             const jobName = this._getPartialJobName(j.name, 'job') || 'main';
 
             if (parsedConfig) {
@@ -251,7 +263,6 @@ class PipelineModel extends BaseModel {
                 });
 
                 return Promise.all[prJobNames.map((name) => {
-                    // eslint-disable-next-line no-underscore-dangle
                     const jobName = this._getPartialJobName(name, 'job');
 
                     const jobConfig = {
@@ -291,7 +302,6 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     syncPRs() {
-        /* eslint-disable no-underscore-dangle */
         return this.token.then(token =>
             Promise.all([
                 this.jobs,
@@ -309,7 +319,6 @@ class PipelineModel extends BaseModel {
                     this._updateJobArchive(jobList.toUnarchive, false)
                 ]);
             }));
-        /* eslint-enable no-understore-dangle */
     }
 
     /**
@@ -381,14 +390,14 @@ class PipelineModel extends BaseModel {
     /**
      * Checks if any admin from this.admins has github permission to given scmUri
      * @method _hasAdminPermission
+     * @param  {String}    scmUri
      * @return {Promise}
      */
     async _hasAdminPermission(scmUri) {
         /* eslint-disable no-restricted-syntax */
         for (const username of Object.keys(this.admins)) {
-            /* eslint-disable global-require */
+            // eslint-disable-next-line global-require
             const UserFactory = require('./userFactory');
-            /* eslint-enable global-require */
             const factory = UserFactory.getInstance();
 
             // eslint-disable-next-line no-await-in-loop
@@ -415,29 +424,18 @@ class PipelineModel extends BaseModel {
      * @param {Array} scmUrl  checkout url for a repository
      * @return {Promise}
      */
-    async _getPipeline(scmUrl) {
-        /* eslint-disable global-require */
-        const PipelineFactory = require('./pipelineFactory');
-        /* eslint-enable global-require */
-        const pipelineFactory = PipelineFactory.getInstance();
+    async _getScmUri(scmUrl) {
+        const pipelineFactory = this._getPipelineFactory();
         const token = await this.token;
         const admin = await this.admin;
         const scmContext = admin.scmContext;
         const scmUri = await pipelineFactory.scm.parseUrl({
             scmContext,
-            scmUrl,
+            checkoutUrl: scmUrl,
             token
         });
 
-        const hasAdminPermission = await this._hasAdminPermission(scmUri);
-
-        if (!hasAdminPermission) {
-            // need to figure out how to bubble up this err to user
-            // eslint-disable-next-line no-console
-            console.log(`Admins of ${this.pipelineId} has no admin permission to ${scmUrl}`);
-        }
-
-        return pipelineFactory.get({ scmUri });
+        return scmUri;
     }
 
     /**
@@ -447,27 +445,35 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     async _createOrUpdatePipeine(scmUrl) {
-        /* eslint-disable global-require */
-        const PipelineFactory = require('./pipelineFactory');
-        /* eslint-enable global-require */
-        const pipelineFactory = PipelineFactory.getInstance();
+        const pipelineFactory = this._getPipelineFactory();
         const admins = this.admins;
-        const token = await this.token;
-        const admin = await this.admin;
-        const scmContext = admin.scmContext;
-        const scmUri = await pipelineFactory.scm.parseUrl({
-            scmContext,
-            scmUrl,
-            token
-        });
+        const scmContext = this.scmContext;
+        const scmUri = await this._getScmUri(scmUrl);
+        const hasAdminPermission = await this._hasAdminPermission(scmUri);
 
-        const pipeline = await this._getPipeline(scmUrl);
+        if (!hasAdminPermission) {
+            // need to figure out how to bubble up this err to user
+            // eslint-disable-next-line no-console
+            console.log(`Admins of pipeline:${this.id} has no admin permission to ${scmUrl}`);
 
-        // Pipelien exists, update admins
+            return null;
+        }
+
+        const pipeline = await pipelineFactory.get({ scmUri });
+
         if (pipeline) {
-            pipeline.admins = admins;
+            // Child pipeline belongs to this parent, update it
+            if (pipeline.configPipelineId === this.id) {
+                pipeline.admins = admins;
 
-            return pipeline.update();
+                return pipeline.update();
+            }
+
+            // Child pipline does not belong to this parent, return
+            // eslint-disable-next-line no-console
+            console.log(`Pipeline ${scmUrl} already exist: ${pipeline.id}`);
+
+            return null;
         }
 
         return pipelineFactory.create({
@@ -485,13 +491,22 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     async _removePipeine(scmUrl) {
-        const pipeline = await this.getPipeline(scmUrl);
+        const pipelineFactory = this._getPipelineFactory();
+        const scmUri = await this._getScmUri(scmUrl);
 
-        if (!pipeline) {
+        const hasAdminPermission = await this._hasAdminPermission(scmUri);
+
+        if (!hasAdminPermission) {
+            // need to figure out how to bubble up this err to user
+            // eslint-disable-next-line no-console
+            console.log(`Admins of ${this.pipelineId} has no admin permission to ${scmUrl}`);
+
             return null;
         }
 
-        return pipeline.remove();
+        const pipeline = await pipelineFactory.get({ scmUri });
+
+        return pipeline ? pipeline.remove() : null;
     }
 
     /**
@@ -503,13 +518,14 @@ class PipelineModel extends BaseModel {
     async _syncChildPipelines(scmUrls) {
         const toCreateOrUpdate = [];
         const toRemove = [];
+        const oldScmUrls = this.scmUrls || [];
         // scmUrls in the old list but not the new list should be removed
-        const scmUrlsToRemove = this.scmUrls.filtered(scmUrl => !scmUrls.includes(scmUrl));
+        const scmUrlsToRemove = oldScmUrls.filter(scmUrl => !scmUrls.includes(scmUrl));
 
         // create or update child pipelines
-        scmUrls.forEach(scmUrl => toCreateOrUpdate.push(this.createOrUpdatePipeine(scmUrl)));
+        scmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeine(scmUrl)));
         // remove child pipelines
-        scmUrlsToRemove.forEach(scmUrl => toRemove.push(this.removePipeine(scmUrl)));
+        scmUrlsToRemove.forEach(scmUrl => toRemove.push(this._removePipeine(scmUrl)));
 
         return Promise.all([
             toCreateOrUpdate,
@@ -530,24 +546,11 @@ class PipelineModel extends BaseModel {
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
         const JobFactory = require('./jobFactory');
-        const PipelineFactory = require('./pipelineFactory');
         /* eslint-enable global-require */
-
         const factory = JobFactory.getInstance();
-        const pipelineFactory = PipelineFactory.getInstance();
 
         // get the pipeline configuration
-        return new Promise((resolve) => {
-            // If it is a child pipeline, get job config from config pipeline
-            if (this.configPipelineId) {
-                const conf = pipelineFactory.get(this.configPipelineId)
-                    .then(configPipeline => configPipeline.getConfiguration({ ref }));
-
-                return resolve(conf);
-            }
-
-            return resolve(this.getConfiguration({ ref }));
-        })
+        return this.getConfiguration({ ref })
             .then((parsedConfig) => {
                 // If it is an external config pipeline, sync all children
                 if (parsedConfig.scmUrls && !this.configPipelineId) {
@@ -905,6 +908,8 @@ class PipelineModel extends BaseModel {
      * @return {Promise}        Resolves to null if remove successfully
      */
     remove() {
+        const pipelineFactory = this._getPipelineFactory();
+
         const removeJobs = (archived =>
             this.getJobs({
                 params: {
@@ -934,12 +939,21 @@ class PipelineModel extends BaseModel {
                         .then(() => removeEvents(type));
                 }));
 
+        const removeChildPipelines = (() =>
+            pipelineFactory.list({
+                params: {
+                    configPipelineId: this.id
+                }
+            })
+                .then(pipelines => Promise.all(pipelines.map(p => p.remove()))));
+
         return this.secrets
             .then(secrets => Promise.all(secrets.map(secret => secret.remove()))) // remove secrets
             .then(() => removeJobs(true)) // remove archived jobs
             .then(() => removeJobs(false)) // remove non-archived jobs
             .then(() => removeEvents('pipeline')) // remove pipeline events
             .then(() => removeEvents('pr')) // remove pr events
+            .then(() => removeChildPipelines()) // remove pr events
             .then(() => super.remove()); // remove pipeline
     }
 }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -92,14 +92,31 @@ class PipelineModel extends BaseModel {
      * @param  {String}  [ref]   Reference to the branch or PR
      * @return {Promise}         Resolves to parsed and flattened configuration
      */
-    getConfiguration(ref) {
+    getConfiguration(configuration) {
+        const ref = hoek.reach(configuration, 'ref') || undefined;
+        const isPR = hoek.reach(configuration, 'isPR') || false;
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
+        const PipelineFactory = require('./pipelineFactory');
         const TemplateFactory = require('./templateFactory');
         /* eslint-enable global-require */
 
         const templateFactory = TemplateFactory.getInstance();
+        const pipelineFactory = PipelineFactory.getInstance();
+
+        // If it is a child pipeline, use config pipeline's getConfiguration
+        if (this.configPipelineId) {
+            return pipelineFactory.get(this.configPipelineId)
+                .then((configPipeline) => {
+                    // If it is a PR on child pipeine, use config from config pipeline
+                    if (isPR) {
+                        return configPipeline.getConfiguration({});
+                    }
+
+                    return configPipeline.getConfiguration({ ref });
+                });
+        }
 
         return this.admin.then(user => user.unsealToken())
             // fetch the screwdriver.yaml file
@@ -224,7 +241,10 @@ class PipelineModel extends BaseModel {
         const factory = JobFactory.getInstance();
 
         const jobsToCreate = prList.map(pr =>
-            this.getConfiguration(pr.ref).then((config) => {
+            this.getConfiguration({
+                ref: pr.ref,
+                isPR: true
+            }).then((config) => {
                 const prJobNames = workflowParser.getNextJobs(config.workflowGraph, {
                     trigger: '~pr',
                     prNum: pr.name.split('-')[1]
@@ -310,7 +330,10 @@ class PipelineModel extends BaseModel {
                 prNum
             }))
             .then(prInfo => Promise.all([
-                this.getConfiguration(prInfo.ref),
+                this.getConfiguration({
+                    ref: prInfo.ref,
+                    isPR: true
+                }),
                 this.jobs
             ]))
             .then(([parsedConfig, jobs]) => {
@@ -356,6 +379,107 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     *
+     */
+    async getPipeline(scmUrl) {
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const PipelineFactory = require('./pipelineFactory');
+        /* eslint-enable global-require */
+        const pipelineFactory = PipelineFactory.getInstance();
+        const token = await this.token;
+        const admin = await this.admin;
+        const scmContext = admin.scmContext;
+        const scmUri = await pipelineFactory.scm.parseUrl({
+            scmContext,
+            scmUrl,
+            token
+        });
+        const permissions = await admin.getPermissions(scmUri);
+
+        if (!permissions.admin) {
+            throw new Error(
+                `User ${admin.getFullDisplayName()} is not an admin of this repo`
+            );
+        }
+
+        return pipelineFactory.get({ scmUri });
+    }
+
+    /**
+     *
+     */
+    async createPipeine(scmUrl) {
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const PipelineFactory = require('./pipelineFactory');
+        /* eslint-enable global-require */
+        const pipelineFactory = PipelineFactory.getInstance();
+        const token = await this.token;
+        const admin = await this.admin;
+        const scmContext = admin.scmContext;
+        const scmUri = await pipelineFactory.scm.parseUrl({
+            scmContext,
+            scmUrl,
+            token
+        });
+        const pipeline = await this.getPipeline(scmUrl);
+
+        if (pipeline) {
+            return pipeline;
+        }
+
+        return pipelineFactory.create({
+            admins: {
+                [admin.username]: true
+            },
+            scmContext,
+            scmUri,
+            configPipelineId: this.id
+        });
+    }
+
+    /**
+     *
+     */
+    async removePipeine(scmUrl) {
+        const pipeline = await this.getPipeline(scmUrl);
+
+        if (!pipeline) {
+            return null;
+        }
+
+        return pipeline.remove();
+    }
+
+    /**
+     * Sync the pipeline by looking up screwdriver.yaml
+     * Create, update, or disable jobs if necessary.
+     * Store/update the pipeline workflowGraph
+     * @method sync
+     * @param {String} [ref]  A reference to fetch the screwdriver.yaml, can be branch/tag/commit
+     * @return {Promise}
+     */
+    async syncConfigPipeline(scmUrls) {
+        const pipelinesToCreate = [];
+        const pipelinesToRemove = [];
+
+        // eslind does not like await in loop, follow eslint example: https://eslint.org/docs/rules/no-await-in-loop
+        // add child pipelines
+        scmUrls.forEach(scmUrl => pipelinesToCreate.push(this.createPipeine(scmUrl)));
+
+        // remove child pipelines
+        scmUrls.forEach(scmUrl => pipelinesToRemove.push(this.removePipeine(scmUrl)));
+
+        return Promise.all([
+            pipelinesToCreate,
+            pipelinesToRemove
+        ]);
+    }
+
+    /**
      * Sync the pipeline by looking up screwdriver.yaml
      * Create, update, or disable jobs if necessary.
      * Store/update the pipeline workflowGraph
@@ -368,82 +492,101 @@ class PipelineModel extends BaseModel {
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
         const JobFactory = require('./jobFactory');
+        const PipelineFactory = require('./pipelineFactory');
         /* eslint-enable global-require */
 
         const factory = JobFactory.getInstance();
+        const pipelineFactory = PipelineFactory.getInstance();
 
         // get the pipeline configuration
-        return this.getConfiguration(ref)
-            // get list of jobs to create
+        return new Promise((resolve) => {
+            // if using external config, get job config from config pipeine
+            if (this.configPipelineId) {
+                const conf = pipelineFactory.get(this.configPipelineId)
+                    .then(configPipeline => configPipeline.getConfiguration({ ref }));
+
+                return resolve(conf);
+            }
+
+            return resolve(this.getConfiguration({ ref }));
+        })
             .then((parsedConfig) => {
                 this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 
-                return this.jobs
-                    .then((existingJobs) => {
-                        const jobsToSync = [];
-                        const jobsProcessed = [];
-                        const triggersToSync = [];
-                        const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
-                        const pipelineId = this.id;
+                // If it is an external config pipeline, sync all children
+                if (parsedConfig.scmUrls && !this.configPipelineId) {
+                    this.scmUrls = parsedConfig.scmUrls;
 
-                        // Loop through all existing jobs
-                        existingJobs.forEach((job) => {
-                            const jobName = job.name;
-                            let requiresList = [];
+                    return this.syncConfigPipeline(this.scmUrls)
+                        .then(() => parsedConfig);
+                }
 
-                            // if it's in the yaml, update it
-                            if (parsedConfigJobNames.includes(jobName)) {
-                                const permutations = parsedConfig.jobs[jobName];
+                return parsedConfig;
+            }).then(parsedConfig => this.jobs
+                .then((existingJobs) => {
+                    const jobsToSync = [];
+                    const jobsProcessed = [];
+                    const triggersToSync = [];
+                    const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
+                    const pipelineId = this.id;
 
-                                requiresList = permutations[0].requires || [];
-                                job.permutations = permutations;
-                                job.archived = false;
-                                jobsToSync.push(job.update());
-                            // if it's not in the yaml then archive it
-                            } else if (!job.isPR()) {
-                                job.archived = true;
-                                jobsToSync.push(job.update());
-                            }
+                    // Loop through all existing jobs
+                    existingJobs.forEach((job) => {
+                        const jobName = job.name;
+                        let requiresList = [];
 
-                            // sync external triggers for existing jobs
+                        // if it's in the yaml, update it
+                        if (parsedConfigJobNames.includes(jobName)) {
+                            const permutations = parsedConfig.jobs[jobName];
+
+                            requiresList = permutations[0].requires || [];
+                            job.permutations = permutations;
+                            job.archived = false;
+                            jobsToSync.push(job.update());
+                        // if it's not in the yaml then archive it
+                        } else if (!job.isPR()) {
+                            job.archived = true;
+                            jobsToSync.push(job.update());
+                        }
+
+                        // sync external triggers for existing jobs
+                        triggersToSync.push(syncExternalTriggers({
+                            pipelineId,
+                            jobName,
+                            requiresList
+                        }));
+
+                        // if it's a PR, leave it alone
+                        jobsProcessed.push(job.name);
+                    });
+
+                    // Loop through all defined jobs in the yaml
+                    Object.keys(parsedConfig.jobs).forEach((jobName) => {
+                        const permutations = parsedConfig.jobs[jobName];
+                        const jobConfig = {
+                            pipelineId,
+                            name: jobName,
+                            permutations
+                        };
+                        const requiresList = permutations[0].requires || [];
+
+                        // If the job has not been processed, create it (new jobs)
+                        if (!jobsProcessed.includes(jobName)) {
+                            jobsToSync.push(factory.create(jobConfig));
+
+                            // sync external triggers for new jobs
                             triggersToSync.push(syncExternalTriggers({
-                                pipelineId,
+                                pipelineId: this.id,
                                 jobName,
                                 requiresList
                             }));
-
-                            // if it's a PR, leave it alone
-                            jobsProcessed.push(job.name);
-                        });
-
-                        // Loop through all defined jobs in the yaml
-                        Object.keys(parsedConfig.jobs).forEach((jobName) => {
-                            const permutations = parsedConfig.jobs[jobName];
-                            const jobConfig = {
-                                pipelineId,
-                                name: jobName,
-                                permutations
-                            };
-                            const requiresList = permutations[0].requires || [];
-
-                            // If the job has not been processed, create it (new jobs)
-                            if (!jobsProcessed.includes(jobName)) {
-                                jobsToSync.push(factory.create(jobConfig));
-
-                                // sync external triggers for new jobs
-                                triggersToSync.push(syncExternalTriggers({
-                                    pipelineId: this.id,
-                                    jobName,
-                                    requiresList
-                                }));
-                            }
-                        });
-
-                        return Promise.all(triggersToSync)
-                            .then(() => Promise.all(jobsToSync));
+                        }
                     });
-            })
+
+                    return Promise.all(triggersToSync)
+                        .then(() => Promise.all(jobsToSync));
+                }))
             // wait until all promises have resolved
             .then((updatedJobs) => {
                 // Add jobId to workflowGraph.nodes

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "async": "^2.6.1",
+    "async": "^2.0.1",
     "base64url": "^3.0.0",
     "compare-versions": "^3.2.1",
     "docker-parse-image": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "async": "^2.0.1",
+    "async": "^2.6.1",
     "base64url": "^3.0.0",
     "compare-versions": "^3.2.1",
     "docker-parse-image": "^3.0.1",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,6 +3,8 @@ shared:
 
 jobs:
     main:
+        environment:
+            SD_SONAR_OPTS: "-Dsonar.sources=lib -Dsonar.javascript.lcov.reportPath=artifacts/coverage/lcov.info"
         requires: [~pr, ~commit]
         steps:
             - install: npm install
@@ -10,7 +12,7 @@ jobs:
 
     publish:
         requires: main
-        template: screwdriver-cd/semantic-release 
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -32,7 +32,10 @@ describe('Event Factory', () => {
             save: sinon.stub()
         };
         pipelineFactoryMock = {
-            get: sinon.stub()
+            get: sinon.stub(),
+            scm: {
+                getCommitSha: sinon.stub().resolves('configpipelinesha')
+            }
         };
         buildFactoryMock = {
             create: sinon.stub()
@@ -417,6 +420,30 @@ describe('Event Factory', () => {
                 });
             })
         );
+
+        it('should call pipeline sync with configPipelineSha if passed in', () => {
+            config.parentEventId = 222;
+            config.configPipelineSha = 'configpipelinesha';
+
+            return eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.calledWith(pipelineMock.sync, config.configPipelineSha);
+            });
+        });
+
+        it('should create event with config pipeline sha if it is child pipeline', () => {
+            pipelineMock.configPipelineId = 1;
+            pipelineFactoryMock.get.withArgs(1).resolves({
+                id: 1,
+                token: Promise.resolve('token')
+            });
+
+            return eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.deepEqual(model.configPipelineSha, 'configpipelinesha');
+                assert.calledWith(pipelineMock.sync, 'configpipelinesha');
+            });
+        });
 
         it('throw error if sourcepaths is not supported', () => {
             jobsMock = [{

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -666,6 +666,27 @@ describe('Pipeline Model', () => {
                     assert.notCalled(pipelineFactoryMock.update);
                 });
         });
+
+        it('Remove child pipeline and reset scmUrls if it is removed from new yaml', () => {
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'bar.git'
+            })).resolves('bar');
+            childPipelineMock.configPipelineId = 456;
+            pipelineFactoryMock.get.resolves(childPipelineMock);
+            pipeline.scmUrls = [
+                'bar.git'
+            ];
+
+            return pipeline.sync()
+                .then((p) => {
+                    assert.equal(p.id, testId);
+                    assert.equal(p.scmUrls, null);
+                    assert.calledOnce(childPipelineMock.remove);
+                });
+        });
     });
 
     describe('syncPR', () => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -11,8 +11,7 @@ const PARSED_YAML = require('../data/parser');
 const PARSED_YAML_WITH_REQUIRES = require('../data/parserWithRequires');
 const PARSED_YAML_PR = require('../data/parserWithWorkflowGraphPR');
 const SCM_URLS = [
-    'foo.git',
-    'bar.git'
+    'foo.git'
 ];
 const EXTERNAL_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML, {
     annotations: { 'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s' },
@@ -35,6 +34,7 @@ describe('Pipeline Model', () => {
     let triggerFactoryMock;
     let pipelineFactoryMock;
     let configPipelineMock;
+    let childPipelineMock;
 
     const dateNow = 1111111111;
     const scmUri = 'github.com:12345:master';
@@ -59,6 +59,7 @@ describe('Pipeline Model', () => {
         decorated.isPR = sinon.stub().returns(false);
         decorated.prNum = null;
         decorated.remove = sinon.stub().resolves(null);
+        decorated.update = sinon.stub().resolves(job);
 
         return decorated;
     };
@@ -81,7 +82,7 @@ describe('Pipeline Model', () => {
     beforeEach(() => {
         publishJob = getJobMocks({
             id: 99999,
-            me: 'publish',
+            name: 'publish',
             archived: false
         });
 
@@ -147,11 +148,25 @@ describe('Pipeline Model', () => {
         configPipelineMock = {
             id: 1,
             scmUrls: SCM_URLS,
-            getConfiguration: sinon.stub().resolves(EXTERNAL_PARSED_YAML)
+            getConfiguration: sinon.stub().resolves(EXTERNAL_PARSED_YAML),
+            update: sinon.stub().resolves(null),
+            remove: sinon.stub().resolves(null)
+        };
+        childPipelineMock = {
+            id: 2,
+            scmUrls: SCM_URLS,
+            configPipelineId: testId,
+            update: sinon.stub().resolves(null),
+            remove: sinon.stub().resolves(null)
         };
         pipelineFactoryMock = {
             get: sinon.stub().resolves(configPipelineMock),
-            create: sinon.stub()
+            update: sinon.stub().resolves(null),
+            create: sinon.stub(),
+            list: sinon.stub().resolves([]),
+            scm: {
+                parseUrl: sinon.stub()
+            }
         };
         scmMock = {
             addWebhook: sinon.stub(),
@@ -221,7 +236,8 @@ describe('Pipeline Model', () => {
         userFactoryMock.get.withArgs({ username: a.username, scmContext }).resolves({
             unsealToken: sinon.stub().resolves('foo'),
             getPermissions: sinon.stub().resolves({
-                push: a.push
+                push: a.push,
+                admin: a.admin
             }),
             username: a.username
         });
@@ -270,6 +286,8 @@ describe('Pipeline Model', () => {
             scmMock.getFile.resolves('superyamlcontent');
             scmMock.addWebhook.resolves();
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
+            parserMock.withArgs('yamlcontentwithscmurls', templateFactoryMock)
+                .resolves(EXTERNAL_PARSED_YAML);
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
             pipeline.admins = { batman: true, robin: true };
@@ -570,6 +588,82 @@ describe('Pipeline Model', () => {
             return pipeline.sync()
                 .catch((err) => {
                     assert.deepEqual(err, error);
+                });
+        });
+
+        it('Sync child pipeline if detects changes in scmUrls', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+
+            parsedYaml.scmUrls = [
+                'foo.git',
+                'bar.git'
+            ];
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs('yamlcontentwithscmurls', templateFactoryMock)
+                .resolves(parsedYaml);
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'foo.git'
+            })).resolves('foo');
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'bar.git'
+            })).resolves('bar');
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'baz.git'
+            })).resolves('baz');
+            pipelineFactoryMock.get.resolves(childPipelineMock);
+            pipelineFactoryMock.get.withArgs({ scmUri: 'bar' }).resolves(null);
+            pipeline.scmUrls = [
+                'baz.git'
+            ];
+
+            return pipeline.sync()
+                .then((p) => {
+                    assert.equal(p.id, testId);
+                    assert.deepEqual(p.scmUrls, [
+                        'foo.git',
+                        'bar.git'
+                    ]);
+                    assert.calledWith(parserMock, 'yamlcontentwithscmurls', templateFactoryMock);
+                    assert.calledOnce(pipelineFactoryMock.create);
+                    assert.calledOnce(childPipelineMock.update);
+                    assert.calledOnce(childPipelineMock.remove);
+                });
+        });
+
+        it('Do not sync child pipelines if no admin permissions', () => {
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'foo.git'
+            })).resolves('foo');
+            pipelineFactoryMock.get.resolves(null);
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+
+            return pipeline.sync()
+                .then((p) => {
+                    assert.equal(p.id, testId);
+                    assert.notCalled(pipelineFactoryMock.create);
+                });
+        });
+
+        it('Do not update child pipelines if not belong to this parent', () => {
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'bar.git'
+            })).resolves('bar');
+            childPipelineMock.configPipelineId = 456;
+            pipelineFactoryMock.get.resolves(childPipelineMock);
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+
+            return pipeline.sync()
+                .then((p) => {
+                    assert.equal(p.id, testId);
+                    assert.notCalled(pipelineFactoryMock.update);
                 });
         });
     });
@@ -1095,7 +1189,17 @@ describe('Pipeline Model', () => {
                 })
         );
 
-        it('gets pipeline config from an external pipeline with an alternate ref', () => {
+        it('gets config from external config pipeline', () => {
+            pipeline.configPipelineId = 1;
+
+            return pipeline.getConfiguration()
+                .then((config) => {
+                    assert.calledWith(configPipelineMock.getConfiguration, { ref: undefined });
+                    assert.equal(config, EXTERNAL_PARSED_YAML);
+                });
+        });
+
+        it('gets config from external config pipeline with an alternate ref', () => {
             pipeline.configPipelineId = 1;
 
             return pipeline.getConfiguration({
@@ -1105,15 +1209,6 @@ describe('Pipeline Model', () => {
                     assert.calledWith(configPipelineMock.getConfiguration, {
                         ref: 'bar'
                     });
-                    assert.equal(config, EXTERNAL_PARSED_YAML);
-                });
-        });
-
-        it('gets pipeline config from an external pipeline', () => {
-            pipeline.configPipelineId = 1;
-
-            return pipeline.getConfiguration()
-                .then((config) => {
                     assert.equal(config, EXTERNAL_PARSED_YAML);
                 });
         });
@@ -1357,6 +1452,18 @@ describe('Pipeline Model', () => {
 
                 // Delete all the events
                 assert.callCount(testEvent.remove, 6);
+
+                // Delete the pipeline
+                assert.calledOnce(datastore.remove);
+            });
+        });
+
+        it('remove child pipelines', () => {
+            pipelineFactoryMock.list.resolves([childPipelineMock, childPipelineMock]);
+
+            return pipeline.remove().then(() => {
+                // Delete all the child pipelines
+                assert.callCount(childPipelineMock.remove, 2);
 
                 // Delete the pipeline
                 assert.calledOnce(datastore.remove);


### PR DESCRIPTION
To support one single config pipeline(with `screwdriver.yaml`) that manages a list of child pipelines, this PR adds the following stuff:
- Sync config pipeline will create/update/remove child pipelines based on `scmUrls` in screwdriver.yaml
- Sync child pipeline will getConfiguration from config pipeline; for child pipeline PRs, get Configuration from config pipeline instead of `prRef` 
- Create event will add an extra field `configPipelineSha` for child pipeline events. So that later on if ppl want to restart event for child pipeline, we know where to get the exact `screwdriver.yaml`

Related to https://github.com/screwdriver-cd/screwdriver/issues/937