### PR TITLE
fix(1010): [small] update the workflowGraph of the event with prChain enabled.

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -265,6 +265,48 @@ function getLatestWorkflowGraph(config) {
     return Promise.resolve(pipeline.workflowGraph);
 }
 
+/**
+ * Update the workflowGraph
+ * @method updateWorkflowGraph
+ * @param  {Object}         config
+ * @param  {Pipeline}       pipeline            Pipeline
+ * @param  {Number}         pipeline.id         Pipeline id
+ * @param  {Object}         eventConfig
+ * @param  {Number}         [eventConfig.prNum] PR number
+ * @param  {Object}         workflowGraph       WorkflowGraph
+ * @resolves {Object}                           Resolves with workflowGraph
+ */
+function updateWorkflowGraph(config) {
+    const { pipeline, eventConfig, workflowGraph } = config;
+
+    if (pipeline.prChain) {
+        // eslint-disable-next-line global-require
+        const JobFactory = require('./jobFactory');
+        const jobFactory = JobFactory.getInstance();
+
+        return jobFactory.list({
+            params: { pipelineId: pipeline.id, archived: false },
+            search: { field: 'name', keyword: `PR-${eventConfig.prNum}:%` }
+        })
+            .then((prChainedJobs) => {
+                const nodes = workflowGraph.nodes;
+
+                prChainedJobs.forEach((job) => {
+                    // Add jobId to workflowGraph.nodes
+                    nodes.forEach((node) => {
+                        if (`PR-${eventConfig.prNum}:${node.name}` === job.name) {
+                            node.id = job.id;
+                        }
+                    });
+                });
+
+                return workflowGraph;
+            });
+    }
+
+    return Promise.resolve(workflowGraph);
+}
+
 class EventFactory extends BaseFactory {
     /**
      * Construct a EventFactory object
@@ -423,8 +465,13 @@ class EventFactory extends BaseFactory {
                         eventConfig: config
                     });
                 })
-                .then((workflowGraph) => {
-                    modelConfig.workflowGraph = workflowGraph;
+                .then(workflowGraph => updateWorkflowGraph({
+                    pipeline,
+                    eventConfig: config,
+                    workflowGraph
+                }))
+                .then((updatedWorkflowGraph) => {
+                    modelConfig.workflowGraph = updatedWorkflowGraph;
 
                     return super.create(modelConfig);
                 })

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -15,7 +15,7 @@ let instance;
 /**
  * Get triggered jobs to start that are enabled
  * @method getJobsFromTrigger
- * @param  {Object}   config
+ * @param  {Object}   config.*
  * @param  {String}   config.branch                         triggered branch name
  * @param  {Array}    config.jobs                           Array of job objects
  * @param  {Object}   config.pipelineConfig
@@ -48,7 +48,7 @@ function getJobsFromTrigger(config) {
 /**
  * Get jobs from job name to start that are enabled
  * @method getJobsFromJobName
- * @param  {Object}   config
+ * @param  {Object}   config.*
  * @param  {Array}    config.jobs      Array of job objects
  * @param  {String}   config.startFrom Startfrom (e.g. ~commit, ~pr, etc)
  * @return {Array}                     Array of jobs to start
@@ -68,7 +68,7 @@ function getJobsFromJobName(config) {
 /**
  * Get PR jobs to start that are enabled
  * @method getJobsFromPR
- * @param  {Object}    config
+ * @param  {Object}    config.*
  * @param  {Array}     config.jobs                           Array of job objects
  * @param  {Number}    config.prNum                          PR number
  * @param  {Object}    config.pipelineConfig
@@ -101,7 +101,7 @@ function getJobsFromPR(config) {
 /**
  * Starts the build if the changed file is part of the sourcePaths, or if there is no sourcePaths
  * @method startBuild
- * @param  {Object}   config                configuration object
+ * @param  {Object}   config.*              configuration object
  * @param  {Object}   config.buildConfig    Build Config to create the build with
  * @param  {Array}    config.changedFiles   List of files that were changed
  * @param  {Array}    config.sourcePaths    List of soure paths
@@ -150,7 +150,7 @@ function startBuild(config) {
  * Create builds associated with this event
  * For example, if startFrom ~commit, then create builds with jobs that have requires: ~commit
  * @method createBuilds
- * @param  {Object}   config
+ * @param  {Object}   config.*
  * @param  {Object}   config.eventConfig
  * @param  {String}   config.eventConfig.sha                 SHA this project was built on
  * @param  {String}   config.eventConfig.username            Username of the user that creates this event
@@ -244,9 +244,9 @@ function createBuilds(config) {
 /**
  * Get the latest workflowGraph
  * @method getLatestWorkflowGraph
- * @param  {Object}         config
- * @param  {Pipeline}       pipeline            Pipeline
- * @param  {Object}         eventConfig
+ * @param  {Object}         config.*
+ * @param  {Pipeline}       pipeline.*          Pipeline
+ * @param  {Object}         eventConfig.*
  * @param  {String}         [eventConfig.prRef] PR ref
  * @resolves {Object}                           Resolves with workflowGraph
  */
@@ -268,10 +268,10 @@ function getLatestWorkflowGraph(config) {
 /**
  * Update the workflowGraph
  * @method updateWorkflowGraph
- * @param  {Object}         config
- * @param  {Pipeline}       pipeline            Pipeline
+ * @param  {Object}         config.*
+ * @param  {Pipeline}       pipeline.*          Pipeline
  * @param  {Number}         pipeline.id         Pipeline id
- * @param  {Object}         eventConfig
+ * @param  {Object}         eventConfig.*
  * @param  {Number}         [eventConfig.prNum] PR number
  * @param  {Object}         workflowGraph       WorkflowGraph
  * @resolves {Object}                           Resolves with workflowGraph

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -272,14 +272,15 @@ function getLatestWorkflowGraph(config) {
  * @param  {Pipeline}       config.pipeline            Pipeline
  * @param  {Number}         config.pipeline.id         Pipeline id
  * @param  {Object}         config.eventConfig
- * @param  {Number}         [config.eventConfig.prNum] PR number
+ * @param  {Number}         [config.eventConfig.prRef] Ref if it's a PR event
+ * @param  {Number}         [config.eventConfig.prNum] PR number if it's a PR event
  * @param  {Object}         config.workflowGraph       WorkflowGraph
  * @resolves {Object}                                  Resolves with workflowGraph
  */
 function updateWorkflowGraph(config) {
     const { pipeline, eventConfig, workflowGraph } = config;
 
-    if (pipeline.prChain) {
+    if (eventConfig.prRef && pipeline.prChain) {
         // eslint-disable-next-line global-require
         const JobFactory = require('./jobFactory');
         const jobFactory = JobFactory.getInstance();

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -15,7 +15,7 @@ let instance;
 /**
  * Get triggered jobs to start that are enabled
  * @method getJobsFromTrigger
- * @param  {Object}   config.*
+ * @param  {Object}   config
  * @param  {String}   config.branch                         triggered branch name
  * @param  {Array}    config.jobs                           Array of job objects
  * @param  {Object}   config.pipelineConfig
@@ -48,7 +48,7 @@ function getJobsFromTrigger(config) {
 /**
  * Get jobs from job name to start that are enabled
  * @method getJobsFromJobName
- * @param  {Object}   config.*
+ * @param  {Object}   config
  * @param  {Array}    config.jobs      Array of job objects
  * @param  {String}   config.startFrom Startfrom (e.g. ~commit, ~pr, etc)
  * @return {Array}                     Array of jobs to start
@@ -68,7 +68,7 @@ function getJobsFromJobName(config) {
 /**
  * Get PR jobs to start that are enabled
  * @method getJobsFromPR
- * @param  {Object}    config.*
+ * @param  {Object}    config
  * @param  {Array}     config.jobs                           Array of job objects
  * @param  {Number}    config.prNum                          PR number
  * @param  {Object}    config.pipelineConfig
@@ -101,7 +101,7 @@ function getJobsFromPR(config) {
 /**
  * Starts the build if the changed file is part of the sourcePaths, or if there is no sourcePaths
  * @method startBuild
- * @param  {Object}   config.*              configuration object
+ * @param  {Object}   config                configuration object
  * @param  {Object}   config.buildConfig    Build Config to create the build with
  * @param  {Array}    config.changedFiles   List of files that were changed
  * @param  {Array}    config.sourcePaths    List of soure paths
@@ -150,7 +150,7 @@ function startBuild(config) {
  * Create builds associated with this event
  * For example, if startFrom ~commit, then create builds with jobs that have requires: ~commit
  * @method createBuilds
- * @param  {Object}   config.*
+ * @param  {Object}   config
  * @param  {Object}   config.eventConfig
  * @param  {String}   config.eventConfig.sha                 SHA this project was built on
  * @param  {String}   config.eventConfig.username            Username of the user that creates this event
@@ -244,11 +244,11 @@ function createBuilds(config) {
 /**
  * Get the latest workflowGraph
  * @method getLatestWorkflowGraph
- * @param  {Object}         config.*
- * @param  {Pipeline}       pipeline.*          Pipeline
- * @param  {Object}         eventConfig.*
- * @param  {String}         [eventConfig.prRef] PR ref
- * @resolves {Object}                           Resolves with workflowGraph
+ * @param  {Object}         config
+ * @param  {Pipeline}       config.pipeline            Pipeline
+ * @param  {Object}         config.eventConfig
+ * @param  {String}         [config.eventConfig.prRef] PR ref
+ * @resolves {Object}                                  Resolves with workflowGraph
  */
 function getLatestWorkflowGraph(config) {
     const { pipeline, eventConfig } = config;
@@ -268,13 +268,13 @@ function getLatestWorkflowGraph(config) {
 /**
  * Update the workflowGraph
  * @method updateWorkflowGraph
- * @param  {Object}         config.*
- * @param  {Pipeline}       pipeline.*          Pipeline
- * @param  {Number}         pipeline.id         Pipeline id
- * @param  {Object}         eventConfig.*
- * @param  {Number}         [eventConfig.prNum] PR number
- * @param  {Object}         workflowGraph       WorkflowGraph
- * @resolves {Object}                           Resolves with workflowGraph
+ * @param  {Object}         config
+ * @param  {Pipeline}       config.pipeline            Pipeline
+ * @param  {Number}         config.pipeline.id         Pipeline id
+ * @param  {Object}         config.eventConfig
+ * @param  {Number}         [config.eventConfig.prNum] PR number
+ * @param  {Object}         config.workflowGraph       WorkflowGraph
+ * @resolves {Object}                                  Resolves with workflowGraph
  */
 function updateWorkflowGraph(config) {
     const { pipeline, eventConfig, workflowGraph } = config;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
     "mockery": "^2.0.0",
+    "rewire": "^4.0.1",
     "sinon": "^4.5.0"
   },
   "dependencies": {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -570,12 +570,12 @@ describe('Event Factory', () => {
             });
 
             // Private function test
-            it('should keep the workflowGraph as is with prChain = false', () => {
+            it('should keep the workflowGraph as is with non pr event and prChain = true', () => {
                 const RewiredEventFactory = rewire('../../lib/eventFactory');
                 // eslint-disable-next-line no-underscore-dangle
                 const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
-                const pipeline = { id: 1234, prChain: false };
-                const eventConfig = { prNum: 1 };
+                const pipeline = { id: 1234, prChain: true };
+                const eventConfig = {}; // non pr event
                 const inWorkflowGraph = {
                     nodes: [
                         { name: '~pr' },
@@ -601,12 +601,43 @@ describe('Event Factory', () => {
                 });
             });
 
-            it('should update the workflowGraph properly with prChain = true', () => {
+            it('should keep the workflowGraph as is with pr event and prChain = false', () => {
+                const RewiredEventFactory = rewire('../../lib/eventFactory');
+                // eslint-disable-next-line no-underscore-dangle
+                const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
+                const pipeline = { id: 1234, prChain: false };
+                const eventConfig = { prRef: 'branch', prNum: 1 };
+                const inWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'job-A' },
+                        { name: 'job-B' }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+                const expectedWorkflowGraph = inWorkflowGraph;
+
+                return updateWorkflowGraph({
+                    pipeline,
+                    eventConfig,
+                    workflowGraph: inWorkflowGraph
+                }).then((actualWorkflowGraph) => {
+                    assert.notCalled(jobFactoryMock.list);
+                    assert.deepEqual(expectedWorkflowGraph, actualWorkflowGraph);
+                });
+            });
+
+            it('should update the workflowGraph properly with pr event and prChain = true', () => {
                 const RewiredEventFactory = rewire('../../lib/eventFactory');
                 // eslint-disable-next-line no-underscore-dangle
                 const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
                 const pipeline = { id: 1234, prChain: true };
-                const eventConfig = { prNum: 1 };
+                const eventConfig = { prRef: 'branch', prNum: 1 };
                 const inWorkflowGraph = {
                     nodes: [
                         { name: '~pr' },

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const sinon = require('sinon');
 const mockery = require('mockery');
+const rewire = require('rewire');
 const PARSED_YAML = require('../data/parserWithWorkflowGraph');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -41,7 +42,8 @@ describe('Event Factory', () => {
             create: sinon.stub()
         };
         jobFactoryMock = {
-            create: sinon.stub()
+            create: sinon.stub(),
+            list: sinon.stub()
         };
         scm = {
             decorateAuthor: sinon.stub(),
@@ -567,6 +569,92 @@ describe('Event Factory', () => {
                 });
             });
 
+            // Private function test
+            it('should keep the workflowGraph as is with prChain = false', () => {
+                const RewiredEventFactory = rewire('../../lib/eventFactory');
+                // eslint-disable-next-line no-underscore-dangle
+                const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
+                const pipeline = { id: 1234, prChain: false };
+                const eventConfig = { prNum: 1 };
+                const inWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'job-A' },
+                        { name: 'job-B' }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+                const expectedWorkflowGraph = inWorkflowGraph;
+
+                return updateWorkflowGraph({
+                    pipeline,
+                    eventConfig,
+                    workflowGraph: inWorkflowGraph
+                }).then((actualWorkflowGraph) => {
+                    assert.notCalled(jobFactoryMock.list);
+                    assert.deepEqual(expectedWorkflowGraph, actualWorkflowGraph);
+                });
+            });
+
+            it('should update the workflowGraph properly with prChain = true', () => {
+                const RewiredEventFactory = rewire('../../lib/eventFactory');
+                // eslint-disable-next-line no-underscore-dangle
+                const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
+                const pipeline = { id: 1234, prChain: true };
+                const eventConfig = { prNum: 1 };
+                const inWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'job-A' },
+                        { name: 'job-B' }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+                const expectedWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        // add ids
+                        { name: 'job-A', id: 22 },
+                        { name: 'job-B', id: 23 }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+                const jobs = [
+                    { name: 'PR-1:job-A', id: 22 },
+                    { name: 'PR-1:job-B', id: 23 }
+                ];
+
+                jobFactoryMock.list.onCall(0).resolves(jobs);
+
+                return updateWorkflowGraph({
+                    pipeline,
+                    eventConfig,
+                    workflowGraph: inWorkflowGraph
+                }).then((actualWorkflowGraph) => {
+                    assert.calledOnce(jobFactoryMock.list);
+                    assert.calledWith(jobFactoryMock.list, sinon.match({
+                        params: { pipelineId: pipeline.id, archived: false },
+                        search: { field: 'name', keyword: `PR-${eventConfig.prNum}:%` }
+                    }));
+                    assert.deepEqual(expectedWorkflowGraph, actualWorkflowGraph);
+                });
+            });
+
             it('should create build of the "PR-1:main" job with prChain config', () => {
                 config.startFrom = '~pr';
                 config.prRef = 'branch';
@@ -577,10 +665,13 @@ describe('Event Factory', () => {
                 afterSyncedPRPipelineMock.jobs = Promise.resolve(jobsMock);
                 afterSyncedPRPipelineMock.prChain = true;
                 afterSyncedPRPipelineMock.update = sinon.stub().resolves(afterSyncedPRPipelineMock);
+                // This function is called in updateWorkflowGraph() which is tested in another unit test.
+                jobFactoryMock.list.resolves([]);
 
                 return eventFactory.create(config).then((model) => {
                     assert.instanceOf(model, Event);
                     assert.notCalled(jobFactoryMock.create);
+                    assert.called(jobFactoryMock.list);
                     assert.calledWith(buildFactoryMock.create, sinon.match({
                         parentBuildId: 12345,
                         eventId: model.id,


### PR DESCRIPTION
## Context

Workflow graphs of PR chain enabled event have no job ids.
This PR adds job ids to those graphs.
And I add `rewire` package for unit tests. Let's write unit tests for each function!

## Note

- Currently `PR-#:` prefixed name is not allowed by the workflow graph validator. We should consider the addition of the prefix carefully.
```
[request,server,error] data: Error: child "workflowGraph" fails because [child "nodes" fails because ["nodes" at position 2 fails because [child "name" fails because ["name" with value "PR-1:first-job" fails to match the required pattern: /^~([\w-]+)$/, "name" with value "PR-1:first-job" fails to match the required pattern: /^[\w-]+$/, "name" with value "PR-1:first-job" fails to match the required pattern: /^~(sd@\d+:[\w-]+|(pr|commit)(:(.+))?)$/]]]]
    at postValidate (/usr/src/app/node_modules/hapi/lib/validation.js:214:30)
...
```

## References

- https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-462615428
