### PR TITLE
fix(1082): [1] [small] add configPipelineSha when event creation

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -312,6 +312,7 @@ class EventFactory extends BaseFactory {
             type: config.type || 'pipeline',
             pipelineId: config.pipelineId,
             sha: config.sha,
+            configPipelineSha: config.configPipelineSha,
             startFrom: config.startFrom,
             causeMessage: config.causeMessage || `Started by ${displayName}`,
             meta: config.meta || {},


### PR DESCRIPTION
## Context
Branch specific job feature has that bug:
> If you have pipeline configured to branch `master` and a job configured to branch `foo`, the issue is when you restart the `foo` branch job, it uses `foo` screwdriver.yaml file instead of `master` screwdriver.yaml

## Objective
To fix the bug, this PR adds `configPipelineSha` when event creation.

## References
Related: https://github.com/screwdriver-cd/screwdriver/issues/1082#issuecomment-397195121
api PR: https://github.com/screwdriver-cd/screwdriver/pull/1165
related bug fix: https://github.com/screwdriver-cd/models/pull/273