### PR TITLE
feat(1132): Pass in config pipeline to bookend config

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -180,7 +180,7 @@ class BuildFactory extends BaseFactory {
                 return Promise.all([
                     job.pipeline,
                     getCommitInfo({ job, scm: this.scm, modelConfig })
-                ]).then(([pipeline, data]) => {
+                ]).then(async ([pipeline, data]) => {
                     // TODO: support matrix jobs
                     const index = number.toString().split('.')[1] || 0;
                     const permutation = job.permutations[index];
@@ -207,6 +207,10 @@ class BuildFactory extends BaseFactory {
                     }));
 
                     const bookendConfig = { pipeline, job, build: modelConfig };
+
+                    if (pipeline.configPipelineId) {
+                        bookendConfig.configPipeline = await pipeline.configPipeline;
+                    }
 
                     return Promise.all([
                         this.bookend.getSetupCommands(bookendConfig),

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -140,17 +140,18 @@ class BuildFactory extends BaseFactory {
     /**
      * Create a new Build
      * @method create
-     * @param  {Object}    config                   Config object
-     * @param  {String}    config.eventId           The eventId that this build belongs to
-     * @param  {String}    config.jobId             The job associated with this build
-     * @param  {String}    config.username          The user that created this build
-     * @param  {String}    config.scmContext        The scm context to which user belongs
-     * @param  {String}    [config.sha]             The sha of the build
-     * @param  {String}    [config.prRef]           The PR branch or reference
-     * @param  {String}    [config.parentBuildId]   Id of the build that triggers this build
-     * @param  {Boolean}   [config.start]           Whether to start the build after creating
-     * @param  {Object}    [config.environment]     Dynamically injected environment variables
-     * @param  {Object}  [config.meta]              Metadata tied to this build
+     * @param  {Object}    config                      Config object
+     * @param  {String}    config.eventId              The eventId that this build belongs to
+     * @param  {String}    config.jobId                The job associated with this build
+     * @param  {String}    config.username             The user that created this build
+     * @param  {String}    config.scmContext           The scm context to which user belongs
+     * @param  {String}    [config.sha]                The sha of the build
+     * @param  {String}    [config.configPipelineSha]  The sha of the config pipeline
+     * @param  {String}    [config.prRef]              The PR branch or reference
+     * @param  {String}    [config.parentBuildId]      Id of the build that triggers this build
+     * @param  {Boolean}   [config.start]              Whether to start the build after creating
+     * @param  {Object}    [config.environment]        Dynamically injected environment variables
+     * @param  {Object}    [config.meta]               Metadata tied to this build
      * @return {Promise}
      */
     create(config) {
@@ -210,6 +211,7 @@ class BuildFactory extends BaseFactory {
 
                     if (pipeline.configPipelineId) {
                         bookendConfig.configPipeline = await pipeline.configPipeline;
+                        bookendConfig.configPipelineSha = config.configPipelineSha;
                     }
 
                     return Promise.all([

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -154,6 +154,7 @@ function startBuild(config) {
 function createBuilds(config) {
     const { eventConfig, eventId, pipeline, pipelineConfig, changedFiles, webhooks } = config;
     const startFrom = eventConfig.startFrom;
+    const configPipelineSha = pipelineConfig.configPipelineSha;
 
     if (!startFrom) {
         return null;
@@ -194,7 +195,11 @@ function createBuilds(config) {
             // Start builds
             return Promise.all(jobsToStart.map(j =>
                 startBuild({
-                    buildConfig: Object.assign({ jobId: j.id, eventId }, eventConfig),
+                    buildConfig: Object.assign({
+                        jobId: j.id,
+                        eventId,
+                        configPipelineSha
+                    }, eventConfig),
                     changedFiles,
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks
@@ -328,10 +333,17 @@ class EventFactory extends BaseFactory {
                     modelConfig.parentEventId = config.parentEventId;
 
                     // for child pipelines restart event, sync with configPipelineSha
+<<<<<<< HEAD
                     if (configPipelineSha) {
                         modelConfig.configPipelineSha = configPipelineSha;
 
                         return p.sync(configPipelineSha);
+=======
+                    if (config.configPipelineSha) {
+                        modelConfig.configPipelineSha = config.configPipelineSha;
+
+                        return p.sync(config.configPipelineSha);
+>>>>>>> Include configPipelineSha in bookendConfig
                     }
 
                     return p.sync(config.sha);

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -333,17 +333,10 @@ class EventFactory extends BaseFactory {
                     modelConfig.parentEventId = config.parentEventId;
 
                     // for child pipelines restart event, sync with configPipelineSha
-<<<<<<< HEAD
                     if (configPipelineSha) {
                         modelConfig.configPipelineSha = configPipelineSha;
 
                         return p.sync(configPipelineSha);
-=======
-                    if (config.configPipelineSha) {
-                        modelConfig.configPipelineSha = config.configPipelineSha;
-
-                        return p.sync(config.configPipelineSha);
->>>>>>> Include configPipelineSha in bookendConfig
                     }
 
                     return p.sync(config.sha);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -661,7 +661,7 @@ class PipelineModel extends BaseModel {
     /**
      * Fetch the build admin
      * @property admin
-     * @return Promise
+     * @return {Promise}
     */
     get admin() {
         delete this.admin;
@@ -791,7 +791,7 @@ class PipelineModel extends BaseModel {
     /**
      * Fetch all jobs that belong to this pipeline
      * @property jobs
-     * @return Promise
+     * @return {Promise}
     */
     get jobs() {
         const listConfig = {
@@ -881,6 +881,17 @@ class PipelineModel extends BaseModel {
         });
 
         return secrets;
+    }
+
+    /**
+     * Fetch the config pipeline if it exists
+     * @property configPipeline
+     * @return   {Promise}
+     */
+    get configPipeline() {
+        const pipelineFactory = this._getPipelineFactory();
+
+        return pipelineFactory.get(this.configPipelineId);
     }
 
     /**

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -138,6 +138,7 @@ describe('Build Factory', () => {
         const jobId = 12345;
         const eventId = 123456;
         const sha = 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f';
+        const configPipelineSha = '63aa3d3058bc0886a8bf42567858e61a7310133c';
         const scmUri = 'github.com:12345:master';
         const scmRepo = {
             name: 'screwdriver-cd/models'
@@ -479,13 +480,22 @@ describe('Build Factory', () => {
                 jobId,
                 eventId,
                 sha,
+                configPipelineSha,
                 meta
             }).then(() => {
                 assert.calledWith(bookendMock.getSetupCommands, {
                     pipeline: pipelineMock,
                     job: jobMock,
                     build: sinon.match.object,
-                    configPipeline: { spooky: 'ghost' }
+                    configPipeline: { spooky: 'ghost' },
+                    configPipelineSha
+                });
+                assert.calledWith(bookendMock.getTeardownCommands, {
+                    pipeline: pipelineMock,
+                    job: jobMock,
+                    build: sinon.match.object,
+                    configPipeline: { spooky: 'ghost' },
+                    configPipelineSha
                 });
             });
         });

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -204,7 +204,7 @@ describe('Event Factory', () => {
                 },
                 getConfiguration: sinon.stub().resolves(PARSED_YAML),
                 update: sinon.stub().resolves(syncedPipelineMock),
-                job: Promise.resolve([]),
+                jobs: Promise.resolve([]),
                 branch: Promise.resolve('branch')
             };
 
@@ -485,6 +485,24 @@ describe('Event Factory', () => {
                     assert.notCalled(buildFactoryMock.create);
                 });
             });
+
+            it('should create builds with config pipeline sha if it is a child pipeline', () => {
+                pipelineMock.configPipelineId = 1;
+                pipelineFactoryMock.get.withArgs(1).resolves({
+                    id: 1,
+                    token: Promise.resolve('token')
+                });
+                config.startFrom = 'main';
+
+                return eventFactory.create(config).then((model) => {
+                    assert.instanceOf(model, Event);
+                    assert.deepEqual(model.configPipelineSha, 'configpipelinesha');
+                    assert.calledWith(pipelineMock.sync, 'configpipelinesha');
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        configPipelineSha: 'configpipelinesha'
+                    }));
+                });
+            });
         });
 
         it('should create an Event', () =>
@@ -553,6 +571,7 @@ describe('Event Factory', () => {
 
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
+                assert.deepEqual(model.configPipelineSha, config.configPipelineSha);
                 assert.calledWith(pipelineMock.sync, config.configPipelineSha);
                 assert.equal(model.configPipelineSha, config.configPipelineSha);
             });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1143,6 +1143,21 @@ describe('Pipeline Model', () => {
         });
     });
 
+    describe('get config pipeline', () => {
+        it('has a config pipeline getter', () => {
+            const childPipeline = new PipelineModel(pipelineConfig);
+
+            childPipeline.id = 2;
+            childPipeline.configPipelineId = testId;
+
+            pipelineFactoryMock.get.withArgs(testId).resolves(pipeline);
+
+            childPipeline.configPipeline.then((configPipeline) => {
+                assert.deepEqual(configPipeline, pipeline);
+            });
+        });
+    });
+
     describe('get jobs', () => {
         it('Get all jobs', () => {
             const expected = {


### PR DESCRIPTION
## Context
In order for an `scm` to clone the parent repository of a child pipeline, it must have information on the parent pipeline. 

This configuration will be used by `getSetupCommand` of `scm-base`.

## Objective
Pass in `pipeline.configPipeline` to `bookendConfig` if the pipeline is a child.

## Reference
Pending:
 - https://github.com/screwdriver-cd/data-schema/pull/260

https://github.com/screwdriver-cd/screwdriver/issues/1132