### PR TITLE
fix(614): update pipeline token lastUsed

### DIFF
--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -69,6 +69,38 @@ class PipelineFactory extends BaseFactory {
     }
 
     /**
+     * Get a pipeline model by id, or personal access token
+     * @method get
+     * @param   {Mixed}     config
+     * @param   {String}    [config.id]             ID of the pipeline
+     * @param   {String}    [config.accessToken]    Access token of the pipeline to look up
+     * @return  {Promise}
+     */
+    get(config) {
+        if (!config.accessToken) {
+            return super.get(config);
+        }
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const TokenFactory = require('./tokenFactory');
+        /* eslint-enable global-require */
+        const tokenFactory = TokenFactory.getInstance();
+
+        return tokenFactory.get({ value: config.accessToken })
+            .then((token) => {
+                if (!token) {
+                    return token;
+                }
+
+                token.lastUsed = (new Date()).toISOString();
+
+                return token.update().then(() => this.get(token.pipelineId));
+            });
+    }
+
+    /**
      * Get an instance of the PipelineFactory
      * @method getInstance
      * @param  {Object}     config


### PR DESCRIPTION
Currently, the `lastUsed` of pipeline token never be updated.
So This PR fix to update it when the pipeline is fetched by accessToken just like user token is doing.

Ref: https://github.com/screwdriver-cd/screwdriver/issues/614#issuecomment-399249412