### PR TITLE
feat(937): Pass config pipeline's secrets to child pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -7,6 +7,7 @@ const BaseModel = require('./base');
 const parser = require('screwdriver-config-parser');
 const workflowParser = require('screwdriver-workflow-parser');
 const hoek = require('hoek');
+const _ = require('lodash');
 const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const PAGINATE_PAGE = 1;
 const PAGINATE_COUNT = 50;
@@ -799,11 +800,33 @@ class PipelineModel extends BaseModel {
         /* eslint-enable global-require */
         const factory = SecretFactory.getInstance();
 
-        const secrets = factory.list(listConfig);
+        let secrets = factory.list(listConfig);
 
-        // ES6 has weird getters and setters in classes,
-        // so we redefine the pipeline property here to resolve to the
-        // resulting promise and not try to recreate the factory, etc.
+        // Fetch and merge config pipeline's secrets
+        if (this.configPipelineId && this.configPipelineId !== this.id) {
+            const configPipelineListConfig = hoek.clone(listConfig);
+
+            configPipelineListConfig.params.pipelineId = this.configPipelineId;
+
+            return Promise.all([
+                secrets,
+                factory.list(configPipelineListConfig)
+            ]).then((results) => {
+                // Merge config pipeline's secrets into this pipeline's
+                secrets = _.uniqBy([...results[0], ...results[1]], 'name');
+
+                // ES6 has weird getters and setters in classes,
+                // so we redefine the pipeline property here to resolve to the
+                // resulting promise and not try to recreate the factory, etc.
+                Object.defineProperty(this, 'secrets', {
+                    enumerable: true,
+                    value: secrets
+                });
+
+                return secrets;
+            });
+        }
+
         Object.defineProperty(this, 'secrets', {
             enumerable: true,
             value: secrets

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -803,7 +803,7 @@ class PipelineModel extends BaseModel {
         let secrets = factory.list(listConfig);
 
         // Fetch and merge config pipeline's secrets
-        if (this.configPipelineId && this.configPipelineId !== this.id) {
+        if (this.configPipelineId) {
             const configPipelineListConfig = hoek.clone(listConfig);
 
             configPipelineListConfig.params.pipelineId = this.configPipelineId;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^6.0.0",
-    "joi": "^13.3.0",
+    "joi": "^13.4.0",
     "mockery": "^2.0.0",
     "sinon": "^4.5.0"
   },
@@ -52,8 +52,8 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.1.0",
-    "screwdriver-data-schema": "^18.21.2",
+    "screwdriver-config-parser": "^4.2.1",
+    "screwdriver-data-schema": "^18.24.2",
     "screwdriver-workflow-parser": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.2.1",
-    "screwdriver-data-schema": "^18.24.2",
+    "screwdriver-config-parser": "^4.3.0",
+    "screwdriver-data-schema": "^18.24.4",
     "screwdriver-workflow-parser": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
+    "lodash": "^4.17.10",
     "screwdriver-config-parser": "^4.1.0",
     "screwdriver-data-schema": "^18.21.2",
     "screwdriver-workflow-parser": "^1.4.1"

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1037,6 +1037,56 @@ describe('Pipeline Model', () => {
             // as the model's pipeline property, now
             assert.calledOnce(secretFactoryMock.list);
         });
+
+        it('gets config pipeline\'s secrets', () => {
+            const childPipelineId = 1234;
+
+            pipelineConfig.id = childPipelineId;
+            pipelineConfig.configPipelineId = pipeline.id;
+
+            const childPipeline = new PipelineModel(pipelineConfig);
+
+            const configPipelineSecrets = [
+                {
+                    name: 'TEST',
+                    value: 'testvalue',
+                    allowInPR: true,
+                    pipelineId: pipeline.id
+                },
+                {
+                    name: 'ANOTHER',
+                    value: 'anothervalue',
+                    allowInPR: true,
+                    pipelineId: pipeline.id
+                }
+            ];
+            const childPipelineSecrets = [
+                {
+                    name: 'TEST',
+                    value: 'SHOULD OVERRIDE',
+                    allowInPR: true,
+                    pipelineId: pipeline.id
+                }
+            ];
+
+            const listConfig = {
+                params: {
+                    pipelineId: childPipeline.id
+                },
+                paginate
+            };
+
+            secretFactoryMock.list.resolves([
+                [childPipelineSecrets],
+                [configPipelineSecrets]
+            ]);
+            // when we fetch secrets it resolves to a promise
+            assert.isFunction(childPipeline.secrets.then);
+            // and a factory is called to create that promise
+            assert.calledWith(secretFactoryMock.list, listConfig);
+            // Both the configPipeline and childPipeline secrets are fetched
+            assert.calledTwice(secretFactoryMock.list);
+        });
     });
 
     describe('get jobs', () => {

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -45,6 +45,7 @@ describe('Token Model', () => {
             userId: 12345,
             hash: '1a2b3c',
             id: 6789,
+            pipelineId: 123,
             name: 'Mobile client auth token',
             description: 'For the mobile app',
             lastUsed: '2017-05-10T01:49:59.327Z',
@@ -107,6 +108,7 @@ describe('Token Model', () => {
         const expected = {
             userId: 12345,
             id: 6789,
+            pipelineId: 123,
             name: 'Mobile client auth token',
             description: 'For the mobile app',
             lastUsed: '2017-05-10T01:49:59.327Z'

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -45,7 +45,6 @@ describe('Token Model', () => {
             userId: 12345,
             hash: '1a2b3c',
             id: 6789,
-            pipelineId: 123,
             name: 'Mobile client auth token',
             description: 'For the mobile app',
             lastUsed: '2017-05-10T01:49:59.327Z',
@@ -108,7 +107,6 @@ describe('Token Model', () => {
         const expected = {
             userId: 12345,
             id: 6789,
-            pipelineId: 123,
             name: 'Mobile client auth token',
             description: 'For the mobile app',
             lastUsed: '2017-05-10T01:49:59.327Z'


### PR DESCRIPTION
## Context
Since child pipelines inherit the configuration of their config pipeline, they should also inherit their config pipeline's secrets.

## Objective
`pipeline.secrets` should return a Promise that includes the config pipeline's secrets if the pipeline is a child pipeline.

In the case that secrets between the two pipeline's share the same name, the child pipeline's secrets should take precedence.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/937
