### PR TITLE
fix(1130): Do not remove secrets and child pipelines on invalid config

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1041,7 +1041,11 @@ class PipelineModel extends BaseModel {
             this.tokens.then(tokens => Promise.all(tokens.map(t => t.remove()))));
 
         return this.secrets
-            .then(secrets => Promise.all(secrets.map(secret => secret.remove()))) // remove secrets
+            .then((secrets) => { // remove secrets
+                const filteredSecrets = secrets.filter(secret => secret.pipelineId === this.id);
+
+                return Promise.all(filteredSecrets.map(secret => secret.remove()));
+            })
             .then(() => removeTokens()) // remove tokens
             .then(() => removeJobs(true)) // remove archived jobs
             .then(() => removeJobs(false)) // remove non-archived jobs

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -556,7 +556,7 @@ class PipelineModel extends BaseModel {
             .then((parsedConfig) => {
                 // If it is an external config pipeline, sync all children
                 if ((this.childPipelines || parsedConfig.childPipelines)
-                    && !this.configPipelineId) {
+                    && !this.configPipelineId && !parsedConfig.errors) {
                     return this._syncChildPipelines(
                         hoek.reach(parsedConfig, 'childPipelines.scmUrls'))
                         .then(() => {

--- a/test/data/parserWithErrors.json
+++ b/test/data/parserWithErrors.json
@@ -1,0 +1,28 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "config-parse-error",
+                        "command": "echo \"Spooky error\"; exit 1"
+                     }
+                 ]
+            }
+         ]
+     },
+    "workflowGraph": {
+        "nodes": [
+             { "name": "~pr" },
+             { "name": "~commit" },
+             { "name": "main" }
+         ],
+        "edges": [
+             { "src": "~pr", "dest": "main" },
+             { "src": "~commit", "dest": "main" }
+         ]
+     },
+    "annotations": {},
+    "errors": ["Spooky error"]
+ }


### PR DESCRIPTION
## Context
When editing a parent pipeline's `screwdriver.yaml`, if it yields a`config-parse-error`, its child pipelines and secrets are deleted.

## Objective
Prevent the deletion of child pipelines on `config-parse-error`. This is done through ensuring that `syncChildPipelines` is not called if the configuration is invalid.

When deleting secrets, filter only for secrets that belong to the pipeline.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1130