### PR TITLE
fix(1082): [10] change way to get jobs from trigger

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -154,17 +154,15 @@ function startBuild(config) {
 function createBuilds(config) {
     const { eventConfig, eventId, pipeline, pipelineConfig, changedFiles, webhooks } = config;
     const startFrom = eventConfig.startFrom;
-    let branch = '';
 
     if (!startFrom) {
         return null;
     }
 
-    return pipeline.branch.then((b) => {
-        branch = b;
-
-        return pipeline.jobs;
-    }).then((jobs) => {
+    return Promise.all([
+        pipeline.branch,
+        pipeline.jobs
+    ]).then(([branch, jobs]) => {
         // When startFrom is ~commit
         const jobsFromTrigger = getJobsFromTrigger({
             jobs,

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -2,7 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
-const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
+const { EXTERNAL_TRIGGER, COMMIT_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 
 let instance;
@@ -18,16 +18,23 @@ let instance;
  * @return {Array}                                          Array of commit jobs to start
  */
 function getJobsFromTrigger(config) {
-    const { jobs, pipelineConfig, startFrom } = config;
-    const isTrigger = EXTERNAL_TRIGGER.test(startFrom);
+    const { jobs, pipelineConfig, startFrom, branch } = config;
+    const isExternalTrigger = EXTERNAL_TRIGGER.test(startFrom);
+    const isCommitTrigger = COMMIT_TRIGGER.test(startFrom);
 
-    if (startFrom !== '~commit' && !isTrigger) {
+    if (!isExternalTrigger && !isCommitTrigger) {
         return [];
     }
 
-    const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+    let nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
         trigger: startFrom
     });
+
+    if (startFrom === '~commit') {
+        nextJobs = nextJobs.concat(workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+            trigger: `~commit:${branch}`
+        }));
+    }
 
     return jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED' && !j.archived);
 }
@@ -42,8 +49,9 @@ function getJobsFromTrigger(config) {
  */
 function getJobsFromJobName(config) {
     const { jobs, startFrom } = config;
+    const isCommitTrigger = COMMIT_TRIGGER.test(startFrom);
 
-    if (startFrom === '~commit' || startFrom === '~pr') {
+    if (isCommitTrigger || startFrom === '~pr') {
         return [];
     }
 
@@ -145,17 +153,23 @@ function startBuild(config) {
 function createBuilds(config) {
     const { eventConfig, eventId, pipeline, pipelineConfig, changedFiles, webhooks } = config;
     const startFrom = eventConfig.startFrom;
+    let branch = '';
 
     if (!startFrom) {
         return null;
     }
 
-    return pipeline.jobs.then((jobs) => {
+    return pipeline.branch.then((b) => {
+        branch = b;
+
+        return pipeline.jobs;
+    }).then((jobs) => {
         // When startFrom is ~commit
         const jobsFromTrigger = getJobsFromTrigger({
             jobs,
             pipelineConfig,
-            startFrom
+            startFrom,
+            branch
         });
         // When startFrom is a job name
         const jobsFromJobName = getJobsFromJobName({

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -15,7 +15,7 @@ let instance;
  * @param  {Object}   config.pipelineConfig
  * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
  * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, ~sd@123:main, etc)
- * @param  {String}   consig.branch                         triggered branch name
+ * @param  {String}   config.branch                         triggered branch name
  * @return {Array}                                          Array of commit jobs to start
  */
 function getJobsFromTrigger(config) {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -15,6 +15,7 @@ let instance;
  * @param  {Object}   config.pipelineConfig
  * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
  * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, ~sd@123:main, etc)
+ * @param  {String}   consig.branch                         triggered branch name
  * @return {Array}                                          Array of commit jobs to start
  */
 function getJobsFromTrigger(config) {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -11,11 +11,11 @@ let instance;
  * Get triggered jobs to start that are enabled
  * @method getJobsFromTrigger
  * @param  {Object}   config
+ * @param  {String}   config.branch                         triggered branch name
  * @param  {Array}    config.jobs                           Array of job objects
  * @param  {Object}   config.pipelineConfig
  * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
  * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, ~sd@123:main, etc)
- * @param  {String}   config.branch                         triggered branch name
  * @return {Array}                                          Array of commit jobs to start
  */
 function getJobsFromTrigger(config) {
@@ -42,7 +42,7 @@ function getJobsFromTrigger(config) {
 
 /**
  * Get jobs from job name to start that are enabled
- * @method getJobsToStart
+ * @method getJobsFromJobName
  * @param  {Object}   config
  * @param  {Array}    config.jobs      Array of job objects
  * @param  {String}   config.startFrom Startfrom (e.g. ~commit, ~pr, etc)

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -147,14 +147,20 @@ describe('Event Factory', () => {
                         { name: 'main' },
                         { name: 'disabledJob' },
                         { name: 'publish' },
-                        { name: '~sd@123:main' }
+                        { name: '~sd@123:main' },
+                        { name: '~commit:branch' },
+                        { name: '~commit:/^.*$/' }
                     ],
                     edges: [
                         { src: '~sd@123:main', dest: 'main' },
                         { src: '~pr', dest: 'main' },
                         { src: '~commit', dest: 'main' },
                         { src: 'main', dest: 'disabledJob' },
-                        { src: '~pr', dest: 'publish' }
+                        { src: '~pr', dest: 'publish' },
+                        { src: '~commit', dest: 'only-commit' },
+                        { src: '~commit:branch', dest: 'main' },
+                        { src: '~commit:branch', dest: 'only-branch' },
+                        { src: '~commit:/^.*$/', dest: 'wild' }
                     ]
                 },
                 causeMessage: 'Started by github:stjohn',
@@ -177,19 +183,26 @@ describe('Event Factory', () => {
                         { name: 'main' },
                         { name: 'disabledJob' },
                         { name: 'publish' },
-                        { name: '~sd@123:main' }
+                        { name: '~sd@123:main' },
+                        { name: '~commit:branch' },
+                        { name: '~commit:/^.*$/' }
                     ],
                     edges: [
                         { src: '~sd@123:main', dest: 'main' },
                         { src: '~pr', dest: 'main' },
                         { src: '~commit', dest: 'main' },
                         { src: 'main', dest: 'disabledJob' },
-                        { src: '~pr', dest: 'publish' }
+                        { src: '~pr', dest: 'publish' },
+                        { src: '~commit', dest: 'only-commit' },
+                        { src: '~commit:branch', dest: 'main' },
+                        { src: '~commit:branch', dest: 'only-branch' },
+                        { src: '~commit:/^.*$/', dest: 'wild' }
                     ]
                 },
                 getConfiguration: sinon.stub().resolves(PARSED_YAML),
                 update: sinon.stub().resolves(syncedPipelineMock),
-                job: Promise.resolve([])
+                job: Promise.resolve([]),
+                branch: Promise.resolve('branch')
             };
 
             afterSyncedPRPipelineMock = Object.assign({}, syncedPipelineMock);
@@ -197,7 +210,8 @@ describe('Event Factory', () => {
 
             pipelineMock = {
                 sync: sinon.stub().resolves(syncedPipelineMock),
-                update: sinon.stub().resolves(syncedPipelineMock)
+                update: sinon.stub().resolves(syncedPipelineMock),
+                branch: sinon.stub().resolves('branch')
             };
 
             pipelineFactoryMock.get.withArgs(pipelineId).resolves(pipelineMock);
@@ -214,7 +228,7 @@ describe('Event Factory', () => {
                     pipelineId: 8765,
                     name: 'main',
                     permutations: [{
-                        requires: ['~commit', '~pr', '~sd@123:main']
+                        requires: ['~commit', '~pr', '~sd@123:main', '~commit:branch']
                     }],
                     state: 'ENABLED'
                 }, {
@@ -231,6 +245,30 @@ describe('Event Factory', () => {
                     name: 'publish',
                     permutations: [{
                         requires: ['~pr']
+                    }],
+                    state: 'ENABLED'
+                }, {
+                    id: 5,
+                    pipelineId: 8765,
+                    name: 'only-branch',
+                    permutations: [{
+                        requires: ['~commit:branch']
+                    }],
+                    state: 'ENABLED'
+                }, {
+                    id: 6,
+                    pipelineId: 8765,
+                    name: 'only-commit',
+                    permutations: [{
+                        requires: ['~commit']
+                    }],
+                    state: 'ENABLED'
+                }, {
+                    id: 7,
+                    pipelineId: 8765,
+                    name: 'wild',
+                    permutations: [{
+                        requires: ['~commit:/^.*$/']
                     }],
                     state: 'ENABLED'
                 }];
@@ -348,6 +386,60 @@ describe('Event Factory', () => {
                 });
             });
 
+            it('should create ~commit and ~commit:branch triggered builds', () => {
+                config.startFrom = '~commit';
+
+                return eventFactory.create(config).then((model) => {
+                    assert.instanceOf(model, Event);
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 1
+                    }));
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 5
+                    }));
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 6
+                    }));
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 7
+                    }));
+                });
+            });
+
+            it('should create ~commit:branch triggered builds', () => {
+                config.startFrom = '~commit:branch';
+
+                return eventFactory.create(config).then((model) => {
+                    assert.instanceOf(model, Event);
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 1
+                    }));
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 5
+                    }));
+                    assert.neverCalledWith(buildFactoryMock.create, sinon.match({
+                        jobId: 6
+                    }));
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 7
+                    }));
+                });
+            });
+
             it('should create build if startFrom is a jobName', () => {
                 config.startFrom = 'main';
 
@@ -430,7 +522,8 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock)
+                jobs: Promise.resolve(jobsMock),
+                branch: Promise.resolve('branch')
             });
 
             config.startFrom = 'main';
@@ -457,7 +550,8 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock)
+                jobs: Promise.resolve(jobsMock),
+                branch: Promise.resolve('branch')
             });
 
             config.startFrom = 'main';
@@ -486,7 +580,8 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock)
+                jobs: Promise.resolve(jobsMock),
+                branch: Promise.resolve('branch')
             });
 
             config.startFrom = 'main';
@@ -524,7 +619,8 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock)
+                jobs: Promise.resolve(jobsMock),
+                branch: Promise.resolve('branch')
             });
 
             config.webhooks = true;
@@ -559,7 +655,8 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock)
+                jobs: Promise.resolve(jobsMock),
+                branch: Promise.resolve('branch')
             });
 
             config.startFrom = '~pr';


### PR DESCRIPTION
## Context
When startFrom is `~commit`, Screwdriver need to start jobs which start from `~commit:branch` and `~commit`.

## Objective
When startFrom is `~commit`, getJobsFromTrigger try to find job which start from `~commit:branch`.

## References
Related to https://github.com/screwdriver-cd/screwdriver/issues/1082