### PR TITLE
[2][small] fix(1220):  Add scmInfo

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -136,12 +136,13 @@ class PipelineModel extends BaseModel {
 
         return this.admin.then(user => user.unsealToken())
             // fetch the screwdriver.yaml file
-            .then((token) => {
+            .then(token => this.scmInfo.then((scmInfo) => {
                 const config = {
                     scmUri: this.scmUri,
                     scmContext: this.scmContext,
                     path: 'screwdriver.yaml',
-                    token
+                    token,
+                    scmInfo
                 };
 
                 if (ref) {
@@ -152,7 +153,7 @@ class PipelineModel extends BaseModel {
                 return promiseToWait(1.8)
                     .then(() => this.scm.getFile(config))
                     .catch(() => '');
-            })
+            }))
             // parse the content of the yaml file
             .then(config => parser(config, templateFactory));
     }
@@ -334,12 +335,14 @@ class PipelineModel extends BaseModel {
     syncPR(prNum) {
         return this.admin
             .then(user => user.unsealToken())
-            .then(token => this.scm.getPrInfo({
-                scmUri: this.scmUri,
-                scmContext: this.scmContext,
-                token,
-                prNum
-            }))
+            .then(token => this.scmInfo.then(scmInfo =>
+                this.scm.getPrInfo({
+                    scmUri: this.scmUri,
+                    scmContext: this.scmContext,
+                    token,
+                    prNum,
+                    scmInfo
+                })))
             .then(prInfo => Promise.all([
                 this.getConfiguration({
                     ref: prInfo.ref,
@@ -654,6 +657,27 @@ class PipelineModel extends BaseModel {
                 return this.update();
             })
             .then(() => this);
+    }
+
+    /**
+     * Fetch a pipeline's scmInfo
+     * @property scmInfo
+     * @return {Promise}
+    */
+    get scmInfo() {
+        if (!this._scmInfo) {
+            this._scmInfo = this.scm.lookupScmUri(this.scmUri);
+        }
+
+        // ES6 has weird getters and setters in classes,
+        // so we redefine the pipeline property here to resolve to the
+        // resulting promise and not try to recreate the factory, etc.
+        Object.defineProperty(this, 'scmInfo', {
+            enumerable: true,
+            value: this._scmInfo
+        });
+
+        return this._scmInfo;
     }
 
     /**
@@ -975,11 +999,14 @@ class PipelineModel extends BaseModel {
     update() {
         return this.admin
             .then(user => user.unsealToken())
-            .then(token => this.scm.decorateUrl({
-                scmUri: this.scmUri,
-                scmContext: this.scmContext,
-                token
-            }))
+            .then(token => this.scmInfo.then(scmInfo =>
+                this.scm.decorateUrl({
+                    scmUri: this.scmUri,
+                    scmContext: this.scmContext,
+                    token,
+                    scmInfo
+                })
+            ))
             .then((scmRepo) => {
                 this.scmRepo = scmRepo;
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -979,6 +979,18 @@ describe('Pipeline Model', () => {
             // We want to cache scmInfo to reduce API call
             assert.calledOnce(scmMock.lookupScmUri);
         });
+
+        it('rejects when lookupScmUri rejects', () => {
+            const testError = new Error('someGithubCommError');
+
+            scmMock.lookupScmUri.rejects(testError);
+
+            return pipeline.scmInfo.then(() => {
+                assert.fail('This should not fail the test');
+            }).catch((err) => {
+                assert.deepEqual(err, testError);
+            });
+        });
     });
 
     describe('get admin', () => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -180,7 +180,8 @@ describe('Pipeline Model', () => {
             getFile: sinon.stub(),
             decorateUrl: sinon.stub(),
             getOpenedPRs: sinon.stub(),
-            getPrInfo: sinon.stub()
+            getPrInfo: sinon.stub(),
+            lookupScmUri: sinon.stub()
         };
         parserMock = sinon.stub();
 
@@ -295,6 +296,7 @@ describe('Pipeline Model', () => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
             scmMock.addWebhook.resolves();
+            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             parserMock.withArgs('yamlcontentwithscmurls', templateFactoryMock)
                 .resolves(EXTERNAL_PARSED_YAML);
@@ -496,7 +498,11 @@ describe('Pipeline Model', () => {
                         scmUri,
                         scmContext,
                         path: 'screwdriver.yaml',
-                        token: 'foo'
+                        token: 'foo',
+                        scmInfo: {
+                            branch: 'branch',
+                            host: 'host'
+                        }
                     });
                     assert.calledWith(parserMock, 'superyamlcontent', templateFactoryMock);
                     assert.calledWith(jobFactoryMock.create, publishMock);
@@ -733,6 +739,7 @@ describe('Pipeline Model', () => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
             scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge' });
+            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
@@ -755,7 +762,11 @@ describe('Pipeline Model', () => {
                     ref: 'pulls/1/merge',
                     scmUri,
                     scmContext,
-                    token: 'foo'
+                    token: 'foo',
+                    scmInfo: {
+                        branch: 'branch',
+                        host: 'host'
+                    }
                 });
                 assert.called(prJob.update);
                 assert.deepEqual(prJob.permutations, PARSED_YAML.jobs.main);
@@ -793,7 +804,11 @@ describe('Pipeline Model', () => {
                     ref: 'pulls/1/merge',
                     scmUri,
                     scmContext,
-                    token: 'foo'
+                    token: 'foo',
+                    scmInfo: {
+                        branch: 'branch',
+                        host: 'host'
+                    }
                 });
                 assert.calledOnce(firstPRJob.update);
                 assert.calledOnce(secondPRJob.update);
@@ -833,7 +848,11 @@ describe('Pipeline Model', () => {
                     ref: 'pulls/1/merge',
                     scmUri,
                     scmContext,
-                    token: 'foo'
+                    token: 'foo',
+                    scmInfo: {
+                        branch: 'branch',
+                        host: 'host'
+                    }
                 });
                 assert.calledOnce(firstPRJob.update);
                 assert.calledOnce(secondPRJob.update);
@@ -875,6 +894,7 @@ describe('Pipeline Model', () => {
         beforeEach(() => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
+            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
@@ -940,6 +960,24 @@ describe('Pipeline Model', () => {
                     assert.notCalled(prJob.update);
                     assert.notCalled(jobFactoryMock.create);
                 });
+        });
+    });
+
+    describe('get scmInfo', () => {
+        beforeEach(() => {
+            scmMock.lookupScmUri.resolves({
+                branch: 'test-branch',
+                host: 'test-host',
+                repo: 'test-repo',
+                owner: 'test-owner'
+            });
+        });
+
+        it('has a scmInfo getter', () => {
+            assert.isFunction(pipeline.scmInfo.then);
+            assert.isFunction(pipeline.scmInfo.then);
+            // We want to cache scmInfo to reduce API call
+            assert.calledOnce(scmMock.lookupScmUri);
         });
     });
 
@@ -1298,6 +1336,7 @@ describe('Pipeline Model', () => {
     describe('getConfiguration', () => {
         beforeEach(() => {
             scmMock.getFile.resolves('superyamlcontent');
+            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             parserMock.withArgs('', templateFactoryMock).resolves('DEFAULT_YAML');
             getUserPermissionMocks({ username: 'batman', push: true });
@@ -1314,7 +1353,11 @@ describe('Pipeline Model', () => {
                         scmUri,
                         scmContext,
                         path: 'screwdriver.yaml',
-                        token: 'foo'
+                        token: 'foo',
+                        scmInfo: {
+                            branch: 'branch',
+                            host: 'host'
+                        }
                     });
                     assert.calledWith(parserMock, 'superyamlcontent', templateFactoryMock);
                 })
@@ -1329,7 +1372,11 @@ describe('Pipeline Model', () => {
                         scmContext,
                         path: 'screwdriver.yaml',
                         token: 'foo',
-                        ref: 'bar'
+                        ref: 'bar',
+                        scmInfo: {
+                            branch: 'branch',
+                            host: 'host'
+                        }
                     });
                     assert.calledWith(parserMock, 'superyamlcontent', templateFactoryMock);
                 })
@@ -1383,7 +1430,11 @@ describe('Pipeline Model', () => {
                         scmContext,
                         path: 'screwdriver.yaml',
                         token: 'foo',
-                        ref: 'foobar'
+                        ref: 'foobar',
+                        scmInfo: {
+                            branch: 'branch',
+                            host: 'host'
+                        }
                     });
                     assert.calledWith(parserMock, '', templateFactoryMock);
                 });
@@ -1414,6 +1465,7 @@ describe('Pipeline Model', () => {
             };
 
             scmMock.decorateUrl.resolves(scmRepo);
+            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             userFactoryMock.get.withArgs({
                 username: 'd2lam',
                 scmContext
@@ -1432,7 +1484,15 @@ describe('Pipeline Model', () => {
             };
 
             return pipeline.update().then((p) => {
-                assert.calledWith(scmMock.decorateUrl, { scmUri, scmContext, token: 'foo' });
+                assert.calledWith(scmMock.decorateUrl, {
+                    scmUri,
+                    scmContext,
+                    token: 'foo',
+                    scmInfo: {
+                        branch: 'branch',
+                        host: 'host'
+                    }
+                });
                 assert.calledWith(datastore.update, expected);
                 assert.ok(p);
             });
@@ -1454,6 +1514,7 @@ describe('Pipeline Model', () => {
             };
 
             scmMock.decorateUrl.resolves(scmRepo);
+            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             userFactoryMock.get.withArgs({
                 username: 'd2lam',
                 scmContext
@@ -1469,7 +1530,15 @@ describe('Pipeline Model', () => {
             };
 
             return pipeline.update().then((p) => {
-                assert.calledWith(scmMock.decorateUrl, { scmUri, scmContext, token: 'foo' });
+                assert.calledWith(scmMock.decorateUrl, {
+                    scmUri,
+                    scmContext,
+                    token: 'foo',
+                    scmInfo: {
+                        branch: 'branch',
+                        host: 'host'
+                    }
+                });
                 assert.calledWith(datastore.update, expected);
                 assert.ok(p);
             });


### PR DESCRIPTION
## Context
Screwdriver calls `lookupScmUri` many times during a single PR event and it should be reduced.

## Objective
I added scmInfo property to the pipeline model to cache scmInfo. And use it to reduce API calls.

## References
original issue: screwdriver-cd/screwdriver#1220
related PRs:
screwdriver-cd/data-schema#273
screwdriver-cd/scm-github#101