### PR TITLE
fix: include prparentjobid in tokengen

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -243,6 +243,17 @@ class BuildModel extends BaseModel {
         return this.job.then(job =>
             job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
                 .then((blockedBy) => {
+                    const tokenGenConfig = {
+                        isPR: job.isPR(),
+                        jobId: job.id,
+                        eventId: this.eventId,
+                        pipelineId: pipeline.id,
+                        configPipelineId: pipeline.configPipelineId
+                    };
+
+                    if (job.prParentJobId) {
+                        tokenGenConfig.prParentJobId = job.prParentJobId;
+                    }
                     const config = {
                         jobId: job.id,
                         annotations: hoek.reach(job.permutations[0],
@@ -251,13 +262,8 @@ class BuildModel extends BaseModel {
                         apiUri: this[apiUri],
                         buildId: this.id,
                         container: this.container,
-                        token: this[tokenGen](this.id, {
-                            isPR: job.isPR(),
-                            jobId: job.id,
-                            eventId: this.eventId,
-                            pipelineId: pipeline.id,
-                            configPipelineId: pipeline.configPipelineId
-                        }, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT) };
+                        token: this[tokenGen](this.id, tokenGenConfig,
+                            pipeline.scmContext, TEMPORAL_JWT_TIMEOUT) };
 
                     if (this.buildClusterName) {
                         config.buildClusterName = this.buildClusterName;

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
-    "screwdriver-config-parser": "^4.7.0",
-    "screwdriver-data-schema": "^18.33.5",
-    "screwdriver-workflow-parser": "^1.6.1",
+    "screwdriver-config-parser": "^4.9.0",
+    "screwdriver-data-schema": "^18.36.0",
+    "screwdriver-workflow-parser": "^1.7.0",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -470,6 +470,7 @@ describe('Build Model', () => {
 
     describe('start', () => {
         let sandbox;
+        const prParentJobId = 1000;
 
         beforeEach(() => {
             sandbox = sinon.sandbox.create();
@@ -477,6 +478,7 @@ describe('Build Model', () => {
             executorMock.start.resolves(null);
             jobFactoryMock.get.resolves({
                 id: jobId,
+                prParentJobId,
                 name: 'main',
                 pipeline: Promise.resolve({
                     id: pipelineId,
@@ -513,7 +515,8 @@ describe('Build Model', () => {
                         jobId,
                         pipelineId,
                         configPipelineId,
-                        eventId
+                        eventId,
+                        prParentJobId
                     }, scmContext, TEMPORAL_JWT_TIMEOUT);
 
                     assert.calledWith(scmMock.updateCommitStatus, {
@@ -550,7 +553,8 @@ describe('Build Model', () => {
                         jobId,
                         pipelineId,
                         configPipelineId,
-                        eventId
+                        eventId,
+                        prParentJobId
                     }, scmContext, TEMPORAL_JWT_TIMEOUT);
 
                     assert.calledWith(scmMock.updateCommitStatus, {


### PR DESCRIPTION
Need to include `prParentJobId` in the jwt so we can do permission check inside store. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1382