### PR TITLE
fix(1114): list builds with merged steps

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -91,6 +91,30 @@ function dockerImageName({ container, dockerRegistry }) {
     return updatedName.fullname;
 }
 
+/**
+ * Merge build with step models
+ * @method mergeStepsModel
+ * @param  {Build}        build     Build model
+ * @return {Promise}                Build model with merged steps
+ */
+function mergeStepsModel(build) {
+    return build.getStepsModel()
+        .then((stepsModel) => {
+            build.steps = build.steps.map((step) => {
+                const stepModel = stepsModel.find(s => s.name === step.name);
+
+                // For backward compatibility, old builds do not have stepModel
+                if (stepModel) {
+                    return stepModel.toJson();
+                }
+
+                return step;
+            });
+
+            return build;
+        });
+}
+
 class BuildFactory extends BaseFactory {
     /**
      * Construct a JobFactory object
@@ -251,22 +275,22 @@ class BuildFactory extends BaseFactory {
      * @return {Promise}           Resolve build model after merging with step models
      */
     get(config) {
-        return super.get(config)
-            .then(build => build.getStepsModel()
-                .then((stepsModel) => {
-                    build.steps = build.steps.map((step) => {
-                        const stepModel = stepsModel.find(s => s.name === step.name);
+        return super.get(config).then(mergeStepsModel);
+    }
 
-                        // For backward compatibility, old builds do not have stepModel
-                        if (stepModel) {
-                            return stepModel.toJson();
-                        }
-
-                        return step;
-                    });
-
-                    return build;
-                }));
+    /**
+     * List secrets with pagination and filter options
+     * @method list
+     * @param  {Object}   config                  Config object
+     * @param  {Object}   config.params           Parameters to filter on
+     * @param  {Object}   config.paginate         Pagination parameters
+     * @param  {Number}   config.paginate.count   Number of items per page
+     * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @return {Promise}                          Resolve builds after merging with step models
+     */
+    list(config) {
+        return super.list(config)
+            .then(builds => Promise.all(builds.map(mergeStepsModel)));
     }
 
     /**

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -549,6 +549,36 @@ describe('Build Factory', () => {
         });
     });
 
+    describe('list', () => {
+        const buildData = {
+            steps
+        };
+        const stepsData = steps.map(step => Object.assign({ code: 0 }, step));
+        const stepsMock = stepsData.map((step) => {
+            const mock = hoek.clone(step);
+
+            mock.toJson = sinon.stub().returns(step);
+
+            return mock;
+        });
+
+        it('should list builds without step models', () => {
+            getStepsModelStub.resolves([]);
+            datastore.scan.resolves([buildData, buildData]);
+
+            return factory.list({})
+                .then(builds => builds.map(build => assert.deepEqual(build.steps, steps)));
+        });
+
+        it('should list builds with merged step data', () => {
+            getStepsModelStub.resolves(stepsMock);
+            datastore.scan.resolves([buildData, buildData]);
+
+            return factory.list({})
+                .then(builds => builds.map(build => assert.deepEqual(build.steps, stepsData)));
+        });
+    });
+
     describe('getInstance', () => {
         let config;
 


### PR DESCRIPTION
list builds should also return builds with merged steps

Related to https://github.com/screwdriver-cd/screwdriver/issues/1114