### PR TITLE
fix(1095): Add docs for command arguments field [2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,6 +1230,7 @@ factory.create(config).then(model => {
 | config.name | String | Yes | The command name |
 | config.version | String | Yes | Version of the command |
 | config.description | String | Yes | Description of the command |
+| config.arguments | String | No | Arguments for command usage (e.g.: '-d <domain> -h <host>') |
 | config.maintainer | String | Yes | Maintainer's email |
 | config.format | String | Yes | Format of the command, habitat or docker or binary |
 | config.habitat | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Habitat command |

--- a/README.md
+++ b/README.md
@@ -1230,7 +1230,7 @@ factory.create(config).then(model => {
 | config.name | String | Yes | The command name |
 | config.version | String | Yes | Version of the command |
 | config.description | String | Yes | Description of the command |
-| config.arguments | String | No | Arguments for command usage (e.g.: '-d <domain> -h <host>') |
+| config.usage | String | No | Command usage and arguments (e.g.: 'sd-cmd exec foo/bar@1 -d <domain> -h <host>') |
 | config.maintainer | String | Yes | Maintainer's email |
 | config.format | String | Yes | Format of the command, habitat or docker or binary |
 | config.habitat | Object | Yes (any one of habitat, docker, binary) | Configuration Object for Habitat command |

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -31,7 +31,7 @@ class CommandFactory extends BaseFactory {
      * @param  {String}     config.version       Version of the command
      * @param  {String}     config.description   Description of the command
      * @param  {String}     config.maintainer    Maintainer's email
-     * @param  {String}     [config.arguments]   Command arguments for usage (e.g.: '-d <domain> -h <host>')
+     * @param  {String}     [config.usage]       Command usage and arguments (e.g.: 'sd-cmd exec foo/bar@1 -d <domain> -h <host>')
      * @param  {String}     config.format        Format of the command
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command
@@ -53,7 +53,7 @@ class CommandFactory extends BaseFactory {
      * @param  {String}     config.version       Version of the command
      * @param  {String}     config.description   Description of the command
      * @param  {String}     config.maintainer    Maintainer's email
-     * @param  {String}     [config.arguments]   Command arguments for usage (e.g.: '-d <domain> -h <host>')
+     * @param  {String}     [config.usage]       Command usage and arguments (e.g.: 'sd-cmd exec foo/bar@1 -d <domain> -h <host>')
      * @param  {String}     config.format        Format of the command
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -31,6 +31,7 @@ class CommandFactory extends BaseFactory {
      * @param  {String}     config.version       Version of the command
      * @param  {String}     config.description   Description of the command
      * @param  {String}     config.maintainer    Maintainer's email
+     * @param  {String}     [config.arguments]   Command arguments for usage (e.g.: '-d <domain> -h <host>')
      * @param  {String}     config.format        Format of the command
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command
@@ -52,6 +53,7 @@ class CommandFactory extends BaseFactory {
      * @param  {String}     config.version       Version of the command
      * @param  {String}     config.description   Description of the command
      * @param  {String}     config.maintainer    Maintainer's email
+     * @param  {String}     [config.arguments]   Command arguments for usage (e.g.: '-d <domain> -h <host>')
      * @param  {String}     config.format        Format of the command
      * @param  {Object}     config.habitat       Habitat config of the command
      * @param  {Object}     config.docker        Docker config of the command

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.4.0",
-    "screwdriver-data-schema": "^18.28.0",
+    "screwdriver-config-parser": "^4.5.0",
+    "screwdriver-data-schema": "^18.29.2",
     "screwdriver-workflow-parser": "^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.3.1",
-    "screwdriver-data-schema": "^18.24.7",
+    "screwdriver-config-parser": "^4.4.0",
+    "screwdriver-data-schema": "^18.28.0",
     "screwdriver-workflow-parser": "^1.5.0"
   }
 }

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -12,6 +12,7 @@ describe('Command Factory', () => {
     const version = '1.3';
     const maintainer = 'foo@bar.com';
     const description = 'this is a command';
+    const args = '-d <domain> -h <host>';
     const format = 'habitat';
     const habitat = {
         mode: 'remote',
@@ -25,6 +26,7 @@ describe('Command Factory', () => {
         version,
         maintainer,
         description,
+        arguments: args,
         format,
         habitat,
         pipelineId

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -12,7 +12,7 @@ describe('Command Factory', () => {
     const version = '1.3';
     const maintainer = 'foo@bar.com';
     const description = 'this is a command';
-    const args = '-d <domain> -h <host>';
+    const usage = 'sd-cmd exec foo/bar@1 -d <domain> -h <host>';
     const format = 'habitat';
     const habitat = {
         mode: 'remote',
@@ -26,7 +26,7 @@ describe('Command Factory', () => {
         version,
         maintainer,
         description,
-        arguments: args,
+        usage,
         format,
         habitat,
         pipelineId


### PR DESCRIPTION
Adding documentation for command `arguments`

Blocked by https://github.com/screwdriver-cd/data-schema/pull/261
Related to https://github.com/screwdriver-cd/screwdriver/issues/1095