### PR TITLE
fix(1440): Convert string to JSON for custom Git status

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -2,6 +2,7 @@
 
 const BaseModel = require('./base');
 const hoek = require('hoek');
+const winston = require('winston');
 const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 
 // Symbols for private members
@@ -137,7 +138,10 @@ function getStatusConfig({ metadata }) {
 
         // Break early if status is not formatted correctly
         if (typeof checkObject !== 'object' && typeof checkObject !== 'string') {
-            return statusConfigs;
+            winston.info(`Skipping adding meta status for meta.status.${fieldName}: ` +
+                'is not an object or JSON-parseable string.');
+
+            return;
         }
 
         // Parse JSON string
@@ -145,7 +149,12 @@ function getStatusConfig({ metadata }) {
             try {
                 checkObject = JSON.parse(checkObject);
             } catch (e) {
-                return statusConfigs;
+                const message = `Skipping adding meta status for meta.status.${fieldName}: ` +
+                    'string is not a JSON-parseable string.';
+
+                winston.info(message);
+
+                return;
             }
         }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -133,18 +133,31 @@ function getStatusConfig({ metadata }) {
 
     /* eslint-disable consistent-return */
     Object.keys(metadata).forEach((fieldName) => {
-        if (typeof metadata[fieldName] !== 'object') {
-            return null;
+        let checkObject = metadata[fieldName];
+
+        // Break early if status is not formatted correctly
+        if (typeof checkObject !== 'object' && typeof checkObject !== 'string') {
+            return statusConfigs;
         }
+
+        // Parse JSON string
+        if (typeof checkObject === 'string') {
+            try {
+                checkObject = JSON.parse(checkObject);
+            } catch (e) {
+                return statusConfigs;
+            }
+        }
+
         const defaultMessages = {
             success: `${fieldName} check succeeded`,
             failure: `${fieldName} check failed`
         };
-        const status = hoek.reach(metadata[fieldName], 'status', { default: 'success' });
-        const message = hoek.reach(metadata[fieldName], 'message', {
+        const status = hoek.reach(checkObject, 'status', { default: 'success' });
+        const message = hoek.reach(checkObject, 'message', {
             default: defaultMessages[status] || defaultMessages.failure
         });
-        const url = hoek.reach(metadata[fieldName], 'url');
+        const url = hoek.reach(checkObject, 'url');
         const config = {
             context: fieldName,
             buildStatus: status,
@@ -237,7 +250,7 @@ class BuildModel extends BaseModel {
                     metadata: hoek.reach(this.meta, 'meta.status')
                 });
 
-                if (statusConfigs.length > 0) {
+                if (statusConfigs && statusConfigs.length > 0) {
                     statusConfigs.forEach((c) => {
                         const customStatusConfig = hoek.applyToDefaults(config, c);
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -658,7 +658,9 @@ describe('Build Model', () => {
             });
             build.status = 'FAILURE';
             build.meta.meta.status = {
-                findbugs: 'hello'
+                findbugs: 'hello',
+                snyk: '{"status":"FAILURE","message":"23 package vulnerabilities found. ' +
+                    'Previous count: 0 vulnerabilities."}'
             };
             delete build.meta.meta.summary;
 
@@ -674,7 +676,20 @@ describe('Build Model', () => {
                         url,
                         pipelineId
                     });
-                    assert.notOk(scmMock.updateCommitStatus.secondCall);
+                    assert.calledWith(scmMock.updateCommitStatus.secondCall, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'PR-5:main',
+                        buildStatus: 'FAILURE',
+                        url: 'https://display.com/some/endpoint/pipelines/1234/builds/9876',
+                        pipelineId,
+                        context: 'snyk',
+                        description: '23 package vulnerabilities found. ' +
+                            'Previous count: 0 vulnerabilities.'
+                    });
+                    assert.notOk(scmMock.updateCommitStatus.thirdCall);
                     assert.notCalled(scmMock.addPrComment);
                 });
         });
@@ -696,7 +711,9 @@ describe('Build Model', () => {
             });
             build.status = 'FAILURE';
             build.meta.meta.status = {
-                findbugs: 12345
+                findbugs: 12345,
+                snyk: '{"status":"FAILURE","message":"23 package vulnerabilities found. ' +
+                    'Previous count: 0 vulnerabilities."}'
             };
             delete build.meta.meta.summary;
 
@@ -712,7 +729,20 @@ describe('Build Model', () => {
                         url,
                         pipelineId
                     });
-                    assert.notOk(scmMock.updateCommitStatus.secondCall);
+                    assert.calledWith(scmMock.updateCommitStatus.secondCall, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'PR-5:main',
+                        buildStatus: 'FAILURE',
+                        url: 'https://display.com/some/endpoint/pipelines/1234/builds/9876',
+                        pipelineId,
+                        context: 'snyk',
+                        description: '23 package vulnerabilities found. ' +
+                            'Previous count: 0 vulnerabilities.'
+                    });
+                    assert.notOk(scmMock.updateCommitStatus.thirdCall);
                     assert.notCalled(scmMock.addPrComment);
                 });
         });

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -364,6 +364,85 @@ describe('Build Model', () => {
                 });
         });
 
+        it('promises to update a build, stop the executor, and ' +
+            'update statuses when statuses are JSON string', () => {
+            jobFactoryMock.get.resolves({
+                id: jobId,
+                name: 'PR-5:main',
+                pipeline: Promise.resolve({
+                    id: pipelineId,
+                    configPipelineId,
+                    scmUri,
+                    scmContext,
+                    admin: Promise.resolve(adminUser),
+                    token: Promise.resolve('foo')
+                }),
+                permutations: [{ annotations }],
+                isPR: sinon.stub().returns(true)
+            });
+            build.status = 'FAILURE';
+            build.meta.meta.summary = {};
+            build.meta.meta.status = {
+                findbugs: '{"status":"SUCCESS","message":"923 issues found. ' +
+                    'Previous count: 914 issues.","url":"http://findbugs.com"}',
+                snyk: '{"status":"FAILURE","message":"23 package vulnerabilities found. ' +
+                    'Previous count: 0 vulnerabilities."}'
+            };
+
+            return build.update()
+                .then(() => {
+                    assert.calledWith(executorMock.stop, {
+                        buildId,
+                        jobId,
+                        annotations,
+                        blockedBy: [jobId]
+                    });
+
+                    // Completed step is not modified
+                    assert.deepEqual(build.steps[0], step0);
+                    // In progress step is aborted
+                    assert.ok(build.steps[1].endTime);
+                    assert.equal(build.steps[1].code, 130);
+                    // Unstarted step is not modified
+                    assert.deepEqual(build.steps[2], step2);
+                    assert.calledWith(scmMock.updateCommitStatus.firstCall, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'PR-5:main',
+                        buildStatus: 'FAILURE',
+                        url,
+                        pipelineId
+                    });
+                    assert.calledWith(scmMock.updateCommitStatus.secondCall, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'PR-5:main',
+                        buildStatus: 'SUCCESS',
+                        url: 'http://findbugs.com',
+                        pipelineId,
+                        context: 'findbugs',
+                        description: '923 issues found. Previous count: 914 issues.'
+                    });
+                    assert.calledWith(scmMock.updateCommitStatus.thirdCall, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'PR-5:main',
+                        buildStatus: 'FAILURE',
+                        url: 'https://display.com/some/endpoint/pipelines/1234/builds/9876',
+                        pipelineId,
+                        context: 'snyk',
+                        description: '23 package vulnerabilities found. ' +
+                            'Previous count: 0 vulnerabilities.'
+                    });
+                });
+        });
+
         it('aborts running steps, and sets an endTime', () => {
             build.status = 'ABORTED';
 
@@ -562,7 +641,7 @@ describe('Build Model', () => {
                 });
         });
 
-        it('skips custom status update if meta status field is not an object', () => {
+        it('skips custom status update if meta status field is not a JSON parseable string', () => {
             jobFactoryMock.get.resolves({
                 id: jobId,
                 name: 'PR-5:main',
@@ -580,6 +659,44 @@ describe('Build Model', () => {
             build.status = 'FAILURE';
             build.meta.meta.status = {
                 findbugs: 'hello'
+            };
+            delete build.meta.meta.summary;
+
+            return build.update()
+                .then(() => {
+                    assert.calledWith(scmMock.updateCommitStatus.firstCall, {
+                        token: 'foo',
+                        scmUri,
+                        scmContext,
+                        sha,
+                        jobName: 'PR-5:main',
+                        buildStatus: 'FAILURE',
+                        url,
+                        pipelineId
+                    });
+                    assert.notOk(scmMock.updateCommitStatus.secondCall);
+                    assert.notCalled(scmMock.addPrComment);
+                });
+        });
+
+        it('skips custom status update if meta status field is not an object or string', () => {
+            jobFactoryMock.get.resolves({
+                id: jobId,
+                name: 'PR-5:main',
+                pipeline: Promise.resolve({
+                    id: pipelineId,
+                    configPipelineId,
+                    scmUri,
+                    scmContext,
+                    admin: Promise.resolve(adminUser),
+                    token: Promise.resolve('foo')
+                }),
+                permutations: [{ annotations }],
+                isPR: sinon.stub().returns(true)
+            });
+            build.status = 'FAILURE';
+            build.meta.meta.status = {
+                findbugs: 12345
             };
             delete build.meta.meta.summary;
 


### PR DESCRIPTION
## Context
Currently, you need to set each field in `meta.status` separately:
```
steps:
      - status: |
          meta set meta.status.coverage.status SUCCESS
          meta set meta.status.coverage.message 'Coverage is above 80%'
```
It'd be nicer if we could JSON parse a string for the user so the command can be done in one line:
```
steps:
      - status: |
           meta set --format json meta.summary.coverage '{"status":"SUCCESS","message":"Coverage is above 80%"}'
```

## Objective
This PR tries to JSON parse the string.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1440