### PR TITLE
fix: add sd-setup-init step [2]

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -345,6 +345,10 @@ class BuildFactory extends BaseFactory {
                         // Launcher is hardcoded to do some business in sd-setup-launcher
                         modelConfig.steps.unshift({ name: 'sd-setup-launcher' });
                         modelConfig.createTime = (new Date(number)).toISOString();
+                        modelConfig.steps.unshift({
+                            name: 'sd-setup-init',
+                            startTime: modelConfig.createTime
+                        });
                         modelConfig.stats = {};
 
                         return super.create(modelConfig);

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -247,13 +247,18 @@ describe('Build Factory', () => {
             one: 1
         };
 
+        steps.unshift({
+            name: 'sd-setup-init',
+            startTime: isoTime
+        });
+
         let saveConfig;
 
         beforeEach(() => {
             scmMock.getCommitSha.resolves(sha);
             scmMock.decorateCommit.resolves(commit);
             scmMock.getDisplayName.returns(displayName);
-            bookendMock.getSetupCommands.resolves([steps[1]]);
+            bookendMock.getSetupCommands.resolves([steps[2]]);
             bookendMock.getTeardownCommands.resolves([]);
             datastore.save.resolves({});
 
@@ -510,7 +515,7 @@ describe('Build Factory', () => {
             bookendMock.getTeardownCommands.resolves([teardown]);
             bookendMock.getSetupCommands.resolves([]);
 
-            const expectedSteps = steps.slice(0, 1).concat(steps.slice(2));
+            const expectedSteps = steps.slice(0, 2).concat(steps.slice(3));
 
             expectedSteps.push(teardown);
 


### PR DESCRIPTION
- add an `init` step to hold stats info: e.g. when build got in queue and when it started to pull img etc.
- step `startTime` will be build `createTime`, step `endTime` will be build `startTime`, have another PR to update `endTime` in API

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1270
