### PR TITLE
fix(1150): Include configPipelineId in tokenGen function

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -229,7 +229,8 @@ class BuildModel extends BaseModel {
                     token: this[tokenGen](this.id, {
                         isPR: job.isPR(),
                         jobId: job.id,
-                        pipelineId: pipeline.id
+                        pipelineId: pipeline.id,
+                        configPipelineId: pipeline.configPipelineId
                     }, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT) }))
                 .then(() => this.updateCommitStatus(pipeline))) // update github
                 .then(() => this)

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -18,6 +18,7 @@ describe('Build Model', () => {
     const container = 'node:4';
     const adminUser = { username: 'batman', unsealToken: sinon.stub().resolves('foo') };
     const pipelineId = 1234;
+    const configPipelineId = 1233;
     const scmUri = 'github.com:12345:master';
     const scmContext = 'github:github.com';
     const token = 'equivalentToOneQuarter';
@@ -346,6 +347,7 @@ describe('Build Model', () => {
                 name: 'main',
                 pipeline: Promise.resolve({
                     id: pipelineId,
+                    configPipelineId,
                     scmUri,
                     scmContext,
                     admin: Promise.resolve(adminUser),
@@ -376,7 +378,8 @@ describe('Build Model', () => {
                     assert.calledWith(tokenGen, buildId, {
                         isPR: false,
                         jobId,
-                        pipelineId
+                        pipelineId,
+                        configPipelineId
                     }, scmContext, TEMPORAL_JWT_TIMEOUT);
 
                     assert.calledWith(scmMock.updateCommitStatus, {
@@ -517,6 +520,7 @@ describe('Build Model', () => {
                 name: 'main',
                 pipeline: Promise.resolve({
                     id: pipelineId,
+                    configPipelineId,
                     scmUri,
                     scmContext,
                     admin: Promise.resolve(adminUser),
@@ -541,7 +545,8 @@ describe('Build Model', () => {
                     assert.calledWith(tokenGen, buildId, {
                         isPR: false,
                         jobId,
-                        pipelineId
+                        pipelineId,
+                        configPipelineId
                     }, scmContext, TEMPORAL_JWT_TIMEOUT);
 
                     assert.calledWith(scmMock.updateCommitStatus, {


### PR DESCRIPTION
## Context
Currently, when checking access to build secrets, only the `pipelineId` is checked. 
https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/secrets/index.js#L61-L63

This will not work in the case of child pipelines since they inherit their parent pipeline secrets. Therefore, we include the `configPipelineId` as part of the JWT in order to cover this case.

## Objective
Pass in the `configPipelineId` as part of the `tokenGen` function.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1150