### PR TITLE
fix: add cmt to allow jobName in getJobs

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -955,6 +955,7 @@ class PipelineModel extends BaseModel {
      * @param  {Object}   [config]                  Configuration object
      * @param  {Object}   [config.params]           Filter params
      * @param  {Boolean}  [config.params.archived]  Get archived/non-archived jobs
+     * @param  {String}   [config.params.name]      Get job with this name
      * @param  {String}   [config.type]             Type of jobs (pr or pipeline)
      * @param  {Object}   [config.paginate]         Pagination parameters
      * @param  {Number}   [config.paginate.count]   Number of items per page


### PR DESCRIPTION
Allow query by job name. Shouldn't need code change since we just merge the `listConfig`

Related: https://github.com/screwdriver-cd/screwdriver/issues/1522