### PR TITLE
fix(1319): pass buildClusterName to executor if it exists

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -242,20 +242,29 @@ class BuildModel extends BaseModel {
         // Make sure that a pipeline and job is associated with the build
         return this.job.then(job =>
             job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
-                .then(blockedBy => this[executor].start({
-                    jobId: job.id,
-                    annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
-                    blockedBy,
-                    apiUri: this[apiUri],
-                    buildId: this.id,
-                    container: this.container,
-                    token: this[tokenGen](this.id, {
-                        isPR: job.isPR(),
+                .then((blockedBy) => {
+                    const config = {
                         jobId: job.id,
-                        eventId: this.eventId,
-                        pipelineId: pipeline.id,
-                        configPipelineId: pipeline.configPipelineId
-                    }, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT) }))
+                        annotations: hoek.reach(job.permutations[0],
+                            'annotations', { default: {} }),
+                        blockedBy,
+                        apiUri: this[apiUri],
+                        buildId: this.id,
+                        container: this.container,
+                        token: this[tokenGen](this.id, {
+                            isPR: job.isPR(),
+                            jobId: job.id,
+                            eventId: this.eventId,
+                            pipelineId: pipeline.id,
+                            configPipelineId: pipeline.configPipelineId
+                        }, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT) };
+
+                    if (this.buildClusterName) {
+                        config.buildClusterName = this.buildClusterName;
+                    }
+
+                    return this[executor].start(config);
+                })
                 .then(() => this.updateCommitStatus(pipeline))) // update github
                 .then(() => this)
         );
@@ -326,12 +335,20 @@ class BuildModel extends BaseModel {
         return this.job
             .then(job => job.pipeline
                 .then(pipeline => getBlockedByIds(pipeline, job))
-                .then(blockedBy => this[executor].stop({
-                    annotations: job.permutations[0].annotations,
-                    blockedBy,
-                    buildId: this.id,
-                    jobId: job.id
-                })))
+                .then((blockedBy) => {
+                    const config = {
+                        annotations: job.permutations[0].annotations,
+                        blockedBy,
+                        buildId: this.id,
+                        jobId: job.id
+                    };
+
+                    if (this.buildClusterName) {
+                        config.buildClusterName = this.buildClusterName;
+                    }
+
+                    return this[executor].stop(config);
+                }))
             .then(() => this);
     }
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -412,6 +412,21 @@ describe('Build Model', () => {
                 })
         );
 
+        it('passes buildClusterName to executor when it exists', () => {
+            build.buildClusterName = 'sd';
+
+            return build.stop()
+                .then(() => {
+                    assert.calledWith(executorMock.stop, {
+                        buildId,
+                        buildClusterName: 'sd',
+                        jobId,
+                        annotations,
+                        blockedBy: [jobId]
+                    });
+                });
+        });
+
         it('rejects on executor failure', () => {
             const expectedError = new Error('cantStopTheRock');
 
@@ -513,6 +528,43 @@ describe('Build Model', () => {
                     });
                 })
         );
+
+        it('passes buildClusterName to executor if it exists', () => {
+            build.buildClusterName = 'sd';
+
+            return build.start()
+                .then(() => {
+                    assert.calledWith(executorMock.start, {
+                        jobId,
+                        annotations,
+                        blockedBy: [jobId],
+                        apiUri,
+                        buildId,
+                        buildClusterName: 'sd',
+                        container,
+                        token
+                    });
+
+                    assert.calledWith(tokenGen, buildId, {
+                        isPR: false,
+                        jobId,
+                        pipelineId,
+                        configPipelineId,
+                        eventId
+                    }, scmContext, TEMPORAL_JWT_TIMEOUT);
+
+                    assert.calledWith(scmMock.updateCommitStatus, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'main',
+                        buildStatus: 'QUEUED',
+                        url,
+                        pipelineId
+                    });
+                });
+        });
 
         it('get internal blockedby job Ids and pass to executor start', () => {
             const blocking1 = {


### PR DESCRIPTION
pass buildClusterName to executor if it exists

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1319