### PR TITLE
fix(1011): Always update repo name and branch

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -975,22 +975,18 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     update() {
-        if (this.isDirty('scmUri')) {
-            return this.admin
-                .then(user => user.unsealToken())
-                .then(token => this.scm.decorateUrl({
-                    scmUri: this.scmUri,
-                    scmContext: this.scmContext,
-                    token
-                }))
-                .then((scmRepo) => {
-                    this.scmRepo = scmRepo;
+        return this.admin
+            .then(user => user.unsealToken())
+            .then(token => this.scm.decorateUrl({
+                scmUri: this.scmUri,
+                scmContext: this.scmContext,
+                token
+            }))
+            .then((scmRepo) => {
+                this.scmRepo = scmRepo;
 
-                    return super.update();
-                });
-        }
-
-        return super.update();
+                return super.update();
+            });
     }
 
     /**


### PR DESCRIPTION
## Context
If a user changes their repo name, Screwdriver isn't currently updating the scm repo information stored and displaying it correctly in the pipeline page.

## Objective
This PR changes it so calling `update()` always updates the scmRepo information.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1011