### PR TITLE
fix: Check if template exists with default namespace and name

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -77,9 +77,17 @@ class TemplateFactory extends BaseFactory {
 
         // If fullTemplateName has no '/', don't need to bother to grep for namespace
         if (fullTemplateName.indexOf('/') <= -1) {
-            parsedTemplate.namespace = 'default';
+            // Check if template with default namespace and name exist, default to using that template
+            return super.list({ params: {
+                namespace: 'default',
+                name: parsedTemplate.name
+            } }).then((namespaceExists) => {
+                if (namespaceExists.length > 0) {
+                    parsedTemplate.namespace = 'default';
+                }
 
-            return Promise.resolve(parsedTemplate);
+                return parsedTemplate;
+            });
         }
 
         const [, namespace, name]

--- a/lib/templateTagFactory.js
+++ b/lib/templateTagFactory.js
@@ -51,9 +51,17 @@ class TemplateTagFactory extends BaseFactory {
 
         // If fullTemplateName has no '/', don't need to bother to grep for namespace
         if (fullTemplateName.indexOf('/') <= -1) {
-            parsedTemplate.namespace = 'default';
+            // Check if template with default namespace and name exist, default to using that template
+            return super.list({ params: {
+                namespace: 'default',
+                name: parsedTemplate.name
+            } }).then((namespaceExists) => {
+                if (namespaceExists.length > 0) {
+                    parsedTemplate.namespace = 'default';
+                }
 
-            return Promise.resolve(parsedTemplate);
+                return parsedTemplate;
+            });
         }
 
         const [, namespace, name]

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -305,13 +305,15 @@ describe('Template Factory', () => {
             ];
         });
 
+        // namespace: namespace
+        // name: testTemplate
         it('should get a template when namespace is passed in', () => {
             datastore.get.resolves(returnValue[2]);
             expected = Object.assign({}, returnValue[2]);
 
             return factory.get(config).then((model) => {
                 assert.calledWith(datastore.get, sinon.match({
-                    params: { name: 'testTemplate', namespace, version: '1.0.2' }
+                    params: { name, namespace, version: '1.0.2' }
                 }));
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
@@ -320,8 +322,30 @@ describe('Template Factory', () => {
             });
         });
 
-        it('should get template from default namespace when no namespace is passed in', () => {
+        // name: testTemplate
+        // Template with "namespace: default, name: test" does not exist
+        it('should get template when default namespace does not exist', () => {
             datastore.get.resolves(returnValue[3]);
+            datastore.scan.resolves([]);
+            expected = Object.assign({}, returnValue[3]);
+            delete config.namespace;
+
+            return factory.get(config).then((model) => {
+                assert.calledWith(datastore.get, sinon.match({
+                    params: { name: 'testTemplate', namespace: null, version: '1.0.2' }
+                }));
+                assert.instanceOf(model, Template);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        // name: testTemplate
+        // Template with "namespace: default, name: test" exists
+        it('should get template when default namespace does not exist', () => {
+            datastore.get.resolves(returnValue[3]);
+            datastore.scan.resolves([returnValue[3]]);
             expected = Object.assign({}, returnValue[3]);
             delete config.namespace;
 
@@ -336,6 +360,7 @@ describe('Template Factory', () => {
             });
         });
 
+        // name: namespace/testTemplate
         it('should get a template with implicit namespace in name', () => {
             datastore.get.resolves(returnValue[3]);
             datastore.scan.resolves([]);

--- a/test/lib/templateTagFactory.test.js
+++ b/test/lib/templateTagFactory.test.js
@@ -65,6 +65,7 @@ describe('TemplateTag Factory', () => {
     describe('create', () => {
         const generatedId = 1234135;
         let expected;
+        let returnValue;
 
         beforeEach(() => {
             expected = {
@@ -73,12 +74,37 @@ describe('TemplateTag Factory', () => {
                 tag,
                 version
             };
+            returnValue = [{
+                id: generatedId,
+                name,
+                tag,
+                version
+            }];
         });
 
-        // namespace should be default
+        // namespace should be default since a template exists with that name and namespace
         // name: testTemplateTag
-        it('creates a Template Tag given name, tag, and version', () => {
+        it('creates a Template Tag given name, tag, and version and defaults namespace', () => {
             expected.namespace = 'default';
+            datastore.scan.resolves(returnValue);
+            datastore.save.resolves(expected);
+
+            return factory.create({
+                name,
+                tag,
+                version
+            }).then((model) => {
+                assert.instanceOf(model, TemplateTag);
+                Object.keys(expected).forEach((key) => {
+                    assert.strictEqual(model[key], expected[key]);
+                });
+            });
+        });
+
+        // namespace should not be default since a template does not exist with that name and namespace
+        // name: testTemplateTag
+        it('creates a Template Tag given name, tag, and version and no namespace', () => {
+            datastore.scan.resolves([]);
             datastore.save.resolves(expected);
 
             return factory.create({
@@ -254,7 +280,9 @@ describe('TemplateTag Factory', () => {
             };
         });
 
-        it('lists a Template Tag given a name when namespace does not exist', () => {
+        // name: testTemplateTag
+        // Template with default namespace and name exists
+        it('lists a Template Tag given a name when namespace is default', () => {
             datastore.scan.resolves(expected);
 
             return factory.list(config).then((model) => {
@@ -262,6 +290,18 @@ describe('TemplateTag Factory', () => {
             });
         });
 
+        // name: testTemplateTag
+        // Template with default namespace and name does not exist
+        it('lists a Template Tag given a name when namespace does not exist', () => {
+            datastore.scan.onCall(0).resolves([]);
+            datastore.scan.onCall(1).resolves(expected);
+
+            return factory.list(config).then((model) => {
+                assert.instanceOf(model[0], TemplateTag);
+            });
+        });
+
+        // name: namespace/testTemplateTag
         it('lists a Template Tag given a name when namespace exists', () => {
             datastore.scan.resolves(expected);
             config.params.name = fullTemplateName;


### PR DESCRIPTION
Should make sure a template or template tag with namespace "default" exists before we try to set the namespace to default.

This should make things relatively backwards compatible.

Related to https://github.com/screwdriver-cd/screwdriver/issues/926#issuecomment-391907638