### PR TITLE
fix: fix not to throw error when build not found

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -98,6 +98,10 @@ function dockerImageName({ container, dockerRegistry }) {
  * @return {Promise}                Build model with merged steps
  */
 function mergeStepsModel(build) {
+    if (!build) {
+        return Promise.resolve(build);
+    }
+
     return build.getStepsModel()
         .then((stepsModel) => {
             build.steps = build.steps.map((step) => {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -547,6 +547,13 @@ describe('Build Factory', () => {
             return factory.get(buildId)
                 .then(build => assert.deepEqual(build.steps, stepsData));
         });
+
+        it('should not throw when build does not exist', () => {
+            datastore.get.resolves(null);
+
+            return factory.get(buildId)
+                .then(build => assert.deepEqual(build, null));
+        });
     });
 
     describe('list', () => {


### PR DESCRIPTION
I found build API returns 500 error if specified build doesn't exist. I think it should return 404 in this case.
```javascript
{"statusCode ":500, "error": "Internal Server Error", "message": "Cannot read property 'getStepsModel' of null"}
```
And I fixed it by checking null and returning empty value in `BuildFactory.get`.
It is the same behavior as https://github.com/screwdriver-cd/models/blob/master/lib/baseFactory.js#L93-L96