### PR TITLE
[2][small] stop no pipeline pod

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -197,7 +197,11 @@ class Job extends BaseModel {
                     return null;
                 }
 
-                return Promise.all(builds.map(build => build.remove()))
+                return Promise.all(builds.map((build) => {
+                    this[executor].stop({ buildId: build.id });
+
+                    return build.remove();
+                }))
                     .then(() => removeBuilds());
             }));
 

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -369,6 +369,7 @@ describe('Job Model', () => {
                 assert.callCount(build1.remove, 4); // remove builds recursively
                 assert.callCount(build2.remove, 4);
                 assert.calledOnce(datastore.remove); // remove the job
+                assert.callCount(executorMock.stop, 8);
                 assert.notCalled(executorMock.stopPeriodic);
             });
         });

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -94,7 +94,8 @@ describe('Job Model', () => {
 
         executorMock = {
             startPeriodic: sinon.stub().resolves(null),
-            stopPeriodic: sinon.stub().resolves(null)
+            stopPeriodic: sinon.stub().resolves(null),
+            stop: sinon.stub().resolves(null)
         };
 
         tokenGen = sinon.stub().returns(token);


### PR DESCRIPTION
## Context
Our SD cluster sometime has a lof pods which has no pipeline. To prevent wasteful consumption of resources, I add codes to stop pods when a pipeline is deleted.

## Objective
A pod is terminated when the pipeline is deleted.

## Related PR
https://github.com/screwdriver-cd/executor-queue/pull/34
