### PR TITLE
feat(614): [2] add tokens to pipeline model

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ model.getEvents(config)
 | config.type | Number | No | `pipeline` | Type of event: `pipeline` or `pr` |
 | config.sort | Number | No | `descending`| Sorting by createTime |
 
+#### Tokens
+Get the pipeline's access tokens
+```js
+model.tokens
+    .then((tokens) => {
+        // do stuff with tokens
+    });
+```
+
 ### Job Factory
 #### Search
 ```js

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -676,6 +676,40 @@ class PipelineModel extends BaseModel {
         return admin;
     }
 
+    /** Fetch a pipeline's tokens
+    /* @property tokens
+    /* @return {Promise}
+    */
+    get tokens() {
+        const listConfig = {
+            params: {
+                pipelineId: this.id
+            },
+            paginate: {
+                count: PAGINATE_COUNT,
+                page: PAGINATE_PAGE
+            }
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const TokenFactory = require('./tokenFactory');
+        /* eslint-enable global-require */
+        const factory = TokenFactory.getInstance();
+        const tokens = factory.list(listConfig);
+
+        // ES6 has weird getters and setters in classes,
+        // so we redefine the pipeline property here to resolve to the
+        // resulting promise and not try to recreate the factory, etc.
+        Object.defineProperty(this, 'tokens', {
+            enumerable: true,
+            value: tokens
+        });
+
+        return tokens;
+    }
+
     /**
      * This function deletes admins who does not have proper
      * GitHub permission, and returns an proper admin.
@@ -966,8 +1000,12 @@ class PipelineModel extends BaseModel {
             })
                 .then(pipelines => Promise.all(pipelines.map(p => p.remove()))));
 
+        const removeTokens = (() =>
+            this.tokens.then(tokens => Promise.all(tokens.map(t => t.remove()))));
+
         return this.secrets
             .then(secrets => Promise.all(secrets.map(secret => secret.remove()))) // remove secrets
+            .then(() => removeTokens()) // remove tokens
             .then(() => removeJobs(true)) // remove archived jobs
             .then(() => removeJobs(false)) // remove non-archived jobs
             .then(() => removeEvents('pipeline')) // remove pipeline events

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -33,6 +33,7 @@ describe('Pipeline Model', () => {
     let templateFactoryMock;
     let triggerFactoryMock;
     let pipelineFactoryMock;
+    let tokenFactoryMock;
     let configPipelineMock;
     let childPipelineMock;
 
@@ -168,6 +169,9 @@ describe('Pipeline Model', () => {
                 parseUrl: sinon.stub()
             }
         };
+        tokenFactoryMock = {
+            list: sinon.stub()
+        };
         scmMock = {
             addWebhook: sinon.stub(),
             getFile: sinon.stub(),
@@ -194,6 +198,8 @@ describe('Pipeline Model', () => {
         mockery.registerMock('screwdriver-config-parser', parserMock);
         mockery.registerMock('./pipelineFactory', {
             getInstance: sinon.stub().returns(pipelineFactoryMock) });
+        mockery.registerMock('./tokenFactory', {
+            getInstance: sinon.stub().returns(tokenFactoryMock) });
 
         // eslint-disable-next-line global-require
         PipelineModel = require('../../lib/pipeline');
@@ -1383,6 +1389,11 @@ describe('Pipeline Model', () => {
             pipelineId: testId,
             remove: sinon.stub().resolves(null)
         };
+        const token = {
+            name: 'TEST_TOKEN',
+            pipelineId: testId,
+            remove: sinon.stub().resolves(null)
+        };
 
         beforeEach(() => {
             archived = {
@@ -1405,20 +1416,32 @@ describe('Pipeline Model', () => {
             eventFactoryMock.list.resolves([]);
             jobFactoryMock.list.resolves([]);
             secretFactoryMock.list.resolves([secret]);
+            tokenFactoryMock.list.resolves([token]);
         });
 
         afterEach(() => {
             eventFactoryMock.list.reset();
             jobFactoryMock.list.reset();
+            secretFactoryMock.list.reset();
+            tokenFactoryMock.list.reset();
             publishJob.remove.reset();
             mainJob.remove.reset();
             blahJob.remove.reset();
+            secret.remove.reset();
+            token.remove.reset();
         });
 
         it('remove secrets', () =>
             pipeline.remove().then(() => {
                 assert.calledOnce(secretFactoryMock.list);
                 assert.calledOnce(secret.remove);
+            })
+        );
+
+        it('remove tokens', () =>
+            pipeline.remove().then(() => {
+                assert.calledOnce(tokenFactoryMock.list);
+                assert.calledOnce(token.remove);
             })
         );
 
@@ -1545,6 +1568,41 @@ describe('Pipeline Model', () => {
                 assert.isOk(err);
                 assert.equal(err.message, 'error removing secret');
             });
+        });
+
+        it('fail if token.remove returns error', () => {
+            secret.remove.reset();
+            token.remove.rejects(new Error('error removing token'));
+
+            return pipeline.remove().then(() => {
+                assert.fail('should not get here');
+            }).catch((err) => {
+                assert.isOk(err);
+                assert.equal(err.message, 'error removing token');
+            });
+        });
+    });
+
+    describe('get tokens', () => {
+        it('has a tokens getter', () => {
+            const listConfig = {
+                params: {
+                    pipelineId: testId
+                },
+                paginate
+            };
+
+            tokenFactoryMock.list.resolves(null);
+            // when we fetch tokens it resolves to a promise
+            assert.isFunction(pipeline.tokens.then);
+            // and a factory is called to create that promise
+            assert.calledWith(tokenFactoryMock.list, listConfig);
+
+            // When we call user.tokens again it is still a promise
+            assert.isFunction(pipeline.tokens.then);
+            // ...but the factory was not recreated, since the promise is stored
+            // as the model's tokens property, now
+            assert.calledOnce(tokenFactoryMock.list);
         });
     });
 });

--- a/test/lib/token.test.js
+++ b/test/lib/token.test.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const sinon = require('sinon');
 const mockery = require('mockery');
+const hoek = require('hoek');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -58,11 +59,25 @@ describe('Token Model', () => {
         mockery.disable();
     });
 
-    it('is constructed properly', () => {
+    it('is constructed properly for user token', () => {
         assert.instanceOf(token, TokenModel);
         assert.instanceOf(token, BaseModel);
         schema.models.token.allKeys.forEach((key) => {
             assert.strictEqual(token[key], createConfig[key]);
+        });
+    });
+
+    it('is constructed properly for pipeline token', () => {
+        const pipelineConfig = hoek.clone(createConfig);
+
+        delete pipelineConfig.userId;
+        pipelineConfig.pipelineId = 123;
+        token = new TokenModel(pipelineConfig);
+
+        assert.instanceOf(token, TokenModel);
+        assert.instanceOf(token, BaseModel);
+        schema.models.token.allKeys.forEach((key) => {
+            assert.strictEqual(token[key], pipelineConfig[key]);
         });
     });
 
@@ -106,6 +121,7 @@ describe('Token Model', () => {
     describe('toJson', () => {
         const expected = {
             userId: 12345,
+            pipelineId: undefined,
             id: 6789,
             name: 'Mobile client auth token',
             description: 'For the mobile app',


### PR DESCRIPTION
## Context
To implement pipeline API token.

## Objective
This PR allows pipeline models to contain their own tokens.

## References
Original issue:
https://github.com/screwdriver-cd/screwdriver/issues/614

Related PRs:
https://github.com/screwdriver-cd/data-schema/pull/257