### PR TITLE
[DNM] fix(926): Get all template namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,14 @@ factory.getTemplate(fullTemplateName).then(model => {
 | :-------------   | :----- | :-------------|  :-------------|
 | fullTemplateName | String | Yes | Name of the template and the version or tag (e.g. chef/publish@1.2.3 or chef/publish@latest). Can also be just name of the template (e.g. chef/publish) |
 
+#### Get Namespaces
+Get an array of all template namespaces. If no namespaces, the function will resolve with an empty array.
+```js
+factory.getNamespaces().then(model => {
+    // do stuff with template namespaces
+});
+```
+
 #### Search Template
 ```js
 'use strict';

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -280,6 +280,30 @@ class TemplateFactory extends BaseFactory {
     }
 
     /**
+     * Get all unique template namespaces
+     * @method getNamespaces
+     * @return {Promise}                        Resolves array of template namespaces
+     */
+    getNamespaces() {
+        // Get all templates
+        return this.list({})
+            .then((templates) => {
+                const namespaces = [];
+
+                // Push unique template namespaces to an array
+                templates.forEach((template) => {
+                    if (namespaces.indexOf(template.namespace) <= -1) {
+                        namespaces.push(template.namespace);
+                    }
+                });
+                // Sort templates alphabetically
+                namespaces.sort();
+
+                return namespaces;
+            });
+    }
+
+    /**
      * Get an instance of the TemplateFactory
      * @method getInstance
      * @param  {Object}     config

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -608,4 +608,67 @@ describe('Template Factory', () => {
             });
         });
     });
+
+    describe('getNamespaces', () => {
+        let allTemplates;
+
+        beforeEach(() => {
+            allTemplates = [
+                {
+                    id: '1',
+                    namespace: 'namespaceOne',
+                    name: 'testTemplateName',
+                    version: '1.0.1'
+                },
+                {
+                    id: '3',
+                    namespace: 'namespaceTwo',
+                    name: 'testTemplateName',
+                    version: '1.0.3'
+                },
+                {
+                    id: '2',
+                    namespace: 'namespaceThree',
+                    name: 'testTemplateName',
+                    version: '1.0.2'
+                },
+                {
+                    id: '4',
+                    namespace: 'namespaceFour',
+                    name: 'testTemplateName',
+                    version: '2.0.1'
+                },
+                {
+                    id: '5',
+                    namespace: 'namespaceDuplicate',
+                    name: 'testTemplateName',
+                    version: '2.0.1'
+                },
+                {
+                    id: '6',
+                    namespace: 'namespaceDuplicate',
+                    name: 'testTemplateName',
+                    version: '2.0.2'
+                }
+            ];
+        });
+
+        it('should return empty array if no namespaces found', () => {
+            datastore.scan.onCall(0).resolves([]);
+
+            return factory.getNamespaces().then((namespaces) => {
+                assert.isArray(namespaces);
+                assert.lengthOf(namespaces, 0);
+            });
+        });
+
+        it('should return all unique namespaces', () => {
+            datastore.scan.onCall(0).resolves(allTemplates);
+
+            return factory.getNamespaces().then((namespaces) => {
+                assert.isArray(namespaces);
+                assert.lengthOf(namespaces, 5);
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Context
It would be nice to have an API endpoint `GET /templates/namespaces` to return all namespaces.

## Objective
Adding a templateFactory method to get all namespaces so we can have an API endpoint to get all namespaces.

_Note: Not sure what other metadata we would like to return._

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/926