### PR TITLE
fix: add feature flag for multi build cluster

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -74,7 +74,8 @@ async function getBuildClusterName({ annotations, pipeline }) {
         const org = matched ? matched[1] : '';
 
         if (buildCluster.scmContext !== pipeline.scmContext
-            || !buildCluster.scmOrganizations.includes(org)) {
+            || (buildCluster.managedByScrewdriver === false
+                && !buildCluster.scmOrganizations.includes(org))) {
             throw new Error('This pipeline is not authorized to use this build cluster.');
         }
 
@@ -201,11 +202,12 @@ class BuildFactory extends BaseFactory {
      * Construct a JobFactory object
      * @method constructor
      * @param  {Object}    config
-     * @param  {Datastore} config.datastore         Object that will perform datastore operations
-     * @param  {String}    [config.dockerRegistry]  Docker Registry that the images belong to. Default is Docker Hub
-     * @param  {Executor}  config.executor          Object that will perform compute operations
-     * @param  {Bookend}   config.bookend           Object that will calculate the setup and teardown commands
-     * @param  {String}    config.uiUri             Partial Uri including hostname and namespace for ui for git notifications
+     * @param  {Datastore} config.datastore                 Object that will perform datastore operations
+     * @param  {String}    [config.dockerRegistry]          Docker Registry that the images belong to. Default is Docker Hub
+     * @param  {Executor}  config.executor                  Object that will perform compute operations
+     * @param  {Bookend}   config.bookend                   Object that will calculate the setup and teardown commands
+     * @param  {String}    config.uiUri                     Partial Uri including hostname and namespace for ui for git notifications
+     * @param  {Boolean}    config.multiBuildClusterEnabled Enable multiple build cluster feature or not
      */
     constructor(config) {
         super('build', config);
@@ -215,6 +217,7 @@ class BuildFactory extends BaseFactory {
         this.bookend = config.bookend;
         this.apiUri = null;
         this.tokenGen = null;
+        this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
     }
 
     /**
@@ -294,11 +297,14 @@ class BuildFactory extends BaseFactory {
                     const permutation = job.permutations[index];
                     const annotations = hoek.reach(job.permutations[0],
                         'annotations', { default: {} });
+                    let buildClusterName;
 
-                    const buildClusterName = await getBuildClusterName({
-                        annotations,
-                        pipeline
-                    });
+                    if (this.multiBuildClusterEnabled) {
+                        buildClusterName = await getBuildClusterName({
+                            annotations,
+                            pipeline
+                        });
+                    }
 
                     if (buildClusterName) {
                         modelConfig.buildClusterName = buildClusterName;


### PR DESCRIPTION
- add feature flag for multi build cluster, if flag is off, do not set `buildClusterName` at all.
- let users to pick from default build clusters

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1319