### PR TITLE
fix(1179): Fix namespace parsing in template tag create

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const schema = require('screwdriver-data-schema');
+const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
+
 /**
  * Get the value of the annotation that matches name
  * @method getAnnotations
@@ -11,6 +14,41 @@ function getAnnotations(perm, name) {
     return perm.annotations && perm.annotations[name];
 }
 
+/**
+ * Returns an object with the parsed name and namespace to be merged with
+ * the original config for template or templateTag creation
+ * @param  {Object} config
+ * @param  {String} config.name         Template name
+ * @param  {String} [config.namespace]  Template namespace
+ * @return {Object}                     Object that contains parsed name and namespace
+ */
+function parseTemplateConfigName(config) {
+    // Set namespace if it doesn't already exist
+    if (!config.namespace) {
+        const slashIndex = config.name.indexOf('/');
+
+        // Use string in front of slash for namespace if namespace is implicit
+        if (slashIndex > -1) {
+            const [, namespace, name]
+                = TEMPLATE_NAME_REGEX_WITH_NAMESPACE.exec(config.name);
+
+            return {
+                namespace,
+                name
+            };
+        }
+
+        // Set namespace to default if no slash in name
+        return {
+            namespace: 'default'
+        };
+    }
+
+    // No change
+    return {};
+}
+
 module.exports = {
-    getAnnotations
+    getAnnotations,
+    parseTemplateConfigName
 };

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -3,6 +3,8 @@
 const BaseFactory = require('./baseFactory');
 const Template = require('./template');
 const compareVersions = require('compare-versions');
+const hoek = require('hoek');
+const parseTemplateConfigName = require('./helper').parseTemplateConfigName;
 const schema = require('screwdriver-data-schema');
 const TEMPLATE_NAME_REGEX = schema.config.regex.FULL_TEMPLATE_NAME;
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
@@ -125,41 +127,25 @@ class TemplateFactory extends BaseFactory {
     create(config) {
         const [, major, minor] = VERSION_REGEX.exec(config.version);
         const searchVersion = minor ? `${major}${minor}` : major;
-
-        // Set namespace if it doesn't already exist
-        if (!config.namespace) {
-            const slashIndex = config.name.indexOf('/');
-
-            // Use string in front of slash for namespace if there is a slash
-            if (slashIndex > -1) {
-                const [, namespace, name]
-                    = TEMPLATE_NAME_REGEX_WITH_NAMESPACE.exec(config.name);
-
-                config.namespace = namespace;
-                config.name = name;
-            // Set namespace to default if there is no slash
-            } else {
-                config.namespace = 'default';
-            }
-        }
-
-        const fullTemplateName = `${config.namespace}/${config.name}@${searchVersion}`;
+        const nameObj = parseTemplateConfigName(config);
+        const result = hoek.applyToDefaults(config, nameObj);
+        const fullTemplateName = `${result.namespace}/${result.name}@${searchVersion}`;
 
         return this.getTemplate(fullTemplateName)
             .then((latest) => {
                 if (!latest) {
-                    config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
+                    result.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
                 } else {
                     // eslint-disable-next-line max-len
                     const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latest.version);
                     const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
-                    config.version = `${latestMajor}${latestMinor}.${patch}`;
+                    result.version = `${latestMajor}${latestMinor}.${patch}`;
                 }
 
-                config.createTime = (new Date()).toISOString();
+                result.createTime = (new Date()).toISOString();
 
-                return super.create(config);
+                return super.create(result);
             });
     }
 

--- a/lib/templateTagFactory.js
+++ b/lib/templateTagFactory.js
@@ -2,6 +2,8 @@
 
 const BaseFactory = require('./baseFactory');
 const TemplateTag = require('./templateTag');
+const hoek = require('hoek');
+const parseTemplateConfigName = require('./helper').parseTemplateConfigName;
 const schema = require('screwdriver-data-schema');
 const TEMPLATE_NAME_REGEX = schema.config.regex.FULL_TEMPLATE_NAME;
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
@@ -105,23 +107,12 @@ class TemplateTagFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
-        config.createTime = (new Date()).toISOString();
+        const nameObj = parseTemplateConfigName(config);
+        const result = hoek.applyToDefaults(config, nameObj);
 
-        if (config.name && !config.namespace) {
-            // eslint-disable-next-line no-underscore-dangle
-            return this._getNameAndNamespace(config.name).then((parsedTemplateName) => {
-                const { namespace, name } = parsedTemplateName;
+        result.createTime = (new Date()).toISOString();
 
-                if (namespace) {
-                    config.namespace = namespace;
-                    config.name = name;
-                }
-
-                return super.create(config);
-            });
-        }
-
-        return super.create(config);
+        return super.create(result);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hoek": "^5.0.3",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.3.1",
+    "screwdriver-config-parser": "^4.4.1",
     "screwdriver-data-schema": "^18.24.7",
     "screwdriver-workflow-parser": "^1.5.0"
   }

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -99,6 +99,7 @@ describe('Template Factory', () => {
         it('creates a Template with the namespace when it is passed in explicitly', () => {
             expected.version = `${version}.0`;
             expected.namespace = namespace;
+            expected.name = name;
             datastore.save.resolves(expected);
             datastore.scan.resolves([]);
 
@@ -113,8 +114,9 @@ describe('Template Factory', () => {
                 pipelineId
             }).then((model) => {
                 assert.instanceOf(model, Template);
+
                 Object.keys(expected).forEach((key) => {
-                    assert.strictEqual(model[key], expected[key]);
+                    assert.deepEqual(model[key], expected[key]);
                 });
             });
         });
@@ -137,7 +139,7 @@ describe('Template Factory', () => {
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
-                    assert.strictEqual(model[key], expected[key]);
+                    assert.deepEqual(model[key], expected[key]);
                 });
             });
         });
@@ -160,7 +162,7 @@ describe('Template Factory', () => {
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
-                    assert.strictEqual(model[key], expected[key]);
+                    assert.deepEqual(model[key], expected[key]);
                 });
             });
         });
@@ -182,7 +184,7 @@ describe('Template Factory', () => {
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
-                    assert.strictEqual(model[key], expected[key]);
+                    assert.deepEqual(model[key], expected[key]);
                 });
             });
         });
@@ -204,7 +206,7 @@ describe('Template Factory', () => {
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
-                    assert.strictEqual(model[key], expected[key]);
+                    assert.deepEqual(model[key], expected[key]);
                 });
             });
         });
@@ -237,7 +239,7 @@ describe('Template Factory', () => {
             }).then((model) => {
                 assert.instanceOf(model, Template);
                 Object.keys(expected).forEach((key) => {
-                    assert.strictEqual(model[key], expected[key]);
+                    assert.deepEqual(model[key], expected[key]);
                 });
             });
         });

--- a/test/lib/templateTagFactory.test.js
+++ b/test/lib/templateTagFactory.test.js
@@ -124,7 +124,8 @@ describe('TemplateTag Factory', () => {
         it('creates a Template Tag given name with namespace, tag, and version and namespace does not exist', () => {
             datastore.save.resolves(expected);
             datastore.scan.resolves([]);
-            expected.name = fullTemplateName;
+            expected.name = name;
+            expected.namespace = namespace;
 
             return factory.create({
                 name: fullTemplateName,


### PR DESCRIPTION
## Context
Template tag creation is broken because the namespace is not getting created properly.

## Objective
This PR refactors name/namespace parsing in template creation and uses it in template tag creation.

## Related links
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1179