### PR TITLE
fix(1010): pr branch's prChain flag does not override base branch's one.

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -360,10 +360,9 @@ class PipelineModel extends BaseModel {
                 this.jobs
             ]))
             .then(([parsedConfig, jobs]) => {
-                this.prChain = parsedConfig.prChain;
                 logger.info(`pipelineId:${this.id}: prChain flag is ${this.prChain}.`);
 
-                const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}`));
+                const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
 
                 // Get next jobs for when startFrom is ~pr
                 let nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
@@ -407,7 +406,7 @@ class PipelineModel extends BaseModel {
 
                 // filter to keep only the pipeline jobs that include in the jobsToCreate list
                 const prFromPipelineJobs = jobs.filter(j =>
-                    !j.name.startsWith(`PR-${prNum}`) && jobsToCreate.includes(j.name));
+                    !j.name.startsWith(`PR-${prNum}:`) && jobsToCreate.includes(j.name));
 
                 // create a map for PR Parent Jobs like: {main: 1, publish: 2}
                 const prParentJobIdMap = {};

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -20,8 +20,8 @@ const EXTERNAL_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML, {
         scmUrls: SCM_URLS
     }
 });
-const PRCHAIN_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML_PR, {
-    prChain: true
+const NON_PRCHAIN_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML_PR, {
+    prChain: false
 });
 
 describe('Pipeline Model', () => {
@@ -952,7 +952,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('updates PR config and create missing PR jobs if prChain is true', () => {
+        it('updates PR config, but it can not override prChain flag', () => {
             const firstPRJob = {
                 update: sinon.stub().resolves(null),
                 isPR: sinon.stub().returns(true),
@@ -960,7 +960,9 @@ describe('Pipeline Model', () => {
                 state: 'ENABLED',
                 archived: false
             };
-            const clonedYAML = JSON.parse(JSON.stringify(PRCHAIN_PARSED_YAML));
+
+            pipeline.prChain = true;
+            const clonedYAML = JSON.parse(JSON.stringify(NON_PRCHAIN_PARSED_YAML));
 
             jobFactoryMock.list.onCall(0).resolves([mainJob, publishJob, testJob, firstPRJob]); // all jobs
             jobFactoryMock.list.onCall(1).resolves([mainJob, publishJob, testJob]); // pipeline jobs


### PR DESCRIPTION
## Context

Currently, PR branch's `prChain` flag can override base branch's one.
It is contrary to the specifications. This PR fixes it.

## References

- https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-448142968
> #### Precondition:
> * Only the prChain flag of main branch will affect the job chain.
> * Even if prChain flag is changed in PRs, behavior of job chain does not change.
> * This is because, it is quite dangerous that anyone can change prChain flag in PR and run subsequent jobs easily.