### PR TITLE
feat(1010): enabling prChain 2nd step

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -91,7 +91,7 @@ function getJobsFromPR(config) {
     });
 
     const jobsToStart = jobs.filter(
-        j => j.name.startsWith(`PR-${prNum}:`) || nextJobs.includes(j.name)
+        j => j.name.startsWith(`PR-${prNum}:j.name`) || nextJobs.includes(j.name)
     );
 
     return jobsToStart.filter(j => j.state === 'ENABLED' && !j.archived);

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -91,7 +91,7 @@ function getJobsFromPR(config) {
     });
 
     const jobsToStart = jobs.filter(
-        j => j.name.startsWith(`PR-${prNum}:j.name`) || nextJobs.includes(j.name)
+        j => j.name.startsWith(`PR-${prNum}:`) || nextJobs.includes(j.name)
     );
 
     return jobsToStart.filter(j => j.state === 'ENABLED' && !j.archived);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -366,11 +366,27 @@ class PipelineModel extends BaseModel {
                 const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}`));
 
                 // Get next jobs for when startFrom is ~pr
-                const nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
+                let nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
                     trigger: '~pr',
                     prNum,
                     prChain: this.prChain
                 });
+
+                // Get all chained jobs if prChain is true
+                if (this.prChain) {
+                    let triggerJobs = nextJobs.concat();
+
+                    while (triggerJobs.length > 0) {
+                        const chainedJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
+                            trigger: triggerJobs[0],
+                            prChain: this.prChain
+                        });
+
+                        triggerJobs.splice(0, 1);
+                        triggerJobs = triggerJobs.concat(chainedJobs);
+                        nextJobs = nextJobs.concat(chainedJobs);
+                    }
+                }
 
                 // Get all the missing PR- job names
                 const existingPRJobNames = prJobs.map(prJob => prJob.name);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -360,6 +360,9 @@ class PipelineModel extends BaseModel {
                 this.jobs
             ]))
             .then(([parsedConfig, jobs]) => {
+                this.prChain = parsedConfig.prChain;
+                logger.info(`pipelineId:${this.id}: prChain flag is ${this.prChain}.`);
+
                 const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}`));
 
                 // Get next jobs for when startFrom is ~pr
@@ -373,21 +376,11 @@ class PipelineModel extends BaseModel {
                 const existingPRJobNames = prJobs.map(prJob => prJob.name);
                 const missingPRJobNames =
                     nextJobs.filter(nextJob => !existingPRJobNames.includes(nextJob));
-                let jobsToCreate;
-                let jobsToArchive;
-                let jobsToUnarchive;
 
-                logger.info(`pipelineId:${this.id}: prChain flag is ${this.prChain}.`);
-                if (this.prChain) {
-                    jobsToCreate = [];
-                    jobsToArchive = prJobs;
-                    jobsToUnarchive = [];
-                } else {
-                    // Get the job name part, e.g. main from PR-1:main to create job
-                    jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
-                    jobsToArchive = prJobs.filter(prJob => !nextJobs.includes(prJob.name));
-                    jobsToUnarchive = prJobs.filter(prJob => nextJobs.includes(prJob.name));
-                }
+                // Get the job name part, e.g. main from PR-1:main to create job
+                const jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
+                const jobsToArchive = prJobs.filter(prJob => !nextJobs.includes(prJob.name));
+                const jobsToUnarchive = prJobs.filter(prJob => nextJobs.includes(prJob.name));
 
                 // Lazy load factory dependency to prevent circular dependency issues
                 // https://nodejs.org/api/modules.html#modules_cycles

--- a/test/data/parserWithWorkflowGraphPR.json
+++ b/test/data/parserWithWorkflowGraphPR.json
@@ -95,6 +95,18 @@
                 ],
                 "requires": ["~pr"]
             }
+        ],
+        "not_pr_job": [
+            {
+                "image": "node:8",
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install test"
+                    }
+                ],
+                "requires": ["~commit"]
+            }
         ]
     },
     "workflowGraph": {
@@ -104,14 +116,16 @@
             { "name": "main" },
             { "name": "test" },
             { "name": "publish" },
-            { "name": "new_pr_job" }
+            { "name": "new_pr_job" },
+            { "name": "not_pr_job" }
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~pr", "dest": "test" },
             { "src": "~pr", "dest": "new_pr_job" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "publish" }
+            { "src": "main", "dest": "publish" },
+            { "src": "~commit", "dest": "not_pr_job" }
         ]
     },
     "annotations": {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -574,7 +574,7 @@ describe('Event Factory', () => {
                 });
             });
 
-            it('should create build of the "main" job with prChain config', () => {
+            it('should create build of the "PR-1:main" job with prChain config', () => {
                 config.startFrom = '~pr';
                 config.prRef = 'branch';
                 config.prNum = 1;
@@ -590,7 +590,7 @@ describe('Event Factory', () => {
                     assert.calledWith(buildFactoryMock.create, sinon.match({
                         parentBuildId: 12345,
                         eventId: model.id,
-                        jobId: 1,
+                        jobId: 10,
                         prRef: 'branch'
                     }));
                 });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -942,7 +942,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('update PR config and create missing PR jobs if prChain is true', () => {
+        it('updates PR config and create missing PR jobs if prChain is true', () => {
             const firstPRJob = {
                 update: sinon.stub().resolves(null),
                 isPR: sinon.stub().returns(true),


### PR DESCRIPTION
!! Workflow-parser need to be merged at first in order to pass unit test.

## Context
This PR is the second step of enabling prChain feature.
This time we fixed only a backend（api, models, workflow-graph）. UI will be fixed next time.

## Objective
- If `prChain` flag is true in screwdriver.yaml, run subsequent jobs following workflow graph.
- Create all jobs with `PR-${prNum}:` prefix.

## Other PRs
https://github.com/screwdriver-cd/workflow-parser/pull/16
https://github.com/screwdriver-cd/screwdriver/pull/1444

## References
- New design of prChain feature
https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-448142968
