### PR TITLE
[4] feat(1010): enable prChain

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -91,9 +91,6 @@ function getJobsFromPR(config) {
         prChain
     });
 
-    console.log('===== nextJobs ======');
-    console.log(nextJobs);
-
     const jobsToStart = jobs.filter(
         j => j.name.startsWith(`PR-${prNum}:`) || nextJobs.includes(j.name)
     );
@@ -145,8 +142,6 @@ function startBuild(config) {
                 return isMatch;
             }));
     }
-
-    console.log(buildConfig);
 
     return hasChangeInSourcePaths ? buildFactory.create(buildConfig) : null;
 }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -67,16 +67,17 @@ function getJobsFromJobName(config) {
 /**
  * Get PR jobs to start that are enabled
  * @method getJobsFromPR
- * @param  {Object}   config
- * @param  {Array}    config.jobs                           Array of job objects
- * @param  {Number}   config.prNum                          PR number
- * @param  {Object}   config.pipelineConfig
- * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
- * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
- * @resolves {Array}                                        Array of PR jobs to start
+ * @param  {Object}    config
+ * @param  {Array}     config.jobs                           Array of job objects
+ * @param  {Number}    config.prNum                          PR number
+ * @param  {Object}    config.pipelineConfig
+ * @param  {Object}    config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
+ * @param  {String}    config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
+ * @param  {Boolean}   config.prChain                        Flag of triggering subsequent job after pull request job
+ * @resolves {Array}                                         Array of PR jobs to start
  */
 function getJobsFromPR(config) {
-    const { jobs, prNum, pipelineConfig, startFrom } = config;
+    const { jobs, prNum, pipelineConfig, startFrom, prChain } = config;
     const isPRTrigger = PR_TRIGGER.test(startFrom);
 
     if (!isPRTrigger) {
@@ -85,7 +86,8 @@ function getJobsFromPR(config) {
 
     const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
         trigger: startFrom,
-        prNum
+        prNum,
+        prChain
     });
 
     const jobsToStart = jobs.filter(
@@ -194,7 +196,8 @@ function createBuilds(config) {
             jobs,
             prNum: eventConfig.prNum,
             pipelineConfig,
-            startFrom
+            startFrom,
+            prChain: pipeline.prChain
         });
 
         return Promise.all([jobsFromTrigger, jobsFromJobName, jobsFromPR])

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -7,7 +7,8 @@ const {
     COMMIT_TRIGGER,
     PR_TRIGGER
 } = require('screwdriver-data-schema').config.regex;
-const workflowParser = require('screwdriver-workflow-parser');
+// const workflowParser = require('screwdriver-workflow-parser');
+const workflowParser = require('../../../workflow-parser');
 
 let instance;
 
@@ -90,6 +91,9 @@ function getJobsFromPR(config) {
         prChain
     });
 
+    console.log('===== nextJobs ======');
+    console.log(nextJobs);
+
     const jobsToStart = jobs.filter(
         j => j.name.startsWith(`PR-${prNum}:`) || nextJobs.includes(j.name)
     );
@@ -141,6 +145,8 @@ function startBuild(config) {
                 return isMatch;
             }));
     }
+
+    console.log(buildConfig);
 
     return hasChangeInSourcePaths ? buildFactory.create(buildConfig) : null;
 }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -7,8 +7,7 @@ const {
     COMMIT_TRIGGER,
     PR_TRIGGER
 } = require('screwdriver-data-schema').config.regex;
-// const workflowParser = require('screwdriver-workflow-parser');
-const workflowParser = require('../../../workflow-parser');
+const workflowParser = require('screwdriver-workflow-parser');
 
 let instance;
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -355,7 +355,7 @@ class PipelineModel extends BaseModel {
                 let jobsToArchive;
                 let jobsToUnarchive;
 
-                winston.info(`prChain flag is ${this.prChain}.`);
+                winston.info(`pipelineId:${this.id}: prChain flag is ${this.prChain}.`);
                 if (this.prChain) {
                     jobsToCreate = [];
                     jobsToArchive = prJobs;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -187,9 +187,9 @@ class PipelineModel extends BaseModel {
         openedPRsNames.forEach((name, i) => {
             const matchedPRs = existingPRs.filter(job => job.name.startsWith(name));
 
-            // if opened PR was previously archived, unarchive it
+            // if opened PR was previously archived and prChain flag is false, unarchive it
             matchedPRs.forEach((job) => {
-                if (job.archived) {
+                if (job.archived && this.prChain === false) {
                     jobList.toUnarchive.push(job);
                 }
             });
@@ -355,6 +355,7 @@ class PipelineModel extends BaseModel {
                 let jobsToArchive;
                 let jobsToUnarchive;
 
+                winston.info(`prChain flag is ${this.prChain}.`);
                 if (this.prChain) {
                     jobsToCreate = [];
                     jobsToArchive = prJobs;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -221,6 +221,7 @@ class PipelineModel extends BaseModel {
                 j.permutations = parsedConfig.jobs[jobName];
             }
             j.archived = archived;
+            if (archived) winston.info(`${j.name} job of pipeline ${this.id} is archived`);
             jobsToUpdate.push(j.update());
         });
 
@@ -316,8 +317,8 @@ class PipelineModel extends BaseModel {
      * Update the permutations to be correct
      * Create missing PR jobs
      * @param   {Number}   prNum        PR Number
-     * @method syncPR
-     * @return {Promise}
+     * @method  syncPR
+     * @return  {Promise}
      */
     syncPR(prNum) {
         return this.admin
@@ -342,17 +343,28 @@ class PipelineModel extends BaseModel {
                 // Get next jobs for when startFrom is ~pr
                 const nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
                     trigger: '~pr',
-                    prNum
+                    prNum,
+                    prChain: this.prChain
                 });
 
                 // Get all the missing PR- job names
-                const existingPRJobNames = prJobs.map(p => p.name);
-                const missingPRJobNames = nextJobs.filter(j => !existingPRJobNames.includes(j));
+                const existingPRJobNames = prJobs.map(prJob => prJob.name);
+                const missingPRJobNames =
+                    nextJobs.filter(nextJob => !existingPRJobNames.includes(nextJob));
+                let jobsToCreate;
+                let jobsToArchive;
+                let jobsToUnarchive;
 
-                // Get the job name part, e.g. main from PR-1:main to create job
-                const jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
-                const jobsToArchive = prJobs.filter(p => !nextJobs.includes(p.name));
-                const jobsToUnarchive = prJobs.filter(p => nextJobs.includes(p.name));
+                if (this.prChain) {
+                    jobsToCreate = [];
+                    jobsToArchive = prJobs;
+                    jobsToUnarchive = [];
+                } else {
+                    // Get the job name part, e.g. main from PR-1:main to create job
+                    jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
+                    jobsToArchive = prJobs.filter(prJob => !nextJobs.includes(prJob.name));
+                    jobsToUnarchive = prJobs.filter(prJob => nextJobs.includes(prJob.name));
+                }
 
                 // Lazy load factory dependency to prevent circular dependency issues
                 // https://nodejs.org/api/modules.html#modules_cycles
@@ -555,6 +567,7 @@ class PipelineModel extends BaseModel {
 
                 return parsedConfig;
             }).then((parsedConfig) => {
+                this.prChain = parsedConfig.prChain;
                 this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -573,6 +573,28 @@ describe('Event Factory', () => {
                     }));
                 });
             });
+
+            it('should create build of the "main" job with prChain config', () => {
+                config.startFrom = '~pr';
+                config.prRef = 'branch';
+                config.prNum = 1;
+                config.webhooks = true;
+
+                afterSyncedPRPipelineMock.jobs = Promise.resolve(jobsMock);
+                afterSyncedPRPipelineMock.prChain = true;
+                afterSyncedPRPipelineMock.update = sinon.stub().resolves(afterSyncedPRPipelineMock);
+
+                return eventFactory.create(config).then((model) => {
+                    assert.instanceOf(model, Event);
+                    assert.notCalled(jobFactoryMock.create);
+                    assert.calledWith(buildFactoryMock.create, sinon.match({
+                        parentBuildId: 12345,
+                        eventId: model.id,
+                        jobId: 1,
+                        prRef: 'branch'
+                    }));
+                });
+            });
         });
 
         it('should create an Event', () =>

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -980,7 +980,8 @@ describe('Pipeline Model', () => {
                 });
         });
 
-        it('unarchive PR job if it was previously archived', () => {
+        it('unarchive PR job if it was previously archived and prChain is false.', () => {
+            pipeline.prChain = false;
             prJob.archived = true;
             scmMock.getOpenedPRs.resolves([{ name: 'PR-1', ref: 'abc' }]);
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -493,6 +493,22 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('stores prChain to pipeline', () => {
+            const configMock = Object.assign({}, PARSED_YAML);
+
+            configMock.prChain = true;
+            parserMock.withArgs('superyamlcontent', templateFactoryMock)
+                .resolves(configMock);
+            jobs = [];
+            jobFactoryMock.list.resolves(jobs);
+            jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
+            jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
+
+            return pipeline.sync().then(() => {
+                assert.equal(pipeline.prChain, true);
+            });
+        });
+
         it('creates new jobs', () => {
             jobs = [];
             jobFactoryMock.list.resolves(jobs);
@@ -896,6 +912,19 @@ describe('Pipeline Model', () => {
             return pipeline.syncPR(1).catch((err) => {
                 assert.deepEqual(err, error);
             });
+        });
+
+        it('archives old PR job and does not create a PR job if prChain is true', () => {
+            jobs = [mainJob, prJob];
+            jobFactoryMock.list.resolves(jobs);
+            pipeline.prChain = true;
+
+            return pipeline.syncPR(1)
+                .then(() => {
+                    assert.calledOnce(prJob.update);
+                    assert.equal(prJob.archived, true);
+                    assert.notCalled(jobFactoryMock.create);
+                });
         });
     });
 


### PR DESCRIPTION
## Context
We want to implement `prChain` feature. If `prChain` is true, a job name does not have `PR-` prefix and will trigger subsequent jobs. 

## Objective
Pass to `prChain` to workflow-parser and store `prChain` to a pipeline.

## Misc.
Related Issue: https://github.com/screwdriver-cd/screwdriver/issues/1010
Related PRs:
- https://github.com/screwdriver-cd/data-schema/pull/296
- https://github.com/screwdriver-cd/config-parser/pull/81
- https://github.com/screwdriver-cd/workflow-parser/pull/15