### PR TITLE
fix(1094): Default annotations to empty object

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -220,7 +220,7 @@ class BuildModel extends BaseModel {
             job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
                 .then(blockedBy => this[executor].start({
                     jobId: job.id,
-                    annotations: hoek.reach(job.permutations[0], 'annotations'),
+                    annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
                     blockedBy,
                     apiUri: this[apiUri],
                     buildId: this.id,


### PR DESCRIPTION
## Context
If annotations is missing (in the case where the pipeline has no `screwdriver.yaml`), it will be passed into the executor's `start` function as `undefined`. In `executor-k8s`, [`hoek.reach()`](https://github.com/screwdriver-cd/executor-k8s/blob/v11.1.1/index.js#L168) will pull in the annotations as `undefined`.

This causes funky error messages as seen in screwdriver-cd/screwdriver#1094.

## Objective
Default annotations to `{}` if undefined.

## Reference
screwdriver-cd/screwdriver#1094