### PR TITLE
fix(1355): Pass in scmContext to addPrComment

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -173,6 +173,7 @@ class BuildModel extends BaseModel {
                 const prConfig = {
                     comment,
                     prNum,
+                    scmContext: config.scmContext,
                     scmUri: config.scmUri,
                     token
                 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.9.0",
-    "screwdriver-data-schema": "^18.36.0",
+    "screwdriver-data-schema": "^18.38.0",
     "screwdriver-workflow-parser": "^1.7.0",
     "winston": "^2.4.4"
   }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -267,6 +267,7 @@ describe('Build Model', () => {
                     });
                     assert.calledWith(scmMock.addPrComment, {
                         token: 'foo',
+                        scmContext,
                         scmUri,
                         comment: '### SD Pipeline [#1234](https://display.com/some/' +
                         'endpoint/pipelines/1234)\n\n' +


### PR DESCRIPTION
Need to pass in `scmContext` when calling `addPrComment`

Related to https://github.com/screwdriver-cd/models/pull/307 PR, related to https://github.com/screwdriver-cd/screwdriver/issues/1355