### PR TITLE
fix(880): Handle search config for list [3]

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -112,7 +112,7 @@ class BaseFactory {
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
      * @param  {Object}   [config.search]           Search parameters
      * @param  {String}   [config.search.field]     Search field (e.g.: jobName)
-     * @param  {String}   [config.search.term]      Search term (e.g.: %PR-%)
+     * @param  {String}   [config.search.keyword]   Search keyword (e.g.: %PR-%)
      * @param  {String}   [config.sort]             Sorting option ('ascending' or 'descending')
      * @param  {String}   [config.sortBy]           Key to sort by (default is 'id')
      * @return {Promise}

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -110,7 +110,10 @@ class BaseFactory {
      * @param  {Object}   [config.paginate]         Pagination parameters
      * @param  {Number}   [config.paginate.count]   Number of items per page
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
-     * @param  {String}   [config.sort]             Sorting option. 'ascending' or 'descending'
+     * @param  {Object}   [config.search]           Search parameters
+     * @param  {String}   [config.search.field]     Search field (e.g.: jobName)
+     * @param  {String}   [config.search.term]      Search term (e.g.: %PR-%)
+     * @param  {String}   [config.sort]             Sorting option ('ascending' or 'descending')
      * @param  {String}   [config.sortBy]           Key to sort by (default is 'id')
      * @return {Promise}
      */
@@ -119,6 +122,10 @@ class BaseFactory {
             table: this.table,
             params: hoek.reach(config, 'params', { default: {} })
         };
+
+        if (config && config.search) {
+            scanConfig.search = config.search;
+        }
 
         if (config && config.sort) {
             scanConfig.sort = config.sort;

--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
   "dependencies": {
     "async": "^2.6.1",
     "base64url": "^3.0.0",
-    "compare-versions": "^3.3.0",
+    "compare-versions": "^3.4.0",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.5.0",
-    "screwdriver-data-schema": "^18.30.4",
+    "screwdriver-config-parser": "^4.5.3",
+    "screwdriver-data-schema": "^18.32.0",
     "screwdriver-workflow-parser": "^1.6.0",
-    "winston": "^2.4.3"
+    "winston": "^2.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.19.1",
-    "eslint-config-screwdriver": "^3.0.0",
+    "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
     "joi": "^13.6.0",
     "mockery": "^2.0.0",
@@ -53,8 +53,8 @@
     "iron": "^5.0.1",
     "lodash": "^4.17.10",
     "screwdriver-config-parser": "^4.5.3",
-    "screwdriver-data-schema": "^18.32.0",
-    "screwdriver-workflow-parser": "^1.6.0",
+    "screwdriver-data-schema": "^18.32.1",
+    "screwdriver-workflow-parser": "^1.6.1",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -305,7 +305,7 @@ describe('Base Factory', () => {
             factory.list({
                 search: {
                     field: 'scmRepo',
-                    term: '%name%screwdriver-cd/screwdriver%'
+                    keyword: '%name%screwdriver-cd/screwdriver%'
                 }
             })
                 .then(() => {
@@ -314,7 +314,7 @@ describe('Base Factory', () => {
                         params: {},
                         search: {
                             field: 'scmRepo',
-                            term: '%name%screwdriver-cd/screwdriver%'
+                            keyword: '%name%screwdriver-cd/screwdriver%'
                         }
                     });
                 })

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -301,6 +301,25 @@ describe('Base Factory', () => {
                 })
         );
 
+        it('sets search values if they are passed in', () =>
+            factory.list({
+                search: {
+                    field: 'scmRepo',
+                    term: '%name%screwdriver-cd/screwdriver%'
+                }
+            })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        search: {
+                            field: 'scmRepo',
+                            term: '%name%screwdriver-cd/screwdriver%'
+                        }
+                    });
+                })
+        );
+
         it('calls datastore scan with sorting option returns correct values', () =>
             factory.list({ paginate, sort: 'ascending' })
                 .then(() => {


### PR DESCRIPTION
## Context
Since we're adding pagination for pipelines, we can no longer have search functionality stored in the UI. 

## Objective
This PR passes search field and term to the datastore from the `GET /pipelines` endpoint.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880
Blocked by https://github.com/screwdriver-cd/datastore-sequelize/pull/32, https://github.com/screwdriver-cd/data-schema/pull/278