### PR TITLE
[2] fix: Add `prParentJobId` field

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -361,18 +361,47 @@ class PipelineModel extends BaseModel {
                 /* eslint-enable global-require */
                 const jobFactory = JobFactory.getInstance();
 
-                // Create missing PR jobs
-                return Promise.all(jobsToCreate.map(jobName =>
-                    // Create jobs
-                    jobFactory.create({
-                        permutations: parsedConfig.jobs[jobName],
-                        pipelineId: this.id,
-                        name: `PR-${prNum}:${jobName}`
-                    })))
-                    .then(() => Promise.all([
-                        this._updateJobArchive(jobsToArchive, true),
-                        this._updateJobArchive(jobsToUnarchive, false, parsedConfig)
-                    ]));
+                return this.getJobs({ type: 'pipeline' })
+                    .then((pJobs) => {
+                        console.log(pJobs);
+
+                        // filter to keep only the jobs to create from pipeline jobs
+                        const pipelineJobs = pJobs.filter(j => jobsToCreate.includes(j.name));
+
+                        // create a map for PR Parent Jobs like: {main: 1, publish: 2}
+                        const prParentJobIdMap = {};
+
+                        pipelineJobs.forEach((j) => {
+                            prParentJobIdMap[j.name] = j.id;
+                        });
+
+                        console.log(prParentJobIdMap);
+
+                        // Create missing PR jobs
+                        return Promise.all(jobsToCreate.map((jobName) => {
+                            const jobModel = {
+                                permutations: parsedConfig.jobs[jobName],
+                                pipelineId: this.id,
+                                name: `PR-${prNum}:${jobName}`
+                            };
+
+                            // If there is a pr parent
+                            if (prParentJobIdMap[jobName]) {
+                                jobModel.prParentJobIdMap = prParentJobIdMap[jobName];
+                            }
+
+                            // Create jobs
+                            return jobFactory.create({
+                                permutations: parsedConfig.jobs[jobName],
+                                pipelineId: this.id,
+                                name: `PR-${prNum}:${jobName}`
+                            });
+                        }))
+                            .then(() => Promise.all([
+                                this._updateJobArchive(jobsToArchive, true),
+                                this._updateJobArchive(jobsToUnarchive, false, parsedConfig)
+                            ]));
+                    });
             })
             .then(() => delete this.jobs) // so that next time it will not get the cached version of this.jobs
             .then(() => this);
@@ -906,6 +935,8 @@ class PipelineModel extends BaseModel {
 
         return jobFactory.list(listConfig)
             .then((jobs) => {
+                jobs.forEach(j => console.log(j.name));
+
                 // get PR jobs
                 const prJobs = jobs
                     .filter(j => j.isPR() && j.archived === listConfig.params.archived)
@@ -913,6 +944,8 @@ class PipelineModel extends BaseModel {
 
                 const pipelineJobs = jobs
                     .filter(j => !j.isPR() && j.archived === listConfig.params.archived);
+
+                console.log(pipelineJobs);
 
                 if (config && config.type === 'pr') {
                     return prJobs;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -338,6 +338,7 @@ class PipelineModel extends BaseModel {
             ]))
             .then(([parsedConfig, jobs]) => {
                 const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}`));
+                const pJobs = jobs.filter(j => !j.name.startsWith(`PR-${prNum}`));
 
                 // Get next jobs for when startFrom is ~pr
                 const nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
@@ -361,47 +362,36 @@ class PipelineModel extends BaseModel {
                 /* eslint-enable global-require */
                 const jobFactory = JobFactory.getInstance();
 
-                return this.getJobs({ type: 'pipeline' })
-                    .then((pJobs) => {
-                        console.log(pJobs);
+                // filter to keep only the jobs to create from pipeline jobs
+                const pipelineJobs = pJobs.filter(j => jobsToCreate.includes(j.name));
 
-                        // filter to keep only the jobs to create from pipeline jobs
-                        const pipelineJobs = pJobs.filter(j => jobsToCreate.includes(j.name));
+                // create a map for PR Parent Jobs like: {main: 1, publish: 2}
+                const prParentJobIdMap = {};
 
-                        // create a map for PR Parent Jobs like: {main: 1, publish: 2}
-                        const prParentJobIdMap = {};
+                pipelineJobs.forEach((j) => {
+                    prParentJobIdMap[j.name] = j.id;
+                });
 
-                        pipelineJobs.forEach((j) => {
-                            prParentJobIdMap[j.name] = j.id;
-                        });
+                // Create missing PR jobs
+                return Promise.all(jobsToCreate.map((jobName) => {
+                    const jobModel = {
+                        permutations: parsedConfig.jobs[jobName],
+                        pipelineId: this.id,
+                        name: `PR-${prNum}:${jobName}`
+                    };
 
-                        console.log(prParentJobIdMap);
+                    // If there is a pr parent
+                    if (prParentJobIdMap[jobName]) {
+                        jobModel.prParentJobIdMap = prParentJobIdMap[jobName];
+                    }
 
-                        // Create missing PR jobs
-                        return Promise.all(jobsToCreate.map((jobName) => {
-                            const jobModel = {
-                                permutations: parsedConfig.jobs[jobName],
-                                pipelineId: this.id,
-                                name: `PR-${prNum}:${jobName}`
-                            };
-
-                            // If there is a pr parent
-                            if (prParentJobIdMap[jobName]) {
-                                jobModel.prParentJobIdMap = prParentJobIdMap[jobName];
-                            }
-
-                            // Create jobs
-                            return jobFactory.create({
-                                permutations: parsedConfig.jobs[jobName],
-                                pipelineId: this.id,
-                                name: `PR-${prNum}:${jobName}`
-                            });
-                        }))
-                            .then(() => Promise.all([
-                                this._updateJobArchive(jobsToArchive, true),
-                                this._updateJobArchive(jobsToUnarchive, false, parsedConfig)
-                            ]));
-                    });
+                    // Create jobs
+                    return jobFactory.create(jobModel);
+                }))
+                    .then(() => Promise.all([
+                        this._updateJobArchive(jobsToArchive, true),
+                        this._updateJobArchive(jobsToUnarchive, false, parsedConfig)
+                    ]));
             })
             .then(() => delete this.jobs) // so that next time it will not get the cached version of this.jobs
             .then(() => this);
@@ -935,8 +925,6 @@ class PipelineModel extends BaseModel {
 
         return jobFactory.list(listConfig)
             .then((jobs) => {
-                jobs.forEach(j => console.log(j.name));
-
                 // get PR jobs
                 const prJobs = jobs
                     .filter(j => j.isPR() && j.archived === listConfig.params.archived)
@@ -944,8 +932,6 @@ class PipelineModel extends BaseModel {
 
                 const pipelineJobs = jobs
                     .filter(j => !j.isPR() && j.archived === listConfig.params.archived);
-
-                console.log(pipelineJobs);
 
                 if (config && config.type === 'pr') {
                     return prJobs;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -398,7 +398,7 @@ class PipelineModel extends BaseModel {
 
                     // If there is a pr parent
                     if (prParentJobIdMap[jobName]) {
-                        jobModel.prParentJobIdMap = prParentJobIdMap[jobName];
+                        jobModel.prParentJobId = prParentJobIdMap[jobName];
                     }
 
                     // Create jobs

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -233,7 +233,7 @@ class PipelineModel extends BaseModel {
      * @param  {Array}      prList       Array of PR names and refs
      * @return {Promise}
      */
-    _createPRJob(prList) {
+    _createPRJob(allJobs, prList) {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -247,9 +247,21 @@ class PipelineModel extends BaseModel {
                 ref: pr.ref,
                 isPR: true
             }).then((config) => {
+                const prNum = pr.name.split('-')[1];
                 const prJobNames = workflowParser.getNextJobs(config.workflowGraph, {
                     trigger: '~pr',
-                    prNum: pr.name.split('-')[1]
+                    prNum
+                });
+
+                // filter to keep only the pipeline jobs that include in the jobsToCreate list
+                const prFromPipelineJobs = allJobs.filter(j =>
+                    !j.name.startsWith('PR-') && prJobNames.includes(`PR-${prNum}:${j.name}`));
+
+                // create a map for PR Parent Jobs like: {main: 1, publish: 2}
+                const prParentJobIdMap = {};
+
+                prFromPipelineJobs.forEach((j) => {
+                    prParentJobIdMap[j.name] = j.id;
                 });
 
                 return Promise.all[prJobNames.map((name) => {
@@ -260,6 +272,10 @@ class PipelineModel extends BaseModel {
                         name,
                         permutations: config.jobs[jobName]
                     };
+
+                    if (prParentJobIdMap[jobName]) {
+                        jobConfig.prParentJobId = prParentJobIdMap[jobName];
+                    }
 
                     return factory.create(jobConfig);
                 })];
@@ -304,7 +320,7 @@ class PipelineModel extends BaseModel {
                 const jobList = this._checkPRState(existingJobs, openedPRs);
 
                 return Promise.all([
-                    this._createPRJob(jobList.toCreate),
+                    this._createPRJob(existingJobs, jobList.toCreate),
                     this._updateJobArchive(jobList.toArchive, true),
                     this._updateJobArchive(jobList.toUnarchive, false)
                 ]);
@@ -338,7 +354,6 @@ class PipelineModel extends BaseModel {
             ]))
             .then(([parsedConfig, jobs]) => {
                 const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}`));
-                const pJobs = jobs.filter(j => !j.name.startsWith(`PR-${prNum}`));
 
                 // Get next jobs for when startFrom is ~pr
                 const nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
@@ -362,13 +377,14 @@ class PipelineModel extends BaseModel {
                 /* eslint-enable global-require */
                 const jobFactory = JobFactory.getInstance();
 
-                // filter to keep only the jobs to create from pipeline jobs
-                const pipelineJobs = pJobs.filter(j => jobsToCreate.includes(j.name));
+                // filter to keep only the pipeline jobs that include in the jobsToCreate list
+                const prFromPipelineJobs = jobs.filter(j =>
+                    !j.name.startsWith(`PR-${prNum}`) && jobsToCreate.includes(j.name));
 
                 // create a map for PR Parent Jobs like: {main: 1, publish: 2}
                 const prParentJobIdMap = {};
 
-                pipelineJobs.forEach((j) => {
+                prFromPipelineJobs.forEach((j) => {
                     prParentJobIdMap[j.name] = j.id;
                 });
 

--- a/package.json
+++ b/package.json
@@ -40,19 +40,19 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
-    "joi": "^13.6.0",
+    "joi": "^13.7.0",
     "mockery": "^2.0.0",
     "sinon": "^4.5.0"
   },
   "dependencies": {
     "async": "^2.6.1",
-    "base64url": "^3.0.0",
+    "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
-    "iron": "^5.0.1",
+    "iron": "^5.0.6",
     "lodash": "^4.17.11",
-    "screwdriver-config-parser": "^4.5.4",
+    "screwdriver-config-parser": "^4.7.0",
     "screwdriver-data-schema": "^18.33.5",
     "screwdriver-workflow-parser": "^1.6.1",
     "winston": "^2.4.4"

--- a/test/data/parserWithWorkflowGraphPR.json
+++ b/test/data/parserWithWorkflowGraphPR.json
@@ -56,21 +56,25 @@
                 "requires": ["~pr", "~commit", "~sd@12345:test"]
             }
         ],
+        "test": [
+            {
+                "image": "node:10",
+                "commands": [
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "requires": ["~pr"]
+            }
+        ],
         "publish": [
             {
                 "image": "node:4",
                 "commands": [
                     {
-                        "name": "bump",
-                        "command": "npm run bump"
-                    },
-                    {
                         "name": "publish",
                         "command": "npm publish --tag $NODE_TAG"
-                    },
-                    {
-                        "name": "tag",
-                        "command": "git push origin --tags"
                     }
                 ],
                 "environment": {
@@ -98,11 +102,13 @@
             { "name": "~pr" },
             { "name": "~commit" },
             { "name": "main" },
+            { "name": "test" },
             { "name": "publish" },
             { "name": "new_pr_job" }
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
+            { "src": "~pr", "dest": "test" },
             { "src": "~pr", "dest": "new_pr_job" },
             { "src": "~commit", "dest": "main" },
             { "src": "main", "dest": "publish" }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -918,11 +918,11 @@ describe('Pipeline Model', () => {
             prJob = {
                 update: sinon.stub().resolves(null),
                 isPR: sinon.stub().returns(true),
-                name: 'PR-1',
+                name: 'PR-1:main',
                 state: 'ENABLED',
                 archived: false
             };
-            jobs = [mainJob, prJob];
+            jobs = [mainJob, publishJob, prJob];
             jobFactoryMock.list.resolves(jobs);
         });
 
@@ -940,7 +940,7 @@ describe('Pipeline Model', () => {
             prJob.archived = true;
             const prJob2 = {
                 pipelineId: testId,
-                name: 'PR-2',
+                name: 'PR-2:main',
                 permutations: PARSED_YAML.jobs.main
             };
 
@@ -952,7 +952,8 @@ describe('Pipeline Model', () => {
                     assert.calledWith(jobFactoryMock.create, {
                         pipelineId: testId,
                         name: 'PR-2:main',
-                        permutations: PARSED_YAML.jobs.main
+                        permutations: PARSED_YAML.jobs.main,
+                        prParentJobId: 99998
                     });
                 });
         });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -783,7 +783,8 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('update PR config for multiple PR jobs and create missing PR jobs', () => {
+        it.only('update PR config for multiple PR jobs and create missing PR jobs', () => {
+            const jobList = [publishJob, mainJob, pr10, pr3];
             const firstPRJob = {
                 update: sinon.stub().resolves(null),
                 isPR: sinon.stub().returns(true),
@@ -800,12 +801,13 @@ describe('Pipeline Model', () => {
             };
             const clonedYAML = JSON.parse(JSON.stringify(PARSED_YAML_PR));
 
+            jobFactoryMock.list.onCall(0).resolves(jobList);
+            jobFactoryMock.list.onCall(1).resolves([firstPRJob, secondPRJob]);
+            parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(clonedYAML);
+
             clonedYAML.workflowGraph.edges.push({
                 src: '~pr', dest: 'publish'
             });
-
-            jobFactoryMock.list.resolves([firstPRJob, secondPRJob]);
-            parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(clonedYAML);
 
             return pipeline.syncPR(1).then(() => {
                 assert.calledWith(scmMock.getFile, {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -827,7 +827,7 @@ describe('Pipeline Model', () => {
                         requires: ['~pr']
                     }],
                     pipelineId: 123,
-                    prParentJobIdMap: 100
+                    prParentJobId: 100
 
                 });
                 assert.calledWith(jobFactoryMock.create.secondCall, sinon.match({


### PR DESCRIPTION
When create PR jobs, also add a field called `prParentJobId` to references the real job. 
For example, if `main` exists, then `PR-1:main` should have this field to reference the `main` job
If `main` doesn't exist yet, then this field will not be there. 

Blocked By: https://github.com/screwdriver-cd/data-schema/pull/297/files
Related: https://github.com/screwdriver-cd/screwdriver/issues/1382