### PR TITLE
fix: stop executor regardless of non-dirty status

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -260,14 +260,15 @@ class BuildModel extends BaseModel {
             });
         };
 
+        // stop the build if we're done
+        if (this.isDone()) {
+            abortSteps();
+            prom = prom
+                .then(() => this.stop());
+        }
+
         // check if the status is changing
         if (this.isDirty('status')) {
-            // stop the build if we're done
-            if (this.isDone()) {
-                abortSteps();
-                prom = prom
-                    .then(() => this.stop());
-            }
             // update scm with status
             prom = prom
                 .then(() => this.pipeline)
@@ -304,7 +305,7 @@ class BuildModel extends BaseModel {
      */
     isDone() {
         return ['ABORTED', 'FAILURE', 'SUCCESS'].includes(this.status) ||
-        (this.status === 'UNSTABLE' && this.endTime);
+        (this.status === 'UNSTABLE' && !!this.endTime);
     }
 }
 


### PR DESCRIPTION
This is necessary because `UNSTABLE` might be not dirty in some cases:
`RUNNING -> UNSTABLE`: status is `UNSTABLE`, field is dirty
`UNSTABLE -> SUCCESS`: status is `UNSTABLE`, field is not dirty. 

Also, make the tests more accurate.

Related: https://github.com/screwdriver-cd/screwdriver/issues/1152