### PR TITLE
fix(1271): Add option to return raw data for datastore scan [3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ factory.list(config).then(pipelines => {
 | config        | Object | Config Object |
 | config.paginate.page | Number | The page for pagination |
 | config.paginate.count | Number | The count for pagination |
-| config.params | Object | fields to search on |
+| config.params | Object | Fields to search on |
+| config.raw | Boolean | Whether to return raw data or not |
+| config.search | Object | Search parameters |
+| config.search.field | String or Array | Search field(s) (e.g.: jobName) |
+| config.search.keyword | String | Search keyword (e.g.: %PR-%) |
 | config.sort | String | Order to sort by (`ascending` or `descending`) |
 | config.sortBy | String | Key to sort by (default `id`) |
 

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -110,6 +110,7 @@ class BaseFactory {
      * @param  {Object}   [config.paginate]         Pagination parameters
      * @param  {Number}   [config.paginate.count]   Number of items per page
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
+     * @param  {Boolean}  [config.raw]              Whether to return raw data or not
      * @param  {Object}   [config.search]           Search parameters
      * @param  {String}   [config.search.field]     Search field (e.g.: jobName)
      * @param  {String}   [config.search.keyword]   Search keyword (e.g.: %PR-%)
@@ -144,12 +145,17 @@ class BaseFactory {
             };
         }
 
+        if (config && config.raw) {
+            return this.datastore.scan(scanConfig);
+        }
+
         return this.datastore.scan(scanConfig)
             .then((data) => {
                 if (!Array.isArray(data)) {
                     throw new Error('Unexpected response from datastore, ' +
                         `expected Array, got ${typeof data}`);
                 }
+
                 const result = [];
 
                 data.forEach((item) => {

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -105,17 +105,17 @@ class BaseFactory {
     /**
      * List records with pagination and filter options
      * @method list
-     * @param  {Object}   [config]
-     * @param  {Object}   [config.params]           Parameters to filter on
-     * @param  {Object}   [config.paginate]         Pagination parameters
-     * @param  {Number}   [config.paginate.count]   Number of items per page
-     * @param  {Number}   [config.paginate.page]    Specific page of the set to return
-     * @param  {Boolean}  [config.raw]              Whether to return raw data or not
-     * @param  {Object}   [config.search]           Search parameters
-     * @param  {String}   [config.search.field]     Search field (e.g.: jobName)
-     * @param  {String}   [config.search.keyword]   Search keyword (e.g.: %PR-%)
-     * @param  {String}   [config.sort]             Sorting option ('ascending' or 'descending')
-     * @param  {String}   [config.sortBy]           Key to sort by (default is 'id')
+     * @param  {Object}         [config]
+     * @param  {Object}         [config.params]           Parameters to filter on
+     * @param  {Object}         [config.paginate]         Pagination parameters
+     * @param  {Number}         [config.paginate.count]   Number of items per page
+     * @param  {Number}         [config.paginate.page]    Specific page of the set to return
+     * @param  {Boolean}        [config.raw]              Whether to return raw data or not
+     * @param  {Object}         [config.search]           Search parameters
+     * @param  {String|Array}   [config.search.field]     Search field(s) (e.g.: jobName)
+     * @param  {String}         [config.search.keyword]   Search keyword (e.g.: %PR-%)
+     * @param  {String}         [config.sort]             Sorting option ('ascending' or 'descending')
+     * @param  {String}         [config.sortBy]           Key to sort by (default is 'id')
      * @return {Promise}
      */
     list(config) {

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -332,6 +332,36 @@ describe('Base Factory', () => {
                 })
         );
 
+        it('returns raw scan results when raw is true', () => {
+            const distinctRows = [
+                'namespace1',
+                'namespace2',
+                'namespace3'
+            ];
+
+            datastore.scan.resolves(distinctRows);
+
+            return factory.list({
+                params: {
+                    distinct: 'namespace'
+                },
+                raw: true
+            })
+                .then((data) => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {
+                            distinct: 'namespace'
+                        }
+                    });
+                    assert.deepEqual(data, [
+                        'namespace1',
+                        'namespace2',
+                        'namespace3'
+                    ]);
+                });
+        });
+
         it('handles when the scan does not return an array', () => {
             datastore.scan.resolves(null);
 


### PR DESCRIPTION
## Context
When trying to get all distinct namespaces in templates, you should get an array of namespace strings, instead of an array of template objects.

## Objective
This PR changes the `list` function to take in a flag to return raw data.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1271, https://github.com/screwdriver-cd/datastore-sequelize/pull/35