### PR TITLE
feat(1114): add step model

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const EventFactory = require('./lib/eventFactory');
 const JobFactory = require('./lib/jobFactory');
 const PipelineFactory = require('./lib/pipelineFactory');
 const SecretFactory = require('./lib/secretFactory');
+const StepFactory = require('./lib/stepFactory');
 const TemplateFactory = require('./lib/templateFactory');
 const TemplateTagFactory = require('./lib/templateTagFactory');
 const TokenFactory = require('./lib/tokenFactory');
@@ -25,6 +26,7 @@ module.exports = {
     JobFactory,
     PipelineFactory,
     SecretFactory,
+    StepFactory,
     TemplateFactory,
     TemplateTagFactory,
     TokenFactory,

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,6 +11,8 @@ const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
 const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
 const TEMPORAL_JWT_TIMEOUT = 12 * 60; // 12 hours in minutes
+const PAGINATE_PAGE = 1;
+const PAGINATE_COUNT = 50;
 
 /**
  * Get the array of ids for jobs that match the names passed in
@@ -121,6 +123,33 @@ class BuildModel extends BaseModel {
 
             return this.scm.updateCommitStatus(config);
         });
+    }
+
+    /**
+    * Get models for all steps
+    * @method getStepsModel
+    * @return {Promise}
+    */
+    getStepsModel() {
+        const listConfig = {
+            params: {
+                buildId: this.id
+            },
+            paginate: {
+                count: PAGINATE_COUNT,
+                page: PAGINATE_PAGE
+            }
+        };
+
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const StepFactory = require('./stepFactory');
+        /* eslint-enable global-require */
+
+        const factory = StepFactory.getInstance();
+
+        return factory.list(listConfig);
     }
 
     /**
@@ -249,21 +278,34 @@ class BuildModel extends BaseModel {
         const abortSteps = () => {
             const now = (new Date()).toISOString();
 
-            // Fail any running steps
-            this.steps = this.steps.map((step) => {
-                if (step.startTime && !step.endTime) {
-                    step.endTime = now;
-                    step.code = ABORT_CODE;
+            return this.getStepsModel().then((steps) => {
+                if (steps.length !== 0) {
+                    return Promise.all(steps.map((step) => {
+                        if (step.startTime && !step.endTime) {
+                            step.endTime = now;
+                            step.code = ABORT_CODE;
+                        }
+
+                        return step.update();
+                    }));
                 }
 
-                return step;
+                this.steps = this.steps.map((step) => {
+                    if (step.startTime && !step.endTime) {
+                        step.endTime = now;
+                        step.code = ABORT_CODE;
+                    }
+
+                    return step;
+                });
+
+                return this.steps;
             });
         };
 
         // stop the build if we're done
         if (this.isDone()) {
-            abortSteps();
-            prom = prom
+            prom = abortSteps()
                 .then(() => this.stop());
         }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -3,8 +3,6 @@
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const imageParser = require('docker-parse-image');
-const PAGINATE_PAGE = 1;
-const PAGINATE_COUNT = 50;
 let instance;
 
 /**
@@ -91,31 +89,6 @@ function dockerImageName({ container, dockerRegistry }) {
     const updatedName = imageParser(`${dockerRegistry}/${container}`);
 
     return updatedName.fullname;
-}
-
-/**
- *
- */
-function getStepsModel() {
-    const listConfig = {
-        params: {
-            buildId: this.id
-        },
-        paginate: {
-            count: PAGINATE_COUNT,
-            page: PAGINATE_PAGE
-        }
-    };
-
-    // Lazy load factory dependency to prevent circular dependency issues
-    // https://nodejs.org/api/modules.html#modules_cycles
-    /* eslint-disable global-require */
-    const StepFactory = require('./stepFactory');
-    /* eslint-enable global-require */
-
-    const factory = StepFactory.getInstance();
-
-    return factory.list(listConfig);
 }
 
 class BuildFactory extends BaseFactory {
@@ -279,23 +252,22 @@ class BuildFactory extends BaseFactory {
      * @return {Promise}           Resolve build model after merging with step models
      */
     get(config) {
-        return Promise.all([
-            getStepsModel,
-            super.get(config)
-        ]).then(([stepsModel, build]) => {
-            build.steps = build.steps.map((step) => {
-                const stepModel = stepsModel.find(s => s.name === step.name);
+        return super.get(config)
+            .then(build => build.getStepsModel()
+                .then((stepsModel) => {
+                    build.steps = build.steps.map((step) => {
+                        const stepModel = stepsModel.find(s => s.name === step.name);
 
-                // For backward compatibility, old builds do not have stepModel
-                if (stepModel) {
-                    return stepModel;
-                }
+                        // For backward compatibility, old builds do not have stepModel
+                        if (stepModel) {
+                            return stepModel.toJson();
+                        }
 
-                return step;
-            });
+                        return step;
+                    });
 
-            return build;
-        });
+                    return build;
+                }));
     }
 
     /**

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -173,7 +173,6 @@ class BuildFactory extends BaseFactory {
         /* eslint-enable global-require */
         const factory = JobFactory.getInstance();
         const stepFactory = StepFactory.getInstance();
-        /* eslint-enable global-require */
 
         return factory.get(config.jobId)
             .then((job) => {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -3,6 +3,8 @@
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const imageParser = require('docker-parse-image');
+const PAGINATE_PAGE = 1;
+const PAGINATE_COUNT = 50;
 let instance;
 
 /**
@@ -91,6 +93,31 @@ function dockerImageName({ container, dockerRegistry }) {
     return updatedName.fullname;
 }
 
+/**
+ *
+ */
+function getStepsModel() {
+    const listConfig = {
+        params: {
+            buildId: this.id
+        },
+        paginate: {
+            count: PAGINATE_COUNT,
+            page: PAGINATE_PAGE
+        }
+    };
+
+    // Lazy load factory dependency to prevent circular dependency issues
+    // https://nodejs.org/api/modules.html#modules_cycles
+    /* eslint-disable global-require */
+    const StepFactory = require('./stepFactory');
+    /* eslint-enable global-require */
+
+    const factory = StepFactory.getInstance();
+
+    return factory.list(listConfig);
+}
+
 class BuildFactory extends BaseFactory {
     /**
      * Construct a JobFactory object
@@ -169,8 +196,11 @@ class BuildFactory extends BaseFactory {
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
         const JobFactory = require('./jobFactory');
+        const StepFactory = require('./stepFactory');
         /* eslint-enable global-require */
         const factory = JobFactory.getInstance();
+        const stepFactory = StepFactory.getInstance();
+        /* eslint-enable global-require */
 
         return factory.get(config.jobId)
             .then((job) => {
@@ -226,6 +256,12 @@ class BuildFactory extends BaseFactory {
                         return super.create(modelConfig);
                     });
                 })
+                    .then(build => Promise.all(modelConfig.steps.map(step =>
+                        stepFactory.create(Object.assign(
+                            { buildId: build.id },
+                            step
+                        )))).then(() => build)
+                    )
                     .then((build) => {
                         if (config.start === false) {
                             return build;
@@ -234,6 +270,32 @@ class BuildFactory extends BaseFactory {
                         return build.start();
                     });
             });
+    }
+
+    /**
+     * Get a build based on id
+     * @method get
+     * @param  {Mixed}   config    The configuration from which an id is generated or the actual id
+     * @return {Promise}           Resolve build model after merging with step models
+     */
+    get(config) {
+        return Promise.all([
+            getStepsModel,
+            super.get(config)
+        ]).then(([stepsModel, build]) => {
+            build.steps = build.steps.map((step) => {
+                const stepModel = stepsModel.find(s => s.name === step.name);
+
+                // For backward compatibility, old builds do not have stepModel
+                if (stepModel) {
+                    return stepModel;
+                }
+
+                return step;
+            });
+
+            return build;
+        });
     }
 
     /**

--- a/lib/step.js
+++ b/lib/step.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const BaseModel = require('./base');
+
+class StepModel extends BaseModel {
+    /**
+     * Construct a BannerModel object
+     * @method constructor
+     * @param {Object} config
+     * @param {Number} config.buildId         The banner message
+     * @param {String} config.name            The username of the user that created this banner
+     * @param {Number} [config.startTime]     Time the banner object was created
+     */
+    constructor(config) {
+        super('step', config); // data-schema model name
+    }
+}
+
+module.exports = StepModel;

--- a/lib/step.js
+++ b/lib/step.js
@@ -4,12 +4,11 @@ const BaseModel = require('./base');
 
 class StepModel extends BaseModel {
     /**
-     * Construct a BannerModel object
+     * Construct a StepModel object
      * @method constructor
      * @param {Object} config
-     * @param {Number} config.buildId         The banner message
-     * @param {String} config.name            The username of the user that created this banner
-     * @param {Number} [config.startTime]     Time the banner object was created
+     * @param {Number} config.buildId         Build id
+     * @param {String} config.name            Step name
      */
     constructor(config) {
         super('step', config); // data-schema model name

--- a/lib/stepFactory.js
+++ b/lib/stepFactory.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const Step = require('./step');
+
+let instance;
+
+class StepFactory extends BaseFactory {
+    /**
+     * Construct a StepFactory object
+     * @method constructor
+     * @param {Object} config
+     * @param {Object} config.datastore     Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('step', config); // data-schema model name
+    }
+
+    /**
+     * Instantiate a Step class
+     * @method createClass
+     * @param {Object} config
+     * @return {Step}
+     */
+    createClass(config) {
+        return new Step(config);
+    }
+
+    /**
+     * Get an instance of StepFactory
+     * @method getInstance
+     * @param {Object} config
+     * @return {StepFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(StepFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = StepFactory;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
     "screwdriver-config-parser": "^4.5.0",
-    "screwdriver-data-schema": "^18.30.0",
+    "screwdriver-data-schema": "^18.30.4",
     "screwdriver-workflow-parser": "^1.6.0",
     "winston": "^2.4.3"
   }

--- a/test/lib/step.test.js
+++ b/test/lib/step.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const mockery = require('mockery');
+const schema = require('screwdriver-data-schema');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Step Model', () => {
+    let datastore;
+    let BaseModel;
+    let StepModel;
+    let createConfig;
+    let step;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+        datastore = {
+            update: sinon.stub(),
+            remove: sinon.stub().resolves(null)
+        };
+
+        /* eslint-disable global-require */
+        BaseModel = require('../../lib/base');
+        StepModel = require('../../lib/step');
+        /* eslint-enable global-require */
+    });
+
+    beforeEach(() => {
+        datastore.update.resolves({});
+
+        createConfig = {
+            datastore,
+            id: 51,
+            message: 'Screwdriver step message'
+        };
+        step = new StepModel(createConfig);
+    });
+
+    after(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    it('is constructed properly', () => {
+        assert.instanceOf(step, StepModel);
+        assert.instanceOf(step, BaseModel);
+        schema.models.collection.allKeys.forEach((key) => {
+            assert.strictEqual(step[key], createConfig[key]);
+        });
+    });
+
+    describe('update', () => {
+        it('promises to update a step', () => {
+            step.lines = 123;
+
+            return step.update()
+                .then(() => {
+                    assert.calledWith(datastore.update, {
+                        table: 'steps',
+                        params: {
+                            id: 51,
+                            lines: 123
+                        }
+                    });
+                });
+        });
+    });
+
+    describe('remove', () => {
+        it('removes a step', () =>
+            step.remove()
+                .then(() => {
+                    assert.calledWith(datastore.remove, {
+                        table: 'steps',
+                        params: {
+                            id: 51
+                        }
+                    });
+                }));
+    });
+});

--- a/test/lib/stepFactory.test.js
+++ b/test/lib/stepFactory.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Step Factory', () => {
+    const stepId = 1;
+    const buildId = 123;
+    const name = 'echo';
+    const command = 'echo hi';
+    const stepData = {
+        id: stepId,
+        buildId,
+        name,
+        command
+    };
+
+    let StepFactory;
+    let datastore;
+    let factory;
+    let Step;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            get: sinon.stub()
+        };
+
+        /* eslint-disable global-require */
+        Step = require('../../lib/step');
+        StepFactory = require('../../lib/stepFactory');
+        /* eslint-disable global-require */
+
+        factory = new StepFactory({ datastore });
+    });
+
+    afterEach(() => {
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a Collection', () => {
+            const model = factory.createClass(stepData);
+
+            assert.instanceOf(model, Step);
+        });
+    });
+
+    describe('create', () => {
+        it('should create a Step', () => {
+            datastore.save.resolves(stepData);
+
+            return factory.create({
+                buildId,
+                name,
+                command
+            }).then((model) => {
+                assert.isTrue(datastore.save.calledOnce);
+                assert.instanceOf(model, Step);
+
+                Object.keys(stepData).forEach((key) => {
+                    assert.strictEqual(model[key], stepData[key]);
+                });
+            });
+        });
+    });
+
+    describe('get', () => {
+        it('should get a step by ID', () => {
+            datastore.get.resolves(stepData);
+
+            Promise.all([factory.get(stepId), factory.get({ id: stepId })])
+                .then(([step1, step2]) => {
+                    Object.keys(step1).forEach((key) => {
+                        assert.strictEqual(step1[key], stepData[key]);
+                        assert.strictEqual(step2[key], stepData[key]);
+                    });
+                });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+
+            /* eslint-disable global-require */
+            StepFactory = require('../../lib/stepFactory');
+            /* eslint-enable global-require */
+        });
+
+        it('should get an instance', () => {
+            const f1 = StepFactory.getInstance(config);
+            const f2 = StepFactory.getInstance(config);
+
+            assert.instanceOf(f1, StepFactory);
+            assert.instanceOf(f2, StepFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw an error when config not supplied', () => {
+            assert.throw(StepFactory.getInstance,
+                Error, 'No datastore provided to StepFactory');
+        });
+    });
+});


### PR DESCRIPTION
### Context
To avoid race condition when updating step meta when build's running, we separate step into a different model. API will be modified to update the step model directly instead of the whole `steps` field of a build.

### Objectives
This PR contains the following change: 

- add step model
- create step models when creating new build
- `buildFactory.get` now returns a build with merged step data with step models

### Related links
This bug is related to changes made for https://github.com/screwdriver-cd/screwdriver/issues/1114
