### PR TITLE
fix(1244): Pass correct parent pipeline sha to startBuild

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -168,7 +168,6 @@ function startBuild(config) {
 function createBuilds(config) {
     const { eventConfig, eventId, pipeline, pipelineConfig, changedFiles, webhooks } = config;
     const startFrom = eventConfig.startFrom;
-    const configPipelineSha = pipelineConfig.configPipelineSha;
 
     if (!startFrom) {
         return null;
@@ -208,18 +207,21 @@ function createBuilds(config) {
             }
 
             // Start builds
-            return Promise.all(jobsToStart.map(j =>
-                startBuild({
-                    buildConfig: Object.assign({
-                        jobId: j.id,
-                        eventId,
-                        configPipelineSha
-                    }, eventConfig),
+            return Promise.all(jobsToStart.map((j) => {
+                const buildConfig = Object.assign({
+                    jobId: j.id,
+                    eventId
+                }, eventConfig);
+
+                buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;
+
+                return startBuild({
+                    buildConfig,
                     changedFiles,
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks
-                })
-            )).then((buildsCreated) => {
+                });
+            })).then((buildsCreated) => {
                 const nobuilds = buildsCreated.every(b => b === null);
 
                 if (nobuilds) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^6.0.0",
-    "joi": "^13.4.0",
+    "joi": "^13.6.0",
     "mockery": "^2.0.0",
     "sinon": "^4.5.0"
   },
@@ -49,7 +49,7 @@
     "base64url": "^3.0.0",
     "compare-versions": "^3.3.0",
     "docker-parse-image": "^3.0.1",
-    "hoek": "^5.0.3",
+    "hoek": "^5.0.4",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
     "screwdriver-config-parser": "^4.5.0",


### PR DESCRIPTION
## Context
Currently in `createBuild`, we pass in the value of `configPipelineSha` that belongs to `eventConfig`. In the case where a build is triggered via a webhook, this value will improperly be set to a sha belonging to the child pipeline rather than the intended value.

## Objective
Pass in the correct value of `configPipelineSha` to `startBuild`.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1244