### PR TITLE
feat(1440): Update build commit status with custom status [4]

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -123,6 +123,45 @@ function getPrComment({ metadata, buildId, buildUrl, container }) {
     return summaryText ? [commentPrefix, summaryText, commentSuffix].join('\n') : null;
 }
 
+/**
+ * Gets status configs to call updateCommitStatus with
+ * @param  {Object} metadata Metadata object
+ * @return {Array}           Status configs
+ */
+function getStatusConfig({ metadata }) {
+    const statusConfigs = [];
+
+    /* eslint-disable consistent-return */
+    Object.keys(metadata).forEach((fieldName) => {
+        if (typeof metadata[fieldName] !== 'object') {
+            return null;
+        }
+        const defaultMessages = {
+            success: `${fieldName} check succeeded`,
+            failure: `${fieldName} check failed`
+        };
+        const status = hoek.reach(metadata[fieldName], 'status', { default: 'success' });
+        const message = hoek.reach(metadata[fieldName], 'message', {
+            default: defaultMessages[status] || defaultMessages.failure
+        });
+        const url = hoek.reach(metadata[fieldName], 'url');
+        const config = {
+            context: fieldName,
+            buildStatus: status,
+            description: message
+        };
+
+        if (url) {
+            config.url = url;
+        }
+
+        statusConfigs.push(config);
+    });
+    /* eslint-enable consistent-return */
+
+    return statusConfigs;
+}
+
 class BuildModel extends BaseModel {
     /**
      * Construct a BuildModel object
@@ -168,6 +207,8 @@ class BuildModel extends BaseModel {
                 pipelineId: pipeline.id
             };
 
+            const updateTasks = [this.scm.updateCommitStatus(config)];
+
             // Write meta summary to PR comment if meta.meta.summary object exists
             if (hoek.reach(this.meta, 'meta.summary') && this.isDone() && job.isPR()) {
                 const comment = getPrComment({
@@ -186,14 +227,26 @@ class BuildModel extends BaseModel {
                 };
 
                 if (comment) {
-                    return Promise.all([
-                        this.scm.addPrComment(prConfig),
-                        this.scm.updateCommitStatus(config)
-                    ]);
+                    updateTasks.push(this.scm.addPrComment(prConfig));
                 }
             }
 
-            return this.scm.updateCommitStatus(config);
+            // Update git commit status if meta.meta.status object exists
+            if (hoek.reach(this.meta, 'meta.status') && this.isDone() && job.isPR()) {
+                const statusConfigs = getStatusConfig({
+                    metadata: hoek.reach(this.meta, 'meta.status')
+                });
+
+                if (statusConfigs.length > 0) {
+                    statusConfigs.forEach((c) => {
+                        const customStatusConfig = hoek.applyToDefaults(config, c);
+
+                        updateTasks.push(this.scm.updateCommitStatus(customStatusConfig));
+                    });
+                }
+            }
+
+            return Promise.all(updateTasks);
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.9.0",
     "screwdriver-data-schema": "^18.39.0",
-    "screwdriver-workflow-parser": "^1.7.0",
+    "screwdriver-workflow-parser": "^1.8.0",
     "winston": "^2.4.4"
   }
 }


### PR DESCRIPTION
## Context
Users like to add custom status messages to their commits.

## Objective
This PR takes in meta status object and adds custom status messages to Git.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1440
Blocked by https://github.com/screwdriver-cd/scm-github/pull/118