### PR TITLE
fix(1161): Remove templates on pipeline remove

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -714,6 +714,42 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Fetch all templates that belong to this pipeline
+     * @property  {Templates}
+     * @return    {Promise}   Resolves to an array of templates
+    */
+    get templates() {
+        const listConfig = {
+            params: {
+                pipelineId: this.id
+            },
+            paginate: {
+                count: PAGINATE_COUNT,
+                page: PAGINATE_PAGE
+            }
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const TemplateFactory = require('./templateFactory');
+        /* eslint-enable global-require */
+        const factory = TemplateFactory.getInstance();
+
+        const templates = factory.list(listConfig);
+
+        // ES6 has weird getters and setters in classes,
+        // so we redefine the pipeline property here to resolve to the
+        // resulting promise and not try to recreate the factory, etc.
+        Object.defineProperty(this, 'templates', {
+            enumerable: true,
+            value: templates
+        });
+
+        return templates;
+    }
+
+    /**
      * This function deletes admins who does not have proper
      * GitHub permission, and returns an proper admin.
      * @method getFirstAdmin
@@ -949,7 +985,7 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Fetch events belong to a pipeline.
+     * Fetch events belonging to a pipeline.
      * @param  {Object}   [config]                              Configuration object
      * @param  {Number}   [config.sort]                         Sort rangekey by ascending or descending
      * @param  {Number}   [config.params.type = 'pipeline']     Get pipeline or pr events
@@ -1012,14 +1048,16 @@ class PipelineModel extends BaseModel {
                 params: {
                     archived
                 }
-            }).then((jobs) => {
-                if (jobs.length === 0) {
-                    return null;
-                }
+            })
+                .then((jobs) => {
+                    if (jobs.length === 0) {
+                        return null;
+                    }
 
-                return Promise.all(jobs.map(job => job.remove()))
-                    .then(() => removeJobs(archived));
-            }));
+                    return Promise.all(jobs.map(job => job.remove()))
+                        .then(() => removeJobs(archived));
+                })
+        );
 
         const removeEvents = (type =>
             this.getEvents({
@@ -1047,6 +1085,9 @@ class PipelineModel extends BaseModel {
         const removeTokens = (() =>
             this.tokens.then(tokens => Promise.all(tokens.map(t => t.remove()))));
 
+        const removeTemplates = (() =>
+            this.templates.then(templates => Promise.all(templates.map(t => t.remove()))));
+
         return this.secrets
             .then((secrets) => { // remove secrets
                 const filteredSecrets = secrets.filter(secret => secret.pipelineId === this.id);
@@ -1054,6 +1095,7 @@ class PipelineModel extends BaseModel {
                 return Promise.all(filteredSecrets.map(secret => secret.remove()));
             })
             .then(() => removeTokens()) // remove tokens
+            .then(() => removeTemplates()) // remove templates
             .then(() => removeJobs(true)) // remove archived jobs
             .then(() => removeJobs(false)) // remove non-archived jobs
             .then(() => removeEvents('pipeline')) // remove pipeline events

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -144,6 +144,7 @@ describe('Pipeline Model', () => {
             list: sinon.stub()
         };
         templateFactoryMock = {
+            list: sinon.stub()
         };
         triggerFactoryMock = {
             list: sinon.stub(),
@@ -1516,6 +1517,11 @@ describe('Pipeline Model', () => {
             pipelineId: testId,
             remove: sinon.stub().resolves(null)
         };
+        const template = {
+            name: 'TEST_TEMPLATE',
+            pipelineId: testId,
+            remove: sinon.stub().resolves(null)
+        };
 
         beforeEach(() => {
             archived = {
@@ -1539,6 +1545,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.list.resolves([]);
             secretFactoryMock.list.resolves([secret]);
             tokenFactoryMock.list.resolves([token]);
+            templateFactoryMock.list.resolves([template]);
         });
 
         afterEach(() => {
@@ -1546,11 +1553,13 @@ describe('Pipeline Model', () => {
             jobFactoryMock.list.reset();
             secretFactoryMock.list.reset();
             tokenFactoryMock.list.reset();
+            templateFactoryMock.list.reset();
             publishJob.remove.reset();
             mainJob.remove.reset();
             blahJob.remove.reset();
             secret.remove.reset();
             token.remove.reset();
+            template.remove.reset();
         });
 
         it('remove secrets', () =>
@@ -1564,6 +1573,13 @@ describe('Pipeline Model', () => {
             pipeline.remove().then(() => {
                 assert.calledOnce(tokenFactoryMock.list);
                 assert.calledOnce(token.remove);
+            })
+        );
+
+        it('remove templates', () =>
+            pipeline.remove().then(() => {
+                assert.calledOnce(templateFactoryMock.list);
+                assert.calledOnce(template.remove);
             })
         );
 
@@ -1748,6 +1764,38 @@ describe('Pipeline Model', () => {
             // ...but the factory was not recreated, since the promise is stored
             // as the model's tokens property, now
             assert.calledOnce(tokenFactoryMock.list);
+        });
+    });
+
+    describe('get templates', () => {
+        it('has a template getter', () => {
+            const listConfig = {
+                params: {
+                    pipelineId: testId
+                },
+                paginate
+            };
+
+            const template = {
+                name: 'TEST_TEMPLATE',
+                pipelineId: testId
+            };
+
+            templateFactoryMock.list.resolves([template]);
+            // when we fetch templates it resolves to a promise
+            assert.isFunction(pipeline.templates.then);
+            // and a factory is called to create that promise
+            assert.calledWith(templateFactoryMock.list, listConfig);
+
+            // When we call user.tokens again it is still a promise
+            assert.isFunction(pipeline.templates.then);
+            // ...but the factory was not recreated, since the promise is stored
+            // as the model's tokens property, now
+            assert.calledOnce(templateFactoryMock.list);
+
+            pipeline.templates.then((templates) => {
+                assert.deepEqual(templates[0], template);
+            });
         });
     });
 });


### PR DESCRIPTION
## Context
Templates are left in an "orphaned" state if their underlying pipelines are removed. They should be removed as soon as their pipeline is.

## Objective
On `pipeline.remove()` remove all templates belonging to the pipeline.

## Context
https://github.com/screwdriver-cd/screwdriver/issues/1161