### PR TITLE
fix(1441): Skip build periodic for PR builds

### DIFF
--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -63,7 +63,9 @@ class JobFactory extends BaseFactory {
         const pipelineFactory = PipelineFactory.getInstance();
 
         return super.create(c).then((job) => {
-            if (getAnnotations(c.permutations[0], 'screwdriver.cd/buildPeriodically')) {
+            // Do not run job periodically if job is PR
+            if (getAnnotations(c.permutations[0], 'screwdriver.cd/buildPeriodically')
+                && !/^PR-/.test(c.name)) {
                 return pipelineFactory.get(c.pipelineId)
                     .then(pipeline => this.executor.startPeriodic({
                         pipeline,


### PR DESCRIPTION
## Context
PR builds should ignore the `buildPeriodically` annotation.

## Objective
This PR skips build periodically if job is PR.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1441