### PR TITLE
fix: add fetchSteps flag to list builds function

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -388,11 +388,20 @@ class BuildFactory extends BaseFactory {
      * @param  {Object}   config.paginate         Pagination parameters
      * @param  {Number}   config.paginate.count   Number of items per page
      * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @param  {Boolean}  [config.fetchSteps]     Fetch steps for all the builds, default is true
      * @return {Promise}                          Resolve builds after merging with step models
      */
     list(config) {
+        const fetchSteps = config.fetchSteps ? config.fetchSteps : false;
+
         return super.list(config)
-            .then(builds => Promise.all(builds.map(mergeStepsModel)));
+            .then((builds) => {
+                if (fetchSteps) {
+                    return Promise.all(builds.map(mergeStepsModel));
+                }
+
+                return builds;
+            });
     }
 
     /**

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -392,7 +392,7 @@ class BuildFactory extends BaseFactory {
      * @return {Promise}                          Resolve builds after merging with step models
      */
     list(config) {
-        const fetchSteps = config.fetchSteps ? config.fetchSteps : false;
+        const fetchSteps = config.fetchSteps || false;
 
         return super.list(config)
             .then((builds) => {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "async": "^2.6.1",
+    "async": "^2.6.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
     "docker-parse-image": "^3.0.1",

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -724,12 +724,20 @@ describe('Build Factory', () => {
                 .then(builds => builds.map(build => assert.deepEqual(build.steps, steps)));
         });
 
-        it('should list builds with merged step data', () => {
+        it('should list builds with merged step data if config.fetchSteps is true', () => {
+            getStepsStub.resolves(stepsMock);
+            datastore.scan.resolves([buildData, buildData]);
+
+            return factory.list({ fetchSteps: true })
+                .then(builds => builds.map(build => assert.deepEqual(build.steps, stepsData)));
+        });
+
+        it('should not list builds with merged step data by default', () => {
             getStepsStub.resolves(stepsMock);
             datastore.scan.resolves([buildData, buildData]);
 
             return factory.list({})
-                .then(builds => builds.map(build => assert.deepEqual(build.steps, stepsData)));
+                .then(builds => builds.map(build => assert.deepEqual(build.steps, steps)));
         });
     });
 


### PR DESCRIPTION
Currently we will get steps info from steps table for each build during list builds, this creates a lot of unnecessary queries to our DB since usually we do not need steps info when listing builds.

This PR will add a `fetchSteps` flag to list builds function and set it to `false` by default. Later on, if we really need to fetch steps for listing builds, we can still set the flag and get it.