### PR TITLE
fix(880): Save and update pipeline name

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -967,6 +967,7 @@ class PipelineModel extends BaseModel {
             }))
             .then((scmRepo) => {
                 this.scmRepo = scmRepo;
+                this.name = scmRepo.name;
 
                 return super.update();
             });

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -63,6 +63,7 @@ class PipelineFactory extends BaseFactory {
             }))
             .then((scmRepo) => {
                 modelConfig.scmRepo = scmRepo;
+                modelConfig.name = scmRepo.name;
 
                 return super.create(modelConfig);
             });

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.1",
-    "lodash": "^4.17.10",
-    "screwdriver-config-parser": "^4.5.3",
-    "screwdriver-data-schema": "^18.32.1",
+    "lodash": "^4.17.11",
+    "screwdriver-config-parser": "^4.5.4",
+    "screwdriver-data-schema": "^18.32.5",
     "screwdriver-workflow-parser": "^1.6.1",
     "winston": "^2.4.4"
   }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -45,6 +45,11 @@ describe('Pipeline Model', () => {
     const scmContext = 'github:github.com';
     const testId = 123;
     const admins = { batman: true, robin: true };
+    const scmRepo = {
+        name: 'foo/bar',
+        branch: 'master',
+        url: 'https://github.com/foo/bar/tree/master'
+    };
     let jobs;
     let pipelineConfig;
     let publishJob;
@@ -178,7 +183,7 @@ describe('Pipeline Model', () => {
         scmMock = {
             addWebhook: sinon.stub(),
             getFile: sinon.stub(),
-            decorateUrl: sinon.stub(),
+            decorateUrl: sinon.stub().resolves(scmRepo),
             getOpenedPRs: sinon.stub(),
             getPrInfo: sinon.stub()
         };
@@ -1431,17 +1436,12 @@ describe('Pipeline Model', () => {
     });
 
     describe('update', () => {
-        const scmRepo = {
-            name: 'foo/bar',
-            branch: 'master',
-            url: 'https://github.com/foo/bar/tree/master'
-        };
-
         it('updates a pipelines scm repository and branch', () => {
             const expected = {
                 params: {
                     admins: { d2lam: true },
                     id: 123,
+                    name: 'foo/bar',
                     scmContext,
                     scmRepo: {
                         branch: 'master',
@@ -1453,7 +1453,6 @@ describe('Pipeline Model', () => {
                 table: 'pipelines'
             };
 
-            scmMock.decorateUrl.resolves(scmRepo);
             userFactoryMock.get.withArgs({
                 username: 'd2lam',
                 scmContext
@@ -1487,6 +1486,7 @@ describe('Pipeline Model', () => {
                 params: {
                     admins: { d2lam: true },
                     id: 123,
+                    name: 'foo/bar',
                     scmContext,
                     scmRepo: {
                         branch: 'master',
@@ -1497,7 +1497,6 @@ describe('Pipeline Model', () => {
                 table: 'pipelines'
             };
 
-            scmMock.decorateUrl.resolves(scmRepo);
             userFactoryMock.get.withArgs({
                 username: 'd2lam',
                 scmContext

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -104,6 +104,7 @@ describe('Pipeline Factory', () => {
             params: {
                 admins,
                 createTime: nowTime,
+                name: scmRepo.name,
                 scmUri,
                 scmContext,
                 scmRepo


### PR DESCRIPTION
## Context
It's hard to do operations in the UI based on the pipeline name when it is stored in a JSON string in the DB under `scmRepo`.

## Objective
This PR saves and updates the pipeline `name` field at the root level of a pipeline when `scmRepo` is saved/updated.

## Related links
Blocked by https://github.com/screwdriver-cd/data-schema/pull/283
Related to https://github.com/screwdriver-cd/screwdriver/issues/880