### PR TITLE
fix(1281): include eventId in jwt

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -252,6 +252,7 @@ class BuildModel extends BaseModel {
                     token: this[tokenGen](this.id, {
                         isPR: job.isPR(),
                         jobId: job.id,
+                        eventId: this.eventId,
                         pipelineId: pipeline.id,
                         configPipelineId: pipeline.configPipelineId
                     }, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT) }))

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -12,6 +12,7 @@ describe('Build Model', () => {
     const apiUri = 'https://notify.com/some/endpoint';
     const uiUri = 'https://display.com/some/endpoint';
     const jobId = 777;
+    const eventId = 555;
     const now = 112233445566;
     const buildId = 9876;
     const sha = 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f';
@@ -123,6 +124,7 @@ describe('Build Model', () => {
             container,
             createTime: now,
             jobId,
+            eventId,
             number: now,
             status: 'QUEUED',
             sha,
@@ -495,7 +497,8 @@ describe('Build Model', () => {
                         isPR: false,
                         jobId,
                         pipelineId,
-                        configPipelineId
+                        configPipelineId,
+                        eventId
                     }, scmContext, TEMPORAL_JWT_TIMEOUT);
 
                     assert.calledWith(scmMock.updateCommitStatus, {
@@ -662,6 +665,7 @@ describe('Build Model', () => {
                         isPR: false,
                         jobId,
                         pipelineId,
+                        eventId,
                         configPipelineId
                     }, scmContext, TEMPORAL_JWT_TIMEOUT);
 


### PR DESCRIPTION
Cache service will use `SD_TOKEN` for authenticating. We want to implement cache service for events. But the `eventId` is not included in the jwt, we will need to make an extra call to get `eventId`. It will be faster to include `eventId` in the JWT. 

This PR includes `eventId` in the JWT.
Related: 
https://github.com/screwdriver-cd/screwdriver/issues/1281
https://github.com/screwdriver-cd/screwdriver/issues/1257
