### PR TITLE
fix: fix no build event response

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -208,6 +208,7 @@ function createBuilds(config) {
             // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
             if (jobsToStart.length === 0) {
                 winston.info('No jobs to start.');
+
                 return null;
             }
 
@@ -231,6 +232,7 @@ function createBuilds(config) {
 
                 if (builds.length === 0) {
                     winston.info('No jobs to start.');
+
                     return null;
                 }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -8,6 +8,7 @@ const {
     PR_TRIGGER
 } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
+const winston = require('winston');
 
 let instance;
 
@@ -206,6 +207,7 @@ function createBuilds(config) {
         .then((jobsToStart) => {
             // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
             if (jobsToStart.length === 0) {
+                winston.info('No jobs to start.');
                 return null;
             }
 
@@ -228,6 +230,7 @@ function createBuilds(config) {
                 const builds = buildsCreated.filter(b => b !== null);
 
                 if (builds.length === 0) {
+                    winston.info('No jobs to start.');
                     return null;
                 }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -206,7 +206,7 @@ function createBuilds(config) {
         .then((jobsToStart) => {
             // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
             if (jobsToStart.length === 0) {
-                throw new Error('No jobs to start');
+                return null;
             }
 
             // Start builds
@@ -225,13 +225,13 @@ function createBuilds(config) {
                     webhooks
                 });
             })).then((buildsCreated) => {
-                const nobuilds = buildsCreated.every(b => b === null);
+                const builds = buildsCreated.filter(b => b !== null);
 
-                if (nobuilds) {
-                    throw new Error('No jobs to start');
+                if (builds.length === 0) {
+                    return null;
                 }
 
-                return buildsCreated;
+                return builds;
             });
         });
 }
@@ -433,7 +433,7 @@ class EventFactory extends BaseFactory {
                             changedFiles: config.changedFiles,
                             webhooks: config.webhooks
                         }))
-                        .then(() => event);
+                        .then(builds => (builds ? event : null));
                 })
             );
     }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -438,7 +438,11 @@ class EventFactory extends BaseFactory {
                             changedFiles: config.changedFiles,
                             webhooks: config.webhooks
                         }))
-                        .then(builds => (builds ? event : null));
+                        .then((builds) => {
+                            event.builds = builds;
+
+                            return event;
+                        });
                 })
             );
     }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -207,7 +207,7 @@ function createBuilds(config) {
         .then((jobsToStart) => {
             // No jobs to start (eg: when jobs are disabled or startFrom is not valid)
             if (jobsToStart.length === 0) {
-                winston.info('No jobs to start.');
+                winston.info(`No jobs to start in event ${eventId}.`);
 
                 return null;
             }
@@ -231,7 +231,7 @@ function createBuilds(config) {
                 const builds = buildsCreated.filter(b => b !== null);
 
                 if (builds.length === 0) {
-                    winston.info('No jobs to start.');
+                    winston.info(`No jobs to start in event ${eventId}.`);
 
                     return null;
                 }


### PR DESCRIPTION
### Context
Events which doesn't trigger any jobs return error to github webhooks.
It would be better to return 204.

### Objective
* Return null when events starts no jobs.

### References
relates to:
* https://github.com/screwdriver-cd/screwdriver/pull/1445