### PR TITLE
feat(1412): pipeline metrics

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const hoek = require('hoek');
 const BaseModel = require('./base');
 
 class EventModel extends BaseModel {
@@ -15,14 +16,18 @@ class EventModel extends BaseModel {
 
     /**
      * Return builds that belong to this event
-     * @return {Promise}                            List of builds
+     * @param  {String}   [config.startTime]     Search for builds after this startTime
+     * @param  {String}   [config.endTime]       Search for builds before this endTime
+     * @return {Promise}  Resolves to an array of builds
      */
-    getBuilds() {
-        const listConfig = {
+    getBuilds(config) {
+        const defaultConfig = {
             params: {
                 eventId: this.id
             }
         };
+
+        const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1155,7 +1155,7 @@ class PipelineModel extends BaseModel {
      * @param  {String}   [config.endTime]      Only look at events created before this endTime
      * @return {Promise}  [description]
      */
-    async getReports({ startTime, endTime }) {
+    async getMetrics({ startTime, endTime }) {
         // Get events during this time range
         const events = this.getEvents({
             startTime,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1040,6 +1040,8 @@ class PipelineModel extends BaseModel {
      * @param  {Object}   [config.paginate]                     Pagination parameters
      * @param  {Number}   [config.paginate.count]               Number of items per page
      * @param  {Number}   [config.paginate.page]                Specific page of the set to return
+     * @param  {String}   [config.startTime]                    Search for events after this startTime
+     * @param  {String}   [config.endTime]                      Search for events before this endTime
      * @return {Promise}  Resolves to an array of events
      */
     getEvents(config) {
@@ -1144,6 +1146,61 @@ class PipelineModel extends BaseModel {
             .then(() => removeEvents('pr')) // remove pr events
             .then(() => removeChildPipelines()) // remove pr events
             .then(() => super.remove()); // remove pipeline
+    }
+
+    /**
+     * getReports for this pipeline
+     * @method getReports
+     * @param  {String}   [config.startTime]    Only look at events created after this startTime
+     * @param  {String}   [config.endTime]      Only look at events created before this endTime
+     * @return {Promise}  [description]
+     */
+    async getReports({ startTime, endTime }) {
+        // Get events during this time range
+        const events = this.getEvents({
+            startTime,
+            endTime
+        });
+
+        // Calculate event duration by using max endTime - min startTime of builds
+        // that belong this event during this time range
+        const eventDuration = async (event) => {
+            const builds = await event.getBuilds({
+                startTime,
+                endTime
+            });
+
+            // Somehow this event doesn't have any builds
+            if (!builds) {
+                return 0;
+            }
+
+            let minStartTime = new Date(builds[0].startTime);
+            let maxEndTime = new Date(builds[0].endTime);
+
+            for (let i = 1; i < builds.length; i += 1) {
+                const s = new Date(builds[i].startTime);
+                const e = new Date(builds[i].endTime);
+
+                minStartTime = s < minStartTime ? s : minStartTime;
+                maxEndTime = e > maxEndTime ? e : maxEndTime;
+            }
+
+            return Math.round((maxEndTime - minStartTime) / 1000); // round in seconds
+        };
+
+        // Generate reports
+        const results = await events.map(async (e) => {
+            const duration = await eventDuration(e);
+
+            return {
+                id: e.id,
+                createTime: e.createTime,
+                duration
+            };
+        });
+
+        return results;
     }
 }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1151,9 +1151,10 @@ class PipelineModel extends BaseModel {
     /**
      * getReports for this pipeline
      * @method getReports
-     * @param  {String}   [config.startTime]    Only look at events created after this startTime
-     * @param  {String}   [config.endTime]      Only look at events created before this endTime
-     * @return {Promise}  [description]
+     * @param  {Object}   [config]              Configuration object
+     * @param  {String}   [config.startTime]    Look at events created after this startTime
+     * @param  {String}   [config.endTime]      Look at events created before this endTime
+     * @return {Promise}  Resolves to array of metrics for events belong to this pipeline
      */
     async getMetrics(config) {
         // if not config pass in then get all
@@ -1197,11 +1198,7 @@ class PipelineModel extends BaseModel {
         const promiseArray = events.map(async (e) => {
             const duration = await eventDuration(e);
 
-            return {
-                id: e.id,
-                createTime: e.createTime,
-                duration
-            };
+            return Object.assign({}, e, { duration });
         });
 
         return Promise.all(promiseArray);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1155,9 +1155,13 @@ class PipelineModel extends BaseModel {
      * @param  {String}   [config.endTime]      Only look at events created before this endTime
      * @return {Promise}  [description]
      */
-    async getMetrics({ startTime, endTime }) {
+    async getMetrics(config) {
+        // if not config pass in then get all
+        const startTime = config ? config.startTime : null;
+        const endTime = config ? config.endTime : null;
+
         // Get events during this time range
-        const events = this.getEvents({
+        const events = await this.getEvents({
             startTime,
             endTime
         });
@@ -1190,7 +1194,7 @@ class PipelineModel extends BaseModel {
         };
 
         // Generate reports
-        const results = await events.map(async (e) => {
+        const promiseArray = events.map(async (e) => {
             const duration = await eventDuration(e);
 
             return {
@@ -1200,7 +1204,7 @@ class PipelineModel extends BaseModel {
             };
         });
 
-        return results;
+        return Promise.all(promiseArray);
     }
 }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1159,7 +1159,7 @@ class PipelineModel extends BaseModel {
      * @return {Promise}  Resolves to array of metrics for events belong to this pipeline
      */
     async getMetrics(config) {
-        // if not config pass in then get all
+        // if no config pass in then get all (will not pass startTime/endTime to datastore)
         const startTime = config ? config.startTime : null;
         const endTime = config ? config.endTime : null;
 
@@ -1170,12 +1170,9 @@ class PipelineModel extends BaseModel {
         });
 
         // Calculate event duration by using max endTime - min startTime of builds
-        // that belong this event during this time range
+        // that belong this event
         const eventDuration = async (event) => {
-            const builds = await event.getBuilds({
-                startTime,
-                endTime
-            });
+            const builds = await event.getBuilds();
 
             // Somehow this event doesn't have any builds
             if (!builds) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.9.0",
     "screwdriver-data-schema": "^18.39.0",
-    "screwdriver-workflow-parser": "^1.7.0",
+    "screwdriver-workflow-parser": "^1.8.0",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/event.test.js
+++ b/test/lib/event.test.js
@@ -39,7 +39,7 @@ describe('Event Model', () => {
         BaseModel = require('../../lib/base');
 
         createConfig = {
-            id: '1234',
+            id: 1234,
             datastore
         };
         event = new EventModel(createConfig);
@@ -67,13 +67,44 @@ describe('Event Model', () => {
         it('use the default config when not passed in', () => {
             const expected = {
                 params: {
-                    eventId: '1234'
+                    eventId: 1234
                 }
             };
 
             return event.getBuilds().then(() => {
                 assert.calledWith(buildFactoryMock.list, expected);
             });
+        });
+
+        it('merges the passed in config with the default config', () => {
+            const startTime = '2019-01-20T12:00:00.000Z';
+            const endTime = '2019-01-30T12:00:00.000Z';
+            const expected = {
+                params: {
+                    eventId: 1234
+                },
+                startTime,
+                endTime
+            };
+
+            return event.getBuilds({
+                startTime,
+                endTime
+            }).then(() => {
+                assert.calledWith(buildFactoryMock.list, expected);
+            });
+        });
+
+        it('rejects with errors', () => {
+            buildFactoryMock.list.rejects(new Error('cannotgetit'));
+
+            return event.getBuilds()
+                .then(() => {
+                    assert.fail('Should not get here');
+                }).catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.message, 'cannotgetit');
+                });
         });
     });
 });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1943,15 +1943,11 @@ describe('Pipeline Model', () => {
             createTime: '2019-01-24T11:25:00.610Z',
             getBuilds: sinon.stub().resolves([build21, build22])
         };
-        const metrics = [{
-            id: 1,
-            createTime: event1.createTime,
-            duration: (new Date(build12.endTime) - new Date(build11.startTime)) / 1000
-        }, {
-            id: 2,
-            createTime: event2.createTime,
-            duration: (new Date(build22.endTime) - new Date(build22.startTime)) / 1000
-        }];
+        const metrics = [
+            Object.assign({}, event1,
+                { duration: (new Date(build12.endTime) - new Date(build11.startTime)) / 1000 }),
+            Object.assign({}, event2,
+                { duration: (new Date(build22.endTime) - new Date(build22.startTime)) / 1000 })];
 
         it('generates metrics', () => {
             const eventListConfig = {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1976,8 +1976,8 @@ describe('Pipeline Model', () => {
 
             return pipeline.getMetrics({ startTime, endTime }).then((result) => {
                 assert.calledWith(eventFactoryMock.list, eventListConfig);
-                assert.calledWith(event1.getBuilds, { startTime, endTime });
-                assert.calledWith(event2.getBuilds, { startTime, endTime });
+                assert.calledOnce(event1.getBuilds);
+                assert.calledOnce(event2.getBuilds);
                 assert.deepEqual(result, metrics);
             });
         });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1909,51 +1909,84 @@ describe('Pipeline Model', () => {
     describe('get metrics', () => {
         const startTime = '2019-01-20T12:00:00.000Z';
         const endTime = '2019-01-30T12:00:00.000Z';
+        const build11 = {
+            id: 11,
+            eventId: 1,
+            startTime: '2019-01-22T21:08:00.000Z', // minStartTime for event1
+            endTime: '2019-01-22T21:30:00.000Z'
+        };
+        const build12 = {
+            id: 12,
+            eventId: 1,
+            startTime: '2019-01-22T21:21:00.000Z',
+            endTime: '2019-01-22T22:30:00.000Z' // maxEndTime for event1
+        };
+        const build21 = {
+            id: 21,
+            eventId: 2,
+            startTime: '2019-01-24T11:31:00.000Z',
+            endTime: '2019-01-24T12:20:00.000Z'
+        };
+        const build22 = {
+            id: 22,
+            eventId: 2,
+            startTime: '2019-01-24T11:30:00.000Z', // minStartTime for event1
+            endTime: '2019-01-24T15:30:00.000Z' // maxEndTime for event1
+        };
         const event1 = {
             id: 1,
-            createTime: '2019-01-22T21:49:03.610Z'
+            createTime: '2019-01-22T21:00:00.000Z',
+            getBuilds: sinon.stub().resolves([build11, build12])
         };
         const event2 = {
             id: 2,
-            createTime: '2019-01-24T11:00:00.610Z'
+            createTime: '2019-01-24T11:25:00.610Z',
+            getBuilds: sinon.stub().resolves([build21, build22])
         };
         const metrics = [{
             id: 1,
-            createTime: '2019-01-22T21:49:03.610Z',
-            duration: 3600
+            createTime: event1.createTime,
+            duration: (new Date(build12.endTime) - new Date(build11.startTime)) / 1000
         }, {
             id: 2,
-            createTime: '2019-01-24T11:00:00.610Z',
-            duration: 47481
+            createTime: event2.createTime,
+            duration: (new Date(build22.endTime) - new Date(build22.startTime)) / 1000
         }];
-        const eventListConfig = {
-            params: {
-                pipelineId: 123,
-                type: 'pipeline'
-            },
-            sort: 'descending',
-            startTime,
-            endTime
 
-        };
-        const buildListConfig1 = {
-            params: {
-                eventId: event1.id
-            },
-            startTime,
-            endTime
-        };
-        const buildListConfig2 = Object.assign(
-            {}, buildListConfig1, { params: { eventId: event2.id } });
+        it('generates metrics', () => {
+            const eventListConfig = {
+                params: {
+                    pipelineId: 123,
+                    type: 'pipeline'
+                },
+                sort: 'descending',
+                startTime,
+                endTime
+            };
 
-        it.only('generates metrics', () => {
             eventFactoryMock.list.resolves([event1, event2]);
 
             return pipeline.getMetrics({ startTime, endTime }).then((result) => {
                 assert.calledWith(eventFactoryMock.list, eventListConfig);
-                assert.calledTwice(buildFactoryMock.list);
-                assert.calledWith(buildFactoryMock.list.firstCall, buildListConfig1);
-                assert.calledWith(buildFactoryMock.list.secondCall, buildListConfig2);
+                assert.calledWith(event1.getBuilds, { startTime, endTime });
+                assert.calledWith(event2.getBuilds, { startTime, endTime });
+                assert.deepEqual(result, metrics);
+            });
+        });
+
+        it('works with no startTime or endTime params passed in', () => {
+            const eventListConfig = {
+                params: {
+                    pipelineId: 123,
+                    type: 'pipeline'
+                },
+                sort: 'descending'
+            };
+
+            eventFactoryMock.list.resolves([event1, event2]);
+
+            return pipeline.getMetrics().then((result) => {
+                assert.calledWith(eventFactoryMock.list, eventListConfig);
                 assert.deepEqual(result, metrics);
             });
         });
@@ -1961,7 +1994,7 @@ describe('Pipeline Model', () => {
         it('rejects with errors', () => {
             eventFactoryMock.list.rejects(new Error('cannotgetit'));
 
-            return pipeline.getEvents()
+            return pipeline.getMetrics({ startTime, endTime })
                 .then(() => {
                     assert.fail('Should not get here');
                 }).catch((err) => {


### PR DESCRIPTION
Pipeline metrics should have events between a time range and these events duration (to show the trend in the UI). 

**Notes:** Need to observe the performance of this implementation after adding indexes. If it's too slow, we might need a separate table. 

**Blocked By:** 
- Indexes added to DB
- Modify `scan` method inside `datastore-sequelize` for time range: https://github.com/screwdriver-cd/datastore-sequelize/pull/41

**Related:** https://github.com/screwdriver-cd/screwdriver/issues/1412