### PR TITLE
fix(1090): Add createTime to commands, templates, and tags [2]

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -7,6 +7,7 @@ class CommandModel extends BaseModel {
      * Construct an CommandModel object
      * @method constructor
      * @param  {Object}   config                Config object to create the command with
+     * @param  {String}   config.createTime     The time the command was created
      * @param  {Object}   config.datastore      Object that will perform operations on the datastore
      */
     constructor(config) {

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -75,6 +75,8 @@ class CommandFactory extends BaseFactory {
                     config.version = `${latestMajor}${latestMinor}.${patch}`;
                 }
 
+                config.createTime = (new Date()).toISOString();
+
                 return super.create(config);
             });
     }

--- a/lib/commandTag.js
+++ b/lib/commandTag.js
@@ -7,6 +7,7 @@ class CommandTagModel extends BaseModel {
      * Construct a CommandTagModel object
      * @method constructor
      * @param  {Object}    config
+     * @param  {String}    config.createTime    The time the command tag was created
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
      * @param  {String}    config.namespace     The command namespace
      * @param  {String}    config.name          The command name

--- a/lib/commandTagFactory.js
+++ b/lib/commandTagFactory.js
@@ -42,6 +42,22 @@ class CommandTagFactory extends BaseFactory {
 
         return instance;
     }
+
+    /**
+     * Create a new command tag for a given version
+     * @method create
+     * @param  {Object}     config
+     * @param  {String}     config.name         The command name
+     * @param  {String}     config.namespace    The command namespace
+     * @param  {String}     config.tag          The command tag
+     * @param  {String}     config.version      The command version
+     * @return {Promise}
+     */
+    create(config) {
+        config.createTime = (new Date()).toISOString();
+
+        return super.create(config);
+    }
 }
 
 module.exports = CommandTagFactory;

--- a/lib/template.js
+++ b/lib/template.js
@@ -7,7 +7,8 @@ class TemplateModel extends BaseModel {
      * Construct a TemplateModel object
      * @method constructor
      * @param  {Object}    config
-     * @param  {Object}    config.datastore         Object that will perform operations on the datastore
+     * @param  {String}    config.createTime    The time the template was created
+     * @param  {Object}    config.datastore     Object that will perform operations on the datastore
      */
     constructor(config) {
         super('template', config);

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -157,6 +157,8 @@ class TemplateFactory extends BaseFactory {
                     config.version = `${latestMajor}${latestMinor}.${patch}`;
                 }
 
+                config.createTime = (new Date()).toISOString();
+
                 return super.create(config);
             });
     }

--- a/lib/templateTag.js
+++ b/lib/templateTag.js
@@ -7,6 +7,7 @@ class TemplateTagModel extends BaseModel {
      * Construct a TemplateTagModel object
      * @method constructor
      * @param  {Object}    config
+     * @param  {String}    config.createTime    The time the template tag was created
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
      * @param  {String}    config.name          The template name
      * @param  {String}    [config.namespace]   The template namespace

--- a/lib/templateTagFactory.js
+++ b/lib/templateTagFactory.js
@@ -105,6 +105,8 @@ class TemplateTagFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
+        config.createTime = (new Date()).toISOString();
+
         if (config.name && !config.namespace) {
             // eslint-disable-next-line no-underscore-dangle
             return this._getNameAndNamespace(config.name).then((parsedTemplateName) => {

--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
   "dependencies": {
     "async": "^2.0.1",
     "base64url": "^3.0.0",
-    "compare-versions": "^3.2.1",
+    "compare-versions": "^3.3.0",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
     "screwdriver-config-parser": "^4.3.0",
-    "screwdriver-data-schema": "^18.24.4",
-    "screwdriver-workflow-parser": "^1.4.1"
+    "screwdriver-data-schema": "^18.24.7",
+    "screwdriver-workflow-parser": "^1.5.0"
   }
 }


### PR DESCRIPTION
Add createTime to create config for commands, templates, command tags, and template tags

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1090
Blocked by https://github.com/screwdriver-cd/data-schema/pull/255