### PR TITLE
feat(1204): Add pagination for getting pipeline events only [2]

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -116,15 +116,18 @@ class BaseFactory {
     list(config) {
         const scanConfig = {
             table: this.table,
-            params: config.params || {},
-            paginate: {
-                count: hoek.reach(config, 'paginate.count', { default: PAGINATE_COUNT }),
-                page: hoek.reach(config, 'paginate.page', { default: PAGINATE_PAGE })
-            }
+            params: config.params || {}
         };
 
         if (config.sort) {
             scanConfig.sort = config.sort;
+        }
+
+        if (config.paginate) {
+            scanConfig.paginate = {
+                count: hoek.reach(config, 'paginate.count', { default: PAGINATE_COUNT }),
+                page: hoek.reach(config, 'paginate.page', { default: PAGINATE_PAGE })
+            };
         }
 
         return this.datastore.scan(scanConfig)

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -105,8 +105,8 @@ class BaseFactory {
     /**
      * List records with pagination and filter options
      * @method list
-     * @param  {Object}   config                    Config object
-     * @param  {Object}   config.params             Parameters to filter on
+     * @param  {Object}   [config]
+     * @param  {Object}   [config.params]           Parameters to filter on
      * @param  {Object}   [config.paginate]         Pagination parameters
      * @param  {Number}   [config.paginate.count]   Number of items per page
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
@@ -116,14 +116,11 @@ class BaseFactory {
     list(config) {
         const scanConfig = {
             table: this.table,
-            params: config.params || {}
+            params: hoek.reach(config, 'params', { default: {} }),
+            sort: hoek.reach(config, 'sort', { default: 'descending' })
         };
 
-        if (config.sort) {
-            scanConfig.sort = config.sort;
-        }
-
-        if (config.paginate) {
+        if (config && config.paginate) {
             scanConfig.paginate = {
                 count: hoek.reach(config, 'paginate.count', { default: PAGINATE_COUNT }),
                 page: hoek.reach(config, 'paginate.page', { default: PAGINATE_PAGE })

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -116,9 +116,12 @@ class BaseFactory {
     list(config) {
         const scanConfig = {
             table: this.table,
-            params: hoek.reach(config, 'params', { default: {} }),
-            sort: hoek.reach(config, 'sort', { default: 'descending' })
+            params: hoek.reach(config, 'params', { default: {} })
         };
+
+        if (config && config.sort) {
+            scanConfig.sort = config.sort;
+        }
 
         if (config && config.paginate) {
             scanConfig.paginate = {

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -125,8 +125,10 @@ class BaseFactory {
 
         if (config && config.paginate) {
             scanConfig.paginate = {
-                count: hoek.reach(config, 'paginate.count', { default: PAGINATE_COUNT }),
+                count: hoek.reach(config, 'paginate.count', { default: PAGINATE_COUNT })
+                    || PAGINATE_COUNT,
                 page: hoek.reach(config, 'paginate.page', { default: PAGINATE_PAGE })
+                    || PAGINATE_PAGE
             };
         }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,8 +11,6 @@ const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
 const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
 const TEMPORAL_JWT_TIMEOUT = 12 * 60; // 12 hours in minutes
-const PAGINATE_PAGE = 1;
-const PAGINATE_COUNT = 50;
 
 /**
  * Get the array of ids for jobs that match the names passed in
@@ -134,10 +132,6 @@ class BuildModel extends BaseModel {
         const listConfig = {
             params: {
                 buildId: this.id
-            },
-            paginate: {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
             }
         };
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const BaseModel = require('./base');
-const PAGINATE_PAGE = 1;
-const PAGINATE_COUNT = 50;
 
 class EventModel extends BaseModel {
     /**
@@ -23,11 +21,6 @@ class EventModel extends BaseModel {
         const listConfig = {
             params: {
                 eventId: this.id
-            },
-            // We are not implementing paginate, but the datastore is expecting it
-            paginate: {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
             }
         };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -3,8 +3,6 @@
 const BaseModel = require('./base');
 const hoek = require('hoek');
 const getAnnotations = require('./helper').getAnnotations;
-const PAGINATE_PAGE = 1;
-const PAGINATE_COUNT = 50;
 const START_INDEX = 3;
 const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
@@ -116,25 +114,19 @@ class Job extends BaseModel {
      */
     getBuilds(config) {
         const sort = (config && config.sort) ? config.sort.toLowerCase() : 'descending';
-        let paginate = {
-            page: PAGINATE_PAGE,
-            count: PAGINATE_COUNT
-        };
-
-        if (config && config.paginate) {
-            paginate = hoek.applyToDefaults(paginate, config.paginate);
-        }
-
         const listConfig = {
             params: {
                 jobId: this.id
             },
-            sort, // Sort by primary sort key
-            paginate
+            sort // Sort by primary sort key
         };
 
         if (config && config.status) {
             listConfig.params.status = config.status;
+        }
+
+        if (config && config.paginate) {
+            listConfig.paginate = config.paginate;
         }
 
         // Lazy load factory dependency to prevent circular dependency issues

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -687,10 +687,6 @@ class PipelineModel extends BaseModel {
         const listConfig = {
             params: {
                 pipelineId: this.id
-            },
-            paginate: {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
             }
         };
 
@@ -799,10 +795,6 @@ class PipelineModel extends BaseModel {
         const listConfig = {
             params: {
                 pipelineId: this.id
-            },
-            paginate: {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
             }
         };
 
@@ -836,10 +828,6 @@ class PipelineModel extends BaseModel {
         const listConfig = {
             params: {
                 pipelineId: this.id
-            },
-            paginate: {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
             }
         };
 
@@ -902,6 +890,9 @@ class PipelineModel extends BaseModel {
      * @param  {Object}   [config.params]           Filter params
      * @param  {Boolean}  [config.params.archived]  Get archived/non-archived jobs
      * @param  {String}   [config.type]             Type of jobs (pr or pipeline)
+     * @param  {Object}   [config.paginate]         Pagination parameters
+     * @param  {Number}   [config.paginate.count]   Number of items per page
+     * @param  {Number}   [config.paginate.page]    Specific page of the set to return
      * @return {Promise}  Resolves to an array of jobs
      */
     getJobs(config) {
@@ -909,13 +900,8 @@ class PipelineModel extends BaseModel {
             params: {
                 pipelineId: this.id,
                 archived: false
-            },
-            paginate: {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
             }
         };
-
         const listConfig = (config) ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 
         if (listConfig.type) {
@@ -952,9 +938,12 @@ class PipelineModel extends BaseModel {
 
     /**
      * Fetch events belong to a pipeline.
-     * @param  {Object}   [config]                              Configuration object
+     * @param  {Object}   [config]
      * @param  {Number}   [config.sort]                         Sort rangekey by ascending or descending
      * @param  {Number}   [config.params.type = 'pipeline']     Get pipeline or pr events
+     * @param  {Object}   [config.paginate]                     Pagination parameters
+     * @param  {Number}   [config.paginate.count]               Number of items per page
+     * @param  {Number}   [config.paginate.page]                Specific page of the set to return
      * @return {Promise}  Resolves to an array of events
      */
     getEvents(config) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -952,12 +952,16 @@ class PipelineModel extends BaseModel {
                 pipelineId: this.id,
                 type: 'pipeline'
             },
-            sort: 'descending',
-            paginate: {
+            sort: 'descending'
+        };
+
+        // Do not force pagination by default (for backwards compatibility)
+        if (config && config.paginate) {
+            defaultConfig.paginate = {
                 count: PAGINATE_COUNT,
                 page: PAGINATE_PAGE
-            }
-        };
+            };
+        }
 
         const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -10,8 +10,6 @@ const hoek = require('hoek');
 const winston = require('winston');
 const _ = require('lodash');
 const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
-const PAGINATE_PAGE = 1;
-const PAGINATE_COUNT = 50;
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
     job: 2 // main or undefined if using legacy
@@ -954,14 +952,6 @@ class PipelineModel extends BaseModel {
             },
             sort: 'descending'
         };
-
-        // Do not force pagination by default (for backwards compatibility)
-        if (config && config.paginate) {
-            defaultConfig.paginate = {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
-            };
-        }
 
         const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -2,8 +2,6 @@
 
 const BaseModel = require('./base');
 const iron = require('iron');
-const PAGINATE_COUNT = 50;
-const PAGINATE_PAGE = 1;
 // Get symbols for private fields
 const password = Symbol('password');
 
@@ -53,10 +51,6 @@ class UserModel extends BaseModel {
         const listConfig = {
             params: {
                 userId: this.id
-            },
-            paginate: {
-                count: PAGINATE_COUNT,
-                page: PAGINATE_PAGE
             }
         };
 

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -276,6 +276,20 @@ describe('Base Factory', () => {
                 })
         );
 
+        it('sets default paginate values if undefined is passed in', () =>
+            factory.list({ paginate: { page: undefined, count: undefined } })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        paginate: {
+                            page: 1,
+                            count: 50
+                        }
+                    });
+                })
+        );
+
         it('calls datastore scan with sorting option returns correct values', () =>
             factory.list({ paginate, sort: 'ascending' })
                 .then(() => {

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -252,15 +252,25 @@ describe('Base Factory', () => {
                 })
         );
 
-        it('sets default paginate values', () =>
+        it('does not set default paginate values if none are passed in', () =>
             factory.list({})
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {}
+                    });
+                })
+        );
+
+        it('sets default paginate values if some are passed in', () =>
+            factory.list({ paginate: { count: 20 } })
                 .then(() => {
                     assert.calledWith(datastore.scan, {
                         table: 'base',
                         params: {},
                         paginate: {
                             page: 1,
-                            count: 50
+                            count: 20
                         }
                     });
                 })

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -257,7 +257,8 @@ describe('Base Factory', () => {
                 .then(() => {
                     assert.calledWith(datastore.scan, {
                         table: 'base',
-                        params: {}
+                        params: {},
+                        sort: 'descending'
                     });
                 })
         );
@@ -268,6 +269,7 @@ describe('Base Factory', () => {
                     assert.calledWith(datastore.scan, {
                         table: 'base',
                         params: {},
+                        sort: 'descending',
                         paginate: {
                             page: 1,
                             count: 20

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -252,13 +252,12 @@ describe('Base Factory', () => {
                 })
         );
 
-        it('does not set default paginate values if none are passed in', () =>
+        it('does not set default values if none are passed in', () =>
             factory.list({})
                 .then(() => {
                     assert.calledWith(datastore.scan, {
                         table: 'base',
-                        params: {},
-                        sort: 'descending'
+                        params: {}
                     });
                 })
         );
@@ -269,7 +268,6 @@ describe('Base Factory', () => {
                     assert.calledWith(datastore.scan, {
                         table: 'base',
                         params: {},
-                        sort: 'descending',
                         paginate: {
                             page: 1,
                             count: 20

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -798,10 +798,6 @@ describe('Build Model', () => {
             const expected = {
                 params: {
                     buildId
-                },
-                paginate: {
-                    page: 1,
-                    count: 50
                 }
             };
 

--- a/test/lib/event.test.js
+++ b/test/lib/event.test.js
@@ -68,10 +68,6 @@ describe('Event Model', () => {
             const expected = {
                 params: {
                     eventId: '1234'
-                },
-                paginate: {
-                    page: 1,
-                    count: 50
                 }
             };
 

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -253,11 +253,7 @@ describe('Job Model', () => {
                 params: {
                     jobId: '1234'
                 },
-                sort: 'descending',
-                paginate: {
-                    page: 1,
-                    count: 50
-                }
+                sort: 'descending'
             };
 
             return job.getBuilds().then(() => {
@@ -280,6 +276,7 @@ describe('Job Model', () => {
             return job.getBuilds({
                 sort: 'Ascending',
                 paginate: {
+                    page: 1,
                     count: 100
                 }
             }).then(() => {
@@ -295,11 +292,7 @@ describe('Job Model', () => {
                     jobId: '1234',
                     status: 'RUNNING'
                 },
-                sort: 'descending',
-                paginate: {
-                    page: 1,
-                    count: 50
-                }
+                sort: 'descending'
             };
             const expectedSecondCall = Object.assign({}, expectedFirstCall, {
                 params: { jobId: '1234', status: 'QUEUED' } });
@@ -324,11 +317,7 @@ describe('Job Model', () => {
                     jobId: '1234',
                     status: 'SUCCESS'
                 },
-                sort: 'descending',
-                paginate: {
-                    page: 1,
-                    count: 50
-                }
+                sort: 'descending'
             };
 
             return job.getLastSuccessfulBuild().then((successfulBuild) => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1041,8 +1041,7 @@ describe('Pipeline Model', () => {
             const listConfig = {
                 params: {
                     pipelineId: pipeline.id
-                },
-                paginate
+                }
             };
 
             jobFactoryMock.list.resolves(null);
@@ -1064,8 +1063,7 @@ describe('Pipeline Model', () => {
             const listConfig = {
                 params: {
                     pipelineId: pipeline.id
-                },
-                paginate
+                }
             };
 
             secretFactoryMock.list.resolves(null);
@@ -1115,14 +1113,12 @@ describe('Pipeline Model', () => {
             const childPipelineListConfig = {
                 params: {
                     pipelineId: childPipeline.id
-                },
-                paginate
+                }
             };
             const configPipelineListConfig = {
                 params: {
                     pipelineId: pipeline.id
-                },
-                paginate
+                }
             };
 
             secretFactoryMock.list.onCall(0).resolves(childPipelineSecrets);
@@ -1159,13 +1155,12 @@ describe('Pipeline Model', () => {
     });
 
     describe('get jobs', () => {
-        it('Get all jobs', () => {
+        it('gets all jobs', () => {
             const expected = {
                 params: {
                     pipelineId: 123,
                     archived: false
-                },
-                paginate
+                }
             };
 
             const jobList = [publishJob, mainJob, pr10, pr3];
@@ -1179,7 +1174,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('Only gets PR jobs', () => {
+        it('only gets PR jobs', () => {
             const config = {
                 type: 'pr'
             };
@@ -1187,8 +1182,7 @@ describe('Pipeline Model', () => {
                 params: {
                     pipelineId: 123,
                     archived: false
-                },
-                paginate
+                }
             };
             const jobList = [publishJob, mainJob, pr10, pr3];
             const expectedJobs = [pr3, pr10];
@@ -1201,7 +1195,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('Only gets Pipeline jobs', () => {
+        it('only gets Pipeline jobs', () => {
             const config = {
                 type: 'pipeline'
             };
@@ -1209,8 +1203,7 @@ describe('Pipeline Model', () => {
                 params: {
                     pipelineId: 123,
                     archived: false
-                },
-                paginate
+                }
             };
             const jobList = [publishJob, mainJob, pr10, pr3];
             const expectedJobs = [publishJob, mainJob];
@@ -1223,7 +1216,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('Get archived jobs', () => {
+        it('gets archived jobs', () => {
             const config = {
                 params: {
                     archived: true
@@ -1233,8 +1226,7 @@ describe('Pipeline Model', () => {
                 params: {
                     pipelineId: 123,
                     archived: true
-                },
-                paginate
+                }
             };
 
             publishJob.archived = true;
@@ -1257,7 +1249,7 @@ describe('Pipeline Model', () => {
             id: '12855123cc7f1b808aac07feff24d7d5362cc215'
         }];
 
-        it('Get list of events', () => {
+        it('gets a list of events', () => {
             const expected = {
                 params: {
                     pipelineId: 123,
@@ -1275,7 +1267,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('Merge the passed in config with the default config', () => {
+        it('merges the passed in config with the default config', () => {
             const expected = {
                 params: {
                     pipelineId: 123,
@@ -1299,7 +1291,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('Rejects with errors', () => {
+        it('rejects with errors', () => {
             eventFactoryMock.list.rejects(new Error('cannotgetit'));
 
             return pipeline.getEvents()
@@ -1522,8 +1514,7 @@ describe('Pipeline Model', () => {
                 params: {
                     pipelineId: testId,
                     archived: true
-                },
-                paginate
+                }
             };
 
             prType = {
@@ -1733,8 +1724,7 @@ describe('Pipeline Model', () => {
             const listConfig = {
                 params: {
                     pipelineId: testId
-                },
-                paginate
+                }
             };
 
             tokenFactoryMock.list.resolves(null);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -45,10 +45,6 @@ describe('Pipeline Model', () => {
     const scmContext = 'github:github.com';
     const testId = 123;
     const admins = { batman: true, robin: true };
-    const paginate = {
-        page: 1,
-        count: 50
-    };
     let jobs;
     let pipelineConfig;
     let publishJob;
@@ -1255,8 +1251,7 @@ describe('Pipeline Model', () => {
                     pipelineId: 123,
                     type: 'pipeline'
                 },
-                sort: 'descending',
-                paginate
+                sort: 'descending'
             };
 
             eventFactoryMock.list.resolves(events);
@@ -1273,11 +1268,7 @@ describe('Pipeline Model', () => {
                     pipelineId: 123,
                     type: 'pr'
                 },
-                sort: 'descending',
-                paginate: {
-                    page: 1,
-                    count: 50
-                }
+                sort: 'descending'
             };
 
             eventFactoryMock.list.resolves(events);
@@ -1522,7 +1513,6 @@ describe('Pipeline Model', () => {
                     pipelineId: testId,
                     type: 'pr'
                 },
-                paginate,
                 sort: 'descending'
             };
 

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -206,17 +206,11 @@ describe('User Model', () => {
     });
 
     describe('get tokens', () => {
-        const paginate = {
-            page: 1,
-            count: 50
-        };
-
         it('has a tokens getter', () => {
             const listConfig = {
                 params: {
                     userId: createConfig.id
-                },
-                paginate
+                }
             };
 
             tokenFactoryMock.list.resolves(null);


### PR DESCRIPTION
## Context
The pipeline page is taking a long time to load since there are so many events per pipeline. Pagination is only actually done through the UI, not from the API side. It would be nice to do pagination from the API side to speed up UI loading for the pipeline page.

## Objective
This PR will:
- remove pagination for all function calls except `getEvents` (since most functions rely on everything being returned)
- remove default pagination from baseFactory except when `config.pagination` is passed in

2 questions:
1. Not sure if we should default to `sort: descending` (the API will force that default anyways using the data-schema (https://github.com/screwdriver-cd/data-schema/blob/master/api/pagination.js#L18))
2. Not sure if we should always paginate pipeline `getEvents` since *A. it's unlikely people will want more than 50 events* and *B. it'll make the page load a lot faster* or we should default to no pagination for backwards compatibility.

## Related links
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1204