### PR TITLE
fix(1220): Reduce API calls using scmRepo

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -136,13 +136,13 @@ class PipelineModel extends BaseModel {
 
         return this.admin.then(user => user.unsealToken())
             // fetch the screwdriver.yaml file
-            .then(token => this.scmInfo.then((scmInfo) => {
+            .then((token) => {
                 const config = {
                     scmUri: this.scmUri,
                     scmContext: this.scmContext,
                     path: 'screwdriver.yaml',
                     token,
-                    scmInfo
+                    scmRepo: this.scmRepo
                 };
 
                 if (ref) {
@@ -153,7 +153,7 @@ class PipelineModel extends BaseModel {
                 return promiseToWait(1.8)
                     .then(() => this.scm.getFile(config))
                     .catch(() => '');
-            }))
+            })
             // parse the content of the yaml file
             .then(config => parser(config, templateFactory));
     }
@@ -335,14 +335,13 @@ class PipelineModel extends BaseModel {
     syncPR(prNum) {
         return this.admin
             .then(user => user.unsealToken())
-            .then(token => this.scmInfo.then(scmInfo =>
-                this.scm.getPrInfo({
-                    scmUri: this.scmUri,
-                    scmContext: this.scmContext,
-                    token,
-                    prNum,
-                    scmInfo
-                })))
+            .then(token => this.scm.getPrInfo({
+                scmUri: this.scmUri,
+                scmContext: this.scmContext,
+                token,
+                prNum,
+                scmRepo: this.scmRepo
+            }))
             .then(prInfo => Promise.all([
                 this.getConfiguration({
                     ref: prInfo.ref,
@@ -657,27 +656,6 @@ class PipelineModel extends BaseModel {
                 return this.update();
             })
             .then(() => this);
-    }
-
-    /**
-     * Fetch a pipeline's scmInfo
-     * @property scmInfo
-     * @return {Promise}
-    */
-    get scmInfo() {
-        if (!this._scmInfo) {
-            this._scmInfo = this.scm.lookupScmUri(this.scmUri);
-        }
-
-        // ES6 has weird getters and setters in classes,
-        // so we redefine the pipeline property here to resolve to the
-        // resulting promise and not try to recreate the factory, etc.
-        Object.defineProperty(this, 'scmInfo', {
-            enumerable: true,
-            value: this._scmInfo
-        });
-
-        return this._scmInfo;
     }
 
     /**
@@ -999,14 +977,11 @@ class PipelineModel extends BaseModel {
     update() {
         return this.admin
             .then(user => user.unsealToken())
-            .then(token => this.scmInfo.then(scmInfo =>
-                this.scm.decorateUrl({
-                    scmUri: this.scmUri,
-                    scmContext: this.scmContext,
-                    token,
-                    scmInfo
-                })
-            ))
+            .then(token => this.scm.decorateUrl({
+                scmUri: this.scmUri,
+                scmContext: this.scmContext,
+                token
+            }))
             .then((scmRepo) => {
                 this.scmRepo = scmRepo;
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -180,8 +180,7 @@ describe('Pipeline Model', () => {
             getFile: sinon.stub(),
             decorateUrl: sinon.stub(),
             getOpenedPRs: sinon.stub(),
-            getPrInfo: sinon.stub(),
-            lookupScmUri: sinon.stub()
+            getPrInfo: sinon.stub()
         };
         parserMock = sinon.stub();
 
@@ -215,6 +214,11 @@ describe('Pipeline Model', () => {
             id: testId,
             scmUri,
             scmContext,
+            scmRepo: {
+                branch: 'branch',
+                url: 'https://host/owner/repo/tree/branch',
+                name: 'owner/repo'
+            },
             createTime: dateNow,
             admins,
             scm: scmMock
@@ -296,7 +300,6 @@ describe('Pipeline Model', () => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
             scmMock.addWebhook.resolves();
-            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             parserMock.withArgs('yamlcontentwithscmurls', templateFactoryMock)
                 .resolves(EXTERNAL_PARSED_YAML);
@@ -499,9 +502,10 @@ describe('Pipeline Model', () => {
                         scmContext,
                         path: 'screwdriver.yaml',
                         token: 'foo',
-                        scmInfo: {
+                        scmRepo: {
                             branch: 'branch',
-                            host: 'host'
+                            url: 'https://host/owner/repo/tree/branch',
+                            name: 'owner/repo'
                         }
                     });
                     assert.calledWith(parserMock, 'superyamlcontent', templateFactoryMock);
@@ -739,7 +743,6 @@ describe('Pipeline Model', () => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
             scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge' });
-            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
@@ -763,9 +766,10 @@ describe('Pipeline Model', () => {
                     scmUri,
                     scmContext,
                     token: 'foo',
-                    scmInfo: {
+                    scmRepo: {
                         branch: 'branch',
-                        host: 'host'
+                        url: 'https://host/owner/repo/tree/branch',
+                        name: 'owner/repo'
                     }
                 });
                 assert.called(prJob.update);
@@ -805,9 +809,10 @@ describe('Pipeline Model', () => {
                     scmUri,
                     scmContext,
                     token: 'foo',
-                    scmInfo: {
+                    scmRepo: {
                         branch: 'branch',
-                        host: 'host'
+                        url: 'https://host/owner/repo/tree/branch',
+                        name: 'owner/repo'
                     }
                 });
                 assert.calledOnce(firstPRJob.update);
@@ -849,9 +854,10 @@ describe('Pipeline Model', () => {
                     scmUri,
                     scmContext,
                     token: 'foo',
-                    scmInfo: {
+                    scmRepo: {
                         branch: 'branch',
-                        host: 'host'
+                        url: 'https://host/owner/repo/tree/branch',
+                        name: 'owner/repo'
                     }
                 });
                 assert.calledOnce(firstPRJob.update);
@@ -894,7 +900,6 @@ describe('Pipeline Model', () => {
         beforeEach(() => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
-            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
@@ -960,36 +965,6 @@ describe('Pipeline Model', () => {
                     assert.notCalled(prJob.update);
                     assert.notCalled(jobFactoryMock.create);
                 });
-        });
-    });
-
-    describe('get scmInfo', () => {
-        beforeEach(() => {
-            scmMock.lookupScmUri.resolves({
-                branch: 'test-branch',
-                host: 'test-host',
-                repo: 'test-repo',
-                owner: 'test-owner'
-            });
-        });
-
-        it('has a scmInfo getter', () => {
-            assert.isFunction(pipeline.scmInfo.then);
-            assert.isFunction(pipeline.scmInfo.then);
-            // We want to cache scmInfo to reduce API call
-            assert.calledOnce(scmMock.lookupScmUri);
-        });
-
-        it('rejects when lookupScmUri rejects', () => {
-            const testError = new Error('someGithubCommError');
-
-            scmMock.lookupScmUri.rejects(testError);
-
-            return pipeline.scmInfo.then(() => {
-                assert.fail('This should not fail the test');
-            }).catch((err) => {
-                assert.deepEqual(err, testError);
-            });
         });
     });
 
@@ -1348,7 +1323,6 @@ describe('Pipeline Model', () => {
     describe('getConfiguration', () => {
         beforeEach(() => {
             scmMock.getFile.resolves('superyamlcontent');
-            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
             parserMock.withArgs('', templateFactoryMock).resolves('DEFAULT_YAML');
             getUserPermissionMocks({ username: 'batman', push: true });
@@ -1366,9 +1340,10 @@ describe('Pipeline Model', () => {
                         scmContext,
                         path: 'screwdriver.yaml',
                         token: 'foo',
-                        scmInfo: {
+                        scmRepo: {
                             branch: 'branch',
-                            host: 'host'
+                            url: 'https://host/owner/repo/tree/branch',
+                            name: 'owner/repo'
                         }
                     });
                     assert.calledWith(parserMock, 'superyamlcontent', templateFactoryMock);
@@ -1385,9 +1360,10 @@ describe('Pipeline Model', () => {
                         path: 'screwdriver.yaml',
                         token: 'foo',
                         ref: 'bar',
-                        scmInfo: {
+                        scmRepo: {
                             branch: 'branch',
-                            host: 'host'
+                            url: 'https://host/owner/repo/tree/branch',
+                            name: 'owner/repo'
                         }
                     });
                     assert.calledWith(parserMock, 'superyamlcontent', templateFactoryMock);
@@ -1443,9 +1419,10 @@ describe('Pipeline Model', () => {
                         path: 'screwdriver.yaml',
                         token: 'foo',
                         ref: 'foobar',
-                        scmInfo: {
+                        scmRepo: {
                             branch: 'branch',
-                            host: 'host'
+                            url: 'https://host/owner/repo/tree/branch',
+                            name: 'owner/repo'
                         }
                     });
                     assert.calledWith(parserMock, '', templateFactoryMock);
@@ -1477,7 +1454,6 @@ describe('Pipeline Model', () => {
             };
 
             scmMock.decorateUrl.resolves(scmRepo);
-            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             userFactoryMock.get.withArgs({
                 username: 'd2lam',
                 scmContext
@@ -1499,11 +1475,7 @@ describe('Pipeline Model', () => {
                 assert.calledWith(scmMock.decorateUrl, {
                     scmUri,
                     scmContext,
-                    token: 'foo',
-                    scmInfo: {
-                        branch: 'branch',
-                        host: 'host'
-                    }
+                    token: 'foo'
                 });
                 assert.calledWith(datastore.update, expected);
                 assert.ok(p);
@@ -1526,7 +1498,6 @@ describe('Pipeline Model', () => {
             };
 
             scmMock.decorateUrl.resolves(scmRepo);
-            scmMock.lookupScmUri.resolves({ branch: 'branch', host: 'host' });
             userFactoryMock.get.withArgs({
                 username: 'd2lam',
                 scmContext
@@ -1545,11 +1516,7 @@ describe('Pipeline Model', () => {
                 assert.calledWith(scmMock.decorateUrl, {
                     scmUri,
                     scmContext,
-                    token: 'foo',
-                    scmInfo: {
-                        branch: 'branch',
-                        host: 'host'
-                    }
+                    token: 'foo'
                 });
                 assert.calledWith(datastore.update, expected);
                 assert.ok(p);


### PR DESCRIPTION
## Context
I used scmInfo to reduce API calls. But scmInfo cannot be gotten from pipeline because `lookupScmUri` is private function of scm-github.

## Objective
Pipeline model has scmRepo already, and it includes enough information to construct scmInfo.
Use scmRepo instead of scmInfo because `lookupScmUri` is private.

## References
original issue: screwdriver-cd/screwdriver#1220
related PRs:
scm-github: https://github.com/screwdriver-cd/scm-github/pull/102
data-schema: screwdriver-cd/data-schema#277