### PR TITLE
feat(1355): Add PR comment support [5]

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -75,6 +75,50 @@ function getBlockedByIds(pipeline, job) {
     });
 }
 
+/**
+ * Extracts the key value pairs from meta summary and converts
+ * them into markdown format
+ * @method formatSummary
+ * @param {Object}  summary     Meta summary object
+ * @return {String}             Formatted summary with good things from markdown
+ */
+function formatSummary(summary) {
+    let formattedSummary = '';
+
+    Object.keys(summary).forEach((key) => {
+        if (typeof summary[key] === 'string') {
+            formattedSummary += `__${key}__ - ${summary[key]}\n`;
+        }
+    });
+
+    return formattedSummary;
+}
+
+/**
+ * Extracts the summary from metadata and builds a comment
+ * @method getPrComment
+ * @param  {Object}   config
+ * @param  {Object}   config.metadata   Build metadata
+ * @param  {String}   config.pipelineId ID of the pipeline
+ * @param  {String}   config.uiUrl      UI url
+ * @return {String}   comment  containing Summary for each container
+ */
+function getPrComment({ metadata, pipelineId, uiUrl }) {
+    // Format of the comment
+    /**
+        ### SD Pipeline [#133652](https://cd.screwdriver.cd/pipelines/133652)
+        - - - -
+        __foo__ - bar
+        __coverage__ - Coverage increased by 15%
+        __markdown__ - **this** should have been **bold** or *italic*
+      */
+    const commentPrefix = `### SD Pipeline [#${pipelineId}](${uiUrl}/` +
+        `pipelines/${pipelineId})\n`;
+    const summaryText = formatSummary(metadata);
+
+    return summaryText ? `${commentPrefix}\n${summaryText}\n` : null;
+}
+
 class BuildModel extends BaseModel {
     /**
      * Construct a BuildModel object
@@ -118,6 +162,28 @@ class BuildModel extends BaseModel {
                 url: `${this[uiUri]}/pipelines/${pipeline.id}/builds/${this.id}`,
                 pipelineId: pipeline.id
             };
+
+            if (this.meta.summary && this.isDone() && job.isPR()) {
+                const comment = getPrComment({
+                    metadata: this.meta.summary,
+                    pipelineId: config.pipelineId,
+                    uiUrl: this[uiUri]
+                });
+                const prNum = parseInt(config.jobName.match(/^PR-([0-9]+):[\w-]+$/)[1], 10);
+                const prConfig = {
+                    comment,
+                    prNum,
+                    scmUri: config.scmUri,
+                    token
+                };
+
+                if (comment) {
+                    return Promise.all([
+                        this.scm.addPrComment(prConfig),
+                        this.scm.updateCommitStatus(config)
+                    ]);
+                }
+            }
 
             return this.scm.updateCommitStatus(config);
         });


### PR DESCRIPTION
## Context
It would be nice for users to be able to comment back on PRs through a build with relevant metadata.

## Objective
This PR adds a PR comment if `meta.summary` values are set in a build after a build is done.

<img width="384" alt="screen shot 2018-12-14 at 5 17 55 pm" src="https://user-images.githubusercontent.com/3230529/50037267-60f2d500-ffc4-11e8-8847-186adaf4e21b.png">

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1355