### PR TITLE
fix(1220): Reduce for-loop in getFirstAdmin

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -737,6 +737,8 @@ class PipelineModel extends BaseModel {
             if (!permission.push) {
                 delete newAdmins[username];
                 winston.info(`${username} has been removed from admins of pipeline:${this.id}.`);
+            } else {
+                break;
             }
         }
         /* eslint-enable no-restricted-syntax */


### PR DESCRIPTION
## Context
I found the waste API calls in the getFirstAdmin logic. There is no need to find other admins after first admin is found.

## Objective
I fixed getFristAdmin to reduce scm API calls.

## References
screwdriver-cd/screwdriver#1220