### PR TITLE
fix(1405): Add logging around child pipelines events

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -16,6 +16,11 @@ const REGEX_CAPTURING_GROUP = {
 };
 
 winston.level = process.env.LOG_LEVEL || 'info';
+const logger = new (winston.Logger)({
+    transports: [
+        new (winston.transports.Console)({ timestamp: true })
+    ]
+});
 
 /**
  * Sync external triggers
@@ -136,7 +141,8 @@ class PipelineModel extends BaseModel {
 
                 return this.scm.getFile(config)
                     .catch((err) => {
-                        winston.error('Failed to fetch screwdriver.yaml', err);
+                        logger.error(`pipelineId:${this.id}: Failed to fetch ` +
+                            'screwdriver.yaml.', err);
 
                         return '';
                     });
@@ -221,7 +227,7 @@ class PipelineModel extends BaseModel {
                 j.permutations = parsedConfig.jobs[jobName];
             }
             j.archived = archived;
-            if (archived) winston.info(`${j.name} job of pipeline ${this.id} is archived`);
+            if (archived) logger.info(`pipelineId:${this.id}: Archiving ${j.name} job.`);
             jobsToUpdate.push(j.update());
         });
 
@@ -371,7 +377,7 @@ class PipelineModel extends BaseModel {
                 let jobsToArchive;
                 let jobsToUnarchive;
 
-                winston.info(`pipelineId:${this.id}: prChain flag is ${this.prChain}.`);
+                logger.info(`pipelineId:${this.id}: prChain flag is ${this.prChain}.`);
                 if (this.prChain) {
                     jobsToCreate = [];
                     jobsToArchive = prJobs;
@@ -492,7 +498,7 @@ class PipelineModel extends BaseModel {
 
         if (!hasAdminPermission) {
             // need to figure out how to bubble up this err to user
-            winston.error(`No admins of pipeline:${this.id} have admin permissions on ${scmUrl}`);
+            logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
 
             return null;
         }
@@ -504,11 +510,15 @@ class PipelineModel extends BaseModel {
             if (pipeline.configPipelineId === this.id) {
                 pipeline.admins = admins;
 
+                logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with ` +
+                    `pipelineId:${pipeline.id}.`);
+
                 return pipeline.update();
             }
 
-            // Child pipline does not belong to this parent, return
-            winston.error(`Pipeline ${scmUrl} already exists: ${pipeline.id}`);
+            // Child pipeline does not belong to this parent, return
+            logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already ` +
+                `exists: ${pipeline.id}.`);
 
             return null;
         }
@@ -518,6 +528,9 @@ class PipelineModel extends BaseModel {
             scmContext,
             scmUri,
             configPipelineId: this.id
+        }).then((p) => {
+            logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} ` +
+              `with pipelineId:${p.id}.`);
         });
     }
 
@@ -535,14 +548,21 @@ class PipelineModel extends BaseModel {
 
         if (!hasAdminPermission) {
             // need to figure out how to bubble up this err to user
-            winston.error(`Admins of ${this.pipelineId} has no admin permission to ${scmUrl}`);
+            logger.error(`pipelineId:${this.id}: No admins ` +
+                `have admin permissions on ${scmUrl}.`);
 
             return null;
         }
 
         const pipeline = await pipelineFactory.get({ scmUri });
 
-        return pipeline ? pipeline.remove() : null;
+        if (pipeline) {
+            logger.info(`pipelineId:${this.id}: Removing child pipeline for ${scmUrl} with ` +
+                `pipelineId:${pipeline.id}.`);
+            pipeline.remove();
+        }
+
+        return null;
     }
 
     /**
@@ -774,7 +794,7 @@ class PipelineModel extends BaseModel {
 
             if (!permission.push) {
                 delete newAdmins[username];
-                winston.info(`${username} has been removed from admins of pipeline:${this.id}.`);
+                logger.info(`pipelineId:${this.id}: ${username} has been removed from admins.`);
             } else {
                 break;
             }
@@ -782,7 +802,7 @@ class PipelineModel extends BaseModel {
         /* eslint-enable no-restricted-syntax */
 
         if (Object.keys(newAdmins).length === 0) {
-            winston.error(`Pipeline:${this.id} has no admin.`);
+            logger.error(`pipelineId:${this.id}: Pipeline has no admin.`);
             throw new Error('Pipeline has no admin');
         } else {
             // This is needed to make admins dirty and update db

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -318,6 +318,7 @@ describe('Pipeline Model', () => {
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
             pipeline.admins = { batman: true, robin: true };
+            pipelineFactoryMock.create.resolves({ id: '98765' });
             triggerFactoryMock.list.resolves([]);
             triggerFactoryMock.create.resolves(null);
 
@@ -639,7 +640,7 @@ describe('Pipeline Model', () => {
                 });
         });
 
-        it('Sync child pipeline if detects changes in scmUrls', () => {
+        it('syncs child pipeline if there are changes in scmUrls', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
 
             parsedYaml.childPipelines = {
@@ -685,7 +686,7 @@ describe('Pipeline Model', () => {
                 });
         });
 
-        it('Do not sync child pipelines if no admin permissions', () => {
+        it('does not sync child pipelines if no admin permissions', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
@@ -701,7 +702,7 @@ describe('Pipeline Model', () => {
                 });
         });
 
-        it('Do not update child pipelines if not belong to this parent', () => {
+        it('does not update child pipelines if does not belong to this parent', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
@@ -719,7 +720,7 @@ describe('Pipeline Model', () => {
                 });
         });
 
-        it('Remove child pipeline and reset scmUrls if it is removed from new yaml', () => {
+        it('removes child pipeline and resets scmUrls if it is removed from new yaml', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });


### PR DESCRIPTION
## Context
When child pipelines of a parent pipeline are getting removed it's almost impossible to track where and when it happened.

## Objective
This PR adds logging around child pipeline events and attempts to standardize log output from the pipeline factory.

example logs:
```
2018-12-14T01:14:31.407Z - info: pipelineId:123: Updating child pipeline foo.git with pipelineId:2.
2018-12-14T01:14:31.408Z - info: pipelineId:123: Removing child pipeline for baz.git with pipelineId:2.
2018-12-14T01:14:31.408Z - info: pipelineId:123: Creating child pipeline for bar.git with pipelineId:98765.
```

## Related links
https://github.com/screwdriver-cd/screwdriver/issues/1405