### PR TITLE
fix(1152): update isDone for UNSTABLE

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -302,7 +302,8 @@ class BuildModel extends BaseModel {
      * @return boolean
      */
     isDone() {
-        return ['ABORTED', 'FAILURE', 'SUCCESS'].includes(this.status);
+        return ['ABORTED', 'FAILURE', 'SUCCESS'].includes(this.status) ||
+        (this.status === 'UNSTABLE' && this.endTime);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "async": "^2.0.1",
+    "async": "^2.6.1",
     "base64url": "^3.0.0",
     "compare-versions": "^3.3.0",
     "docker-parse-image": "^3.0.1",

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -288,6 +288,50 @@ describe('Build Model', () => {
                     assert.notCalled(executorMock.stop);
                 });
         });
+
+        it('promises to update, but not executor when status is unstable & not done', () => {
+            build.status = 'UNSTABLE';
+
+            return build.update()
+                .then(() => {
+                    assert.calledWith(scmMock.updateCommitStatus, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'main',
+                        buildStatus: 'UNSTABLE',
+                        url,
+                        pipelineId
+                    });
+                    assert.notCalled(executorMock.stop);
+                });
+        });
+
+        it('promises to update, and stop executor when status is unstable & done', () => {
+            build.status = 'UNSTABLE';
+            build.endTime = '2018-06-27T18:22:20.153Z';
+
+            return build.update()
+                .then(() => {
+                    assert.calledWith(scmMock.updateCommitStatus, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'main',
+                        buildStatus: 'UNSTABLE',
+                        url,
+                        pipelineId
+                    });
+                    assert.calledWith(executorMock.stop, {
+                        buildId,
+                        jobId,
+                        annotations,
+                        blockedBy: [jobId]
+                    });
+                });
+        });
     });
 
     describe('stop', () => {


### PR DESCRIPTION
The problem is `UNSTABLE` is not considered `done` so `executor stop` will not be called and `running_key` will not be cleaned up. 

`UNSTABLE` can be `done` or `not done` depending on the `endTime`. Thank you @jithin1987  for the suggestion.

Related: https://github.com/screwdriver-cd/screwdriver/issues/1152