### PR TITLE
feat(1412): metrics for events & builds (pipeline scope)

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -274,15 +274,19 @@ class BuildModel extends BaseModel {
 
     /**
     * Get models for all steps
-    * @method getStepsModel
+    * @param  {String}   [config.startTime]     Search for builds after this startTime
+    * @param  {String}   [config.endTime]       Search for builds before this endTime
+    * @method getSteps
     * @return {Promise}
     */
-    getStepsModel() {
-        const listConfig = {
+    getSteps(config) {
+        const defaultConfig = {
             params: {
                 buildId: this.id
             }
         };
+
+        const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
@@ -438,7 +442,7 @@ class BuildModel extends BaseModel {
         const abortSteps = () => {
             const now = (new Date()).toISOString();
 
-            return this.getStepsModel().then((steps) => {
+            return this.getSteps().then((steps) => {
                 if (steps.length !== 0) {
                     return Promise.all(steps.map((step) => {
                         if (step.startTime && !step.endTime) {
@@ -516,6 +520,36 @@ class BuildModel extends BaseModel {
     isDone() {
         return ['ABORTED', 'FAILURE', 'SUCCESS'].includes(this.status) ||
         (this.status === 'UNSTABLE' && !!this.endTime);
+    }
+
+    /**
+     * getMetrics for this build
+     * @method getMetrics
+     * @param  {Object}   [config]              Configuration object
+     * @param  {String}   [config.startTime]    Look at steps created after this startTime
+     * @param  {String}   [config.endTime]      Look at steps created before this endTime
+     * @return {Promise}  Resolves to array of metrics for steps belong to this event
+     */
+    async getMetrics(config) {
+        // if no config pass in then get all (will not pass startTime/endTime to datastore)
+        const startTime = config ? config.startTime : null;
+        const endTime = config ? config.endTime : null;
+
+        // Get steps during this time range
+        const steps = await this.getSteps({
+            startTime,
+            endTime
+        });
+
+        // Generate metrics
+        const metrics = steps.map((s) => {
+            const { id, name, code } = s;
+            const duration = (s.endTime && s.startTime) ? (s.endTime - s.startTime) : -1; // something wrong, endTime is not there
+
+            return { id, name, code, duration };
+        });
+
+        return metrics;
     }
 }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -288,6 +288,12 @@ class BuildModel extends BaseModel {
 
         const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 
+        if (listConfig.startTime || listConfig.endTime) {
+            // by default, datastore uses the key `createTime` to do time based filtering
+            // since step doesn't have `createTime` field, we use `startTime`
+            listConfig.timeKey = 'startTime';
+        }
+
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */

--- a/lib/build.js
+++ b/lib/build.js
@@ -536,21 +536,17 @@ class BuildModel extends BaseModel {
      * @param  {String}   [config.endTime]      Look at steps created before this endTime
      * @return {Promise}  Resolves to array of metrics for steps belong to this event
      */
-    async getMetrics(config) {
-        // if no config pass in then get all (will not pass startTime/endTime to datastore)
-        const startTime = config ? config.startTime : null;
-        const endTime = config ? config.endTime : null;
-
+    async getMetrics(config = { startTime: null, endTime: null }) {
         // Get steps during this time range
         const steps = await this.getSteps({
-            startTime,
-            endTime
+            startTime: config.startTime,
+            endTime: config.endTime
         });
 
         // Generate metrics
         const metrics = steps.map((s) => {
-            const { id, name, code } = s;
-            const duration = Math.round((new Date(s.endTime) - new Date(s.startTime)) / 1000);
+            const { id, name, code, startTime, endTime } = s;
+            const duration = Math.round((new Date(endTime) - new Date(startTime)) / 1000);
 
             return { id, name, code, duration };
         });

--- a/lib/build.js
+++ b/lib/build.js
@@ -544,7 +544,7 @@ class BuildModel extends BaseModel {
         // Generate metrics
         const metrics = steps.map((s) => {
             const { id, name, code } = s;
-            const duration = (s.endTime && s.startTime) ? (s.endTime - s.startTime) : -1; // something wrong, endTime is not there
+            const duration = Math.round((new Date(s.endTime) - new Date(s.startTime)) / 1000);
 
             return { id, name, code, duration };
         });

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -180,7 +180,7 @@ function mergeStepsModel(build) {
         return Promise.resolve(build);
     }
 
-    return build.getStepsModel()
+    return build.getSteps()
         .then((stepsModel) => {
             build.steps = build.steps.map((step) => {
                 const stepModel = stepsModel.find(s => s.name === step.name);

--- a/lib/event.js
+++ b/lib/event.js
@@ -38,6 +38,36 @@ class EventModel extends BaseModel {
 
         return factory.list(listConfig);
     }
+
+    /**
+     * getMetrics for this event
+     * @method getMetrics
+     * @param  {Object}   [config]              Configuration object
+     * @param  {String}   [config.startTime]    Look at builds created after this startTime
+     * @param  {String}   [config.endTime]      Look at builds created before this endTime
+     * @return {Promise}  Resolves to array of metrics for builds belong to this event
+     */
+    async getMetrics(config) {
+        // if no config pass in then get all (will not pass startTime/endTime to datastore)
+        const startTime = config ? config.startTime : null;
+        const endTime = config ? config.endTime : null;
+
+        // Get builds during this time range
+        const builds = await this.getBuilds({
+            startTime,
+            endTime
+        });
+
+        // Generate metrics
+        const metrics = builds.map((b) => {
+            const { id, createTime, status } = b;
+            const duration = (b.endTime && b.startTime) ? (b.endTime - b.startTime) : -1; // something wrong, endTime is not there
+
+            return { id, createTime, status, duration };
+        });
+
+        return metrics;
+    }
 }
 
 module.exports = EventModel;

--- a/lib/event.js
+++ b/lib/event.js
@@ -47,21 +47,17 @@ class EventModel extends BaseModel {
      * @param  {String}   [config.endTime]      Look at builds created before this endTime
      * @return {Promise}  Resolves to array of metrics for builds belong to this event
      */
-    async getMetrics(config) {
-        // if no config pass in then get all (will not pass startTime/endTime to datastore)
-        const startTime = config ? config.startTime : null;
-        const endTime = config ? config.endTime : null;
-
+    async getMetrics(config = { startTime: null, endTime: null }) {
         // Get builds during this time range
         const builds = await this.getBuilds({
-            startTime,
-            endTime
+            startTime: config.startTime,
+            endTime: config.endTime
         });
 
         // Generate metrics
         const metrics = builds.map((b) => {
-            const { id, createTime, status } = b;
-            const duration = Math.round((new Date(b.endTime) - new Date(b.startTime)) / 1000);
+            const { id, createTime, status, startTime, endTime } = b;
+            const duration = Math.round((new Date(endTime) - new Date(startTime)) / 1000);
 
             return { id, createTime, status, duration };
         });

--- a/lib/event.js
+++ b/lib/event.js
@@ -61,7 +61,7 @@ class EventModel extends BaseModel {
         // Generate metrics
         const metrics = builds.map((b) => {
             const { id, createTime, status } = b;
-            const duration = (b.endTime && b.startTime) ? (b.endTime - b.startTime) : -1; // something wrong, endTime is not there
+            const duration = Math.round((new Date(b.endTime) - new Date(b.startTime)) / 1000);
 
             return { id, createTime, status, duration };
         });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1158,15 +1158,11 @@ class PipelineModel extends BaseModel {
      * @param  {String}   [config.endTime]      Look at events created before this endTime
      * @return {Promise}  Resolves to array of metrics for events belong to this pipeline
      */
-    async getMetrics(config) {
-        // if no config pass in then get all (will not pass startTime/endTime to datastore)
-        const startTime = config ? config.startTime : null;
-        const endTime = config ? config.endTime : null;
-
+    async getMetrics(config = { startTime: null, endTime: null }) {
         // Get events during this time range
         const events = await this.getEvents({
-            startTime,
-            endTime
+            startTime: config.startTime,
+            endTime: config.endTime
         });
 
         // Calculate event duration by using max endTime - min startTime of builds

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1195,9 +1195,10 @@ class PipelineModel extends BaseModel {
 
         // Generate metrics
         const promiseArray = events.map(async (e) => {
+            const { id, createTime, causeMessage, commit, sha } = e;
             const duration = await eventDuration(e);
 
-            return Object.assign({}, e, { duration });
+            return { id, createTime, causeMessage, commit, sha, duration };
         });
 
         return Promise.all(promiseArray);

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -161,7 +161,7 @@ describe('Build Model', () => {
         assert.instanceOf(build, BaseModel);
         assert.isFunction(build.start);
         assert.isFunction(build.stop);
-        assert.isFunction(build.getStepsModel);
+        assert.isFunction(build.getSteps);
 
         schema.models.build.allKeys.forEach((key) => {
             assert.strictEqual(build[key], config[key]);
@@ -1212,7 +1212,7 @@ describe('Build Model', () => {
         });
     });
 
-    describe('getStepsModel', () => {
+    describe('getSteps', () => {
         it('use the default config when not passed in', () => {
             const expected = {
                 params: {
@@ -1220,7 +1220,7 @@ describe('Build Model', () => {
                 }
             };
 
-            return build.getStepsModel().then(() => {
+            return build.getSteps().then(() => {
                 assert.calledWith(stepFactoryMock.list, expected);
             });
         });

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1291,12 +1291,14 @@ describe('Build Model', () => {
             const stepListConfig = {
                 params: {
                     buildId: 9876
-                }
+                },
+                endTime,
+                timeKey: 'startTime'
             };
 
             stepFactoryMock.list.resolves([step1, step2]);
 
-            return build.getMetrics().then((result) => {
+            return build.getMetrics({ endTime }).then((result) => {
                 assert.calledWith(stepFactoryMock.list, stepListConfig);
                 assert.deepEqual(result, metrics);
             });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -6,7 +6,7 @@ const hoek = require('hoek');
 const schema = require('screwdriver-data-schema');
 const sinon = require('sinon');
 let startStub;
-let getStepsModelStub;
+let getStepsStub;
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -21,7 +21,7 @@ class Build {
         this.uiUri = config.uiUri;
         this.steps = config.steps;
         this.start = startStub.resolves(this);
-        this.getStepsModel = getStepsModelStub;
+        this.getSteps = getStepsStub;
     }
 }
 
@@ -112,7 +112,7 @@ describe('Build Factory', () => {
             getInstance: sinon.stub().returns(buildClusterFactoryMock)
         };
         startStub = sinon.stub();
-        getStepsModelStub = sinon.stub();
+        getStepsStub = sinon.stub();
 
         // Fixing mockery issue with duplicate file names
         // by re-registering data-schema with its own implementation
@@ -680,7 +680,7 @@ describe('Build Factory', () => {
         });
 
         it('should get a build by ID without step models', () => {
-            getStepsModelStub.resolves([]);
+            getStepsStub.resolves([]);
             datastore.get.resolves(buildData);
 
             return factory.get(buildId)
@@ -688,7 +688,7 @@ describe('Build Factory', () => {
         });
 
         it('should get a build by ID with merged step data', () => {
-            getStepsModelStub.resolves(stepsMock);
+            getStepsStub.resolves(stepsMock);
             datastore.get.resolves(buildData);
 
             return factory.get(buildId)
@@ -717,7 +717,7 @@ describe('Build Factory', () => {
         });
 
         it('should list builds without step models', () => {
-            getStepsModelStub.resolves([]);
+            getStepsStub.resolves([]);
             datastore.scan.resolves([buildData, buildData]);
 
             return factory.list({})
@@ -725,7 +725,7 @@ describe('Build Factory', () => {
         });
 
         it('should list builds with merged step data', () => {
-            getStepsModelStub.resolves(stepsMock);
+            getStepsStub.resolves(stepsMock);
             datastore.scan.resolves([buildData, buildData]);
 
             return factory.list({})


### PR DESCRIPTION
- Adds build duration trend of an event
- Adds step duration trend of a build
- Removes unnecessary fields from returned metrics for event duration trend of a pipeline

Blocked by: https://github.com/screwdriver-cd/datastore-sequelize/pull/45
Related: https://github.com/screwdriver-cd/screwdriver/issues/1412