### PR TITLE
[2] feat(1270): pass build obj to executor start

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -255,6 +255,7 @@ class BuildModel extends BaseModel {
                         tokenGenConfig.prParentJobId = job.prParentJobId;
                     }
                     const config = {
+                        build: this,
                         jobId: job.id,
                         annotations: hoek.reach(job.permutations[0],
                             'annotations', { default: {} }),

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -339,6 +339,7 @@ class BuildFactory extends BaseFactory {
                         // Launcher is hardcoded to do some business in sd-setup-launcher
                         modelConfig.steps.unshift({ name: 'sd-setup-launcher' });
                         modelConfig.createTime = (new Date(number)).toISOString();
+                        modelConfig.stats = {};
 
                         return super.create(modelConfig);
                     });

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -501,6 +501,7 @@ describe('Build Model', () => {
             build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        build,
                         jobId,
                         annotations,
                         blockedBy: [jobId],
@@ -538,6 +539,7 @@ describe('Build Model', () => {
             return build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        build,
                         jobId,
                         annotations,
                         blockedBy: [jobId],
@@ -606,6 +608,7 @@ describe('Build Model', () => {
             return build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        build,
                         jobId,
                         blockedBy: [jobId, blocking1.id, blocking2.id],
                         annotations,
@@ -678,6 +681,7 @@ describe('Build Model', () => {
             return build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        build,
                         jobId,
                         blockedBy: [jobId, internalJob.id, externalJob1.id, externalJob2.id],
                         annotations,
@@ -708,6 +712,7 @@ describe('Build Model', () => {
             return build.start()
                 .then(() => {
                     assert.calledWith(executorMock.start, {
+                        build,
                         jobId,
                         annotations: { 'beta.screwdriver.cd/executor:': 'k8s-vm' },
                         blockedBy: [jobId],

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -280,7 +280,8 @@ describe('Build Factory', () => {
                     steps,
                     jobId,
                     sha,
-                    meta
+                    meta,
+                    stats: {}
                 }
             };
         });
@@ -448,6 +449,7 @@ describe('Build Factory', () => {
                     build: sinon.match.object
                 });
                 assert.calledOnce(startStub);
+
                 assert.calledWith(datastore.save, saveConfig);
             });
         });


### PR DESCRIPTION
Pass build to executor start, so that executor can update build

Blocked by: https://github.com/screwdriver-cd/data-schema/pull/300
Related: https://github.com/screwdriver-cd/screwdriver/issues/1270