### PR TITLE
fix: [small] inherit previous configPipelineSha

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -323,11 +323,15 @@ class EventFactory extends BaseFactory {
             .then((p) => {
                 // Sync pipeline with the parentEvent sha and create jobs based on that sha
                 if (config.parentEventId) {
+                    const configPipelineSha = config.configPipelineSha;
+
                     modelConfig.parentEventId = config.parentEventId;
 
                     // for child pipelines restart event, sync with configPipelineSha
-                    if (config.configPipelineSha) {
-                        return p.sync(config.configPipelineSha);
+                    if (configPipelineSha) {
+                        modelConfig.configPipelineSha = configPipelineSha;
+
+                        return p.sync(configPipelineSha);
                     }
 
                     return p.sync(config.sha);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -554,6 +554,7 @@ describe('Event Factory', () => {
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledWith(pipelineMock.sync, config.configPipelineSha);
+                assert.equal(model.configPipelineSha, config.configPipelineSha);
             });
         });
 


### PR DESCRIPTION
## Context
I found a bug of External Config feature.  The reproduce flow is below:
1. Create pipelines same as https://github.com/screwdriver-cd-test/external-config-example and https://github.com/screwdriver-cd-test/external-config-child1
2. Start a child pipeline (this called `event1`).
3. Restart from `event1` and create `event2`. `event1` has `configPipelineSha` so it should succeed.
4. Restart from `event2`. `event2` does not have `configPipelineSha` so it should fail.

![image](https://user-images.githubusercontent.com/3445553/42204511-e461a416-7edc-11e8-85bb-f9bc373c2e5c.png)

## Objective
This PR fixed to inherit previous `configPipelineSha`.

## Reference
Related: https://github.com/screwdriver-cd/screwdriver/issues/937