### PR TITLE
feat(1082): [14] [small] fix for enabling branch specific pr trigger

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -83,18 +83,16 @@ function getJobsFromPR(config) {
         return [];
     }
 
-    let nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+    const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
         trigger: startFrom,
         prNum
     });
 
-    nextJobs = nextJobs.concat(jobs.filter(
+    const jobsToStart = jobs.filter(
         j => j.name.startsWith(`PR-${prNum}:`) || nextJobs.includes(j.name)
-    ));
+    );
 
-    const jobsToStart = nextJobs.filter(j => j.state === 'ENABLED' && !j.archived);
-
-    return jobsToStart;
+    return jobsToStart.filter(j => j.state === 'ENABLED' && !j.archived);
 }
 
 /**

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -2,7 +2,11 @@
 
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
-const { EXTERNAL_TRIGGER, COMMIT_TRIGGER } = require('screwdriver-data-schema').config.regex;
+const {
+    EXTERNAL_TRIGGER,
+    COMMIT_TRIGGER,
+    PR_TRIGGER
+} = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 
 let instance;
@@ -51,8 +55,9 @@ function getJobsFromTrigger(config) {
 function getJobsFromJobName(config) {
     const { jobs, startFrom } = config;
     const isCommitTrigger = COMMIT_TRIGGER.test(startFrom);
+    const isPRTrigger = PR_TRIGGER.test(startFrom);
 
-    if (isCommitTrigger || startFrom === '~pr') {
+    if (isCommitTrigger || isPRTrigger) {
         return [];
     }
 
@@ -65,18 +70,29 @@ function getJobsFromJobName(config) {
  * @param  {Object}   config
  * @param  {Array}    config.jobs                           Array of job objects
  * @param  {Number}   config.prNum                          PR number
+ * @param  {Object}   config.pipelineConfig
+ * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
  * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
  * @resolves {Array}                                        Array of PR jobs to start
  */
 function getJobsFromPR(config) {
-    const { jobs, prNum, startFrom } = config;
+    const { jobs, prNum, pipelineConfig, startFrom } = config;
+    const isPRTrigger = PR_TRIGGER.test(startFrom);
 
-    if (startFrom !== '~pr') {
+    if (!isPRTrigger) {
         return [];
     }
 
-    const PRJobArray = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
-    const jobsToStart = PRJobArray.filter(j => j.state === 'ENABLED' && !j.archived);
+    let nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+        trigger: startFrom,
+        prNum
+    });
+
+    nextJobs = nextJobs.concat(jobs.filter(
+        j => j.name.startsWith(`PR-${prNum}:`) || nextJobs.includes(j.name)
+    ));
+
+    const jobsToStart = nextJobs.filter(j => j.state === 'ENABLED' && !j.archived);
 
     return jobsToStart;
 }
@@ -180,6 +196,7 @@ function createBuilds(config) {
         const jobsFromPR = getJobsFromPR({
             jobs,
             prNum: eventConfig.prNum,
+            pipelineConfig,
             startFrom
         });
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
     "screwdriver-config-parser": "^4.5.0",
-    "screwdriver-data-schema": "^18.29.2",
-    "screwdriver-workflow-parser": "^1.5.0"
+    "screwdriver-data-schema": "^18.30.0",
+    "screwdriver-workflow-parser": "^1.6.0"
   }
 }


### PR DESCRIPTION
## Context
The branch specific trigger for `~pr` is not implemented yet.

## Objective
* Fix to get next jobs which requires branch specific pr trigger

## References
* [workflow design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/workflow.md#branch-filtering-scm-branch-specific-jobs)
* issue https://github.com/screwdriver-cd/screwdriver/issues/1082