### PR TITLE
feat(880): Add sortBy field to baseFactory list [3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ const config = {
     paginate {
         page: 2,
         count: 3
-    }
+    },
+    sort: 'ascending',
+    sortBy: 'scmRepo.name'
 }
 
 factory.list(config).then(pipelines => {
@@ -40,6 +42,8 @@ factory.list(config).then(pipelines => {
 | config.paginate.page | Number | The page for pagination |
 | config.paginate.count | Number | The count for pagination |
 | config.params | Object | fields to search on |
+| config.sort | String | Order to sort by (`ascending` or `descending`) |
+| config.sortBy | String | Key to sort by (default `id`) |
 
 #### Create
 ```js
@@ -134,7 +138,8 @@ model.getJobs(config)
 | :-------------   | :---- | :--- | :--- | :-------------|
 | config        | Object | No | | Configuration Object |
 | config.params | Object | No | | Fields to search on |
-| config.params.sort | Boolean | No | false| Sorting by createTime |
+| config.paginate.page | Number | No | | The page for pagination |
+| config.paginate.count | Number | No | | The count for pagination |
 
 
 #### Get Events
@@ -147,7 +152,7 @@ model.getEvents(config)
 | :-------------   | :---- | :--- | :--- | :-------------|
 | config        | Object | No | | Config Object |
 | config.type | Number | No | `pipeline` | Type of event: `pipeline` or `pr` |
-| config.sort | Number | No | `descending`| Sorting by createTime |
+| config.sort | String | No | `descending`| Order to sort by (`ascending` or `descending`) |
 
 #### Tokens
 Get the pipeline's access tokens

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -111,6 +111,7 @@ class BaseFactory {
      * @param  {Number}   [config.paginate.count]   Number of items per page
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
      * @param  {String}   [config.sort]             Sorting option. 'ascending' or 'descending'
+     * @param  {String}   [config.sortBy]           Key to sort by (default is 'id')
      * @return {Promise}
      */
     list(config) {
@@ -121,6 +122,10 @@ class BaseFactory {
 
         if (config && config.sort) {
             scanConfig.sort = config.sort;
+        }
+
+        if (config && config.sortBy) {
+            scanConfig.sortBy = config.sortBy;
         }
 
         if (config && config.paginate) {

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -290,6 +290,17 @@ describe('Base Factory', () => {
                 })
         );
 
+        it('sets sortBy value if it is passed in', () =>
+            factory.list({ sortBy: 'scmRepo.name' })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        sortBy: 'scmRepo.name'
+                    });
+                })
+        );
+
         it('calls datastore scan with sorting option returns correct values', () =>
             factory.list({ paginate, sort: 'ascending' })
                 .then(() => {


### PR DESCRIPTION
## Context
Should be able to sort pipelines by `scmRepo.name`.

## Objective
This PR passes in the `sortBy` field if it is set.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880
Blocked by https://github.com/screwdriver-cd/data-schema/pull/274, https://github.com/screwdriver-cd/datastore-sequelize/pull/31