### PR TITLE
feat(1113): Parse meta from config on event creation

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -150,6 +150,7 @@ class BuildFactory extends BaseFactory {
      * @param  {String}    [config.parentBuildId]   Id of the build that triggers this build
      * @param  {Boolean}   [config.start]           Whether to start the build after creating
      * @param  {Object}    [config.environment]     Dynamically injected environment variables
+     * @param  {Object}  [config.meta]              Metadata tied to this build
      * @return {Promise}
      */
     create(config) {
@@ -161,6 +162,7 @@ class BuildFactory extends BaseFactory {
         modelConfig.cause = `Started by user ${displayName}`;
         modelConfig.number = number;
         modelConfig.status = config.start === false ? 'CREATED' : 'QUEUED';
+        modelConfig.meta = config.meta || {};
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -297,6 +297,7 @@ class EventFactory extends BaseFactory {
      * @param  {String}  [config.workflowGraph]     workflowGraph of parentEvent if there is a parentEvent
      * @param  {Array}   [config.changedFiles]      Array of files that were changed
      * @param  {Boolean} [config.webhooks]          If the create came from a webhook (pr or push) or not
+     * @param  {Object}  [config.meta]              Metadata tied to this event
      * @return {Promise}
      */
     create(config) {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -313,7 +313,7 @@ class EventFactory extends BaseFactory {
             sha: config.sha,
             startFrom: config.startFrom,
             causeMessage: config.causeMessage || `Started by ${displayName}`,
-            meta: {},
+            meta: config.meta || {},
             pr: {}
         };
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.3.0",
+    "screwdriver-config-parser": "^4.3.1",
     "screwdriver-data-schema": "^18.24.7",
     "screwdriver-workflow-parser": "^1.5.0"
   }

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -190,6 +190,11 @@ describe('Build Factory', () => {
             }
         };
 
+        const meta = {
+            foo: 'bar',
+            one: 1
+        };
+
         let saveConfig;
 
         beforeEach(() => {
@@ -223,7 +228,8 @@ describe('Build Factory', () => {
                     environment,
                     steps,
                     jobId,
-                    sha
+                    sha,
+                    meta
                 }
             };
         });
@@ -245,7 +251,7 @@ describe('Build Factory', () => {
             delete saveConfig.params.commit;
 
             return factory.create({
-                garbage, username, jobId, eventId, sha, parentBuildId: 12345
+                garbage, username, jobId, eventId, sha, parentBuildId: 12345, meta
             }).then(() => assert.calledWith(datastore.save, saveConfig));
         });
 
@@ -255,8 +261,9 @@ describe('Build Factory', () => {
             delete saveConfig.params.commit;
             delete saveConfig.params.parentBuildId;
 
-            return factory.create({ username, jobId, eventId, sha }).then(() =>
-                assert.calledWith(datastore.save, saveConfig));
+            return factory.create({
+                username, jobId, eventId, sha, meta
+            }).then(() => assert.calledWith(datastore.save, saveConfig));
         });
 
         it('creates a new build in the datastore, looking up sha', () => {
@@ -270,7 +277,7 @@ describe('Build Factory', () => {
             userFactoryMock.get.resolves(user);
 
             return factory.create({
-                username, scmContext, jobId, eventId, prRef, parentBuildId: 12345
+                username, scmContext, jobId, eventId, prRef, parentBuildId: 12345, meta
             }).then((model) => {
                 assert.instanceOf(model, Build);
                 assert.calledOnce(jobFactory.getInstance);
@@ -314,7 +321,7 @@ describe('Build Factory', () => {
             saveConfig.params.status = 'CREATED';
 
             return factory.create({
-                username, jobId, eventId, parentBuildId: 12345, start: false
+                username, jobId, eventId, parentBuildId: 12345, start: false, meta
             }).then(() => {
                 assert.notCalled(startStub);
                 assert.calledWith(datastore.save, saveConfig);
@@ -357,7 +364,7 @@ describe('Build Factory', () => {
             delete saveConfig.params.commit;
             delete saveConfig.params.parentBuildId;
 
-            return factory.create({ username, jobId, eventId, sha }).then((model) => {
+            return factory.create({ username, jobId, eventId, sha, meta }).then((model) => {
                 assert.calledWith(datastore.save, saveConfig);
                 assert.instanceOf(model, Build);
                 assert.calledOnce(jobFactory.getInstance);
@@ -438,7 +445,8 @@ describe('Build Factory', () => {
                 eventId,
                 parentBuildId: 12345,
                 start: false,
-                environment: { EXTRA: true }
+                environment: { EXTRA: true },
+                meta
             }).then(() => {
                 assert.notCalled(startStub);
                 saveConfig.params.environment.EXTRA = true;

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -513,6 +513,40 @@ describe('Event Factory', () => {
             })
         );
 
+        it('should create an Event with meta', () => {
+            const meta = {
+                foo: 'bar',
+                one: 1
+            };
+
+            config.meta = meta;
+            expected.meta = meta;
+
+            eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.calledWith(scm.decorateAuthor, {
+                    username: 'stjohn',
+                    scmContext,
+                    token: 'foo'
+                });
+                assert.calledWith(scm.decorateCommit, {
+                    scmUri: 'github.com:1234:branch',
+                    scmContext,
+                    sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
+                    token: 'foo'
+                });
+                assert.strictEqual(syncedPipelineMock.lastEventId, model.id);
+                assert.strictEqual(config.prInfo.url, model.pr.url);
+                Object.keys(expected).forEach((key) => {
+                    if (key === 'workflowGraph' || key === 'meta') {
+                        assert.deepEqual(model[key], expected[key]);
+                    } else {
+                        assert.strictEqual(model[key], expected[key]);
+                    }
+                });
+            });
+        });
+
         it('should call pipeline sync with configPipelineSha if passed in', () => {
             config.parentEventId = 222;
             config.configPipelineSha = 'configpipelinesha';


### PR DESCRIPTION
## Context
Events should be created with the meta specified in the config.

## Objective
Create an `event` with `meta` if the field is populated.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1113