### PR TITLE
fix(1220): [1][small] Remove waiting for changedFiles.

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -58,21 +58,6 @@ function syncExternalTriggers(config) {
         });
 }
 
-/**
- * Promise to wait a certain number of seconds
- *
- * Might make this centralized for other tests to leverage
- *
- * @method promiseToWait
- * @param  {Number}      timeToWait  Number of seconds to wait before continuing the chain
- * @return {Promise}
- */
-function promiseToWait(timeToWait) {
-    return new Promise((resolve) => {
-        setTimeout(() => resolve(), timeToWait * 1000);
-    });
-}
-
 class PipelineModel extends BaseModel {
     /**
      * Construct a PipelineModel object
@@ -149,9 +134,7 @@ class PipelineModel extends BaseModel {
                     config.ref = ref;
                 }
 
-                // Github operations are async, we add the wait to ensure we will get latest config
-                return promiseToWait(1.8)
-                    .then(() => this.scm.getFile(config))
+                return this.scm.getFile(config)
                     .catch(() => '');
             })
             // parse the content of the yaml file


### PR DESCRIPTION
## Context
We added the wait to ensure we will get latest config. However, it is enough to wait before getChangedFiles is called.
https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/index.js#L583

## Objective
I removed promiseToWait from pipeline model.

## References
original issue https://github.com/screwdriver-cd/screwdriver/issues/1220#issuecomment-417989327
related PR:
API: screwdriver-cd/screwdriver#1269