### PR TITLE
fix: do not fail build status update if git commit status update failed

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -270,7 +270,12 @@ class BuildModel extends BaseModel {
             }
 
             return Promise.all(updateTasks);
-        });
+        })
+            .catch((err) => {
+                winston.error(`Failed to update commit status: ${err}`);
+
+                return Promise.resolve();
+            });
     }
 
     /**

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -197,13 +197,12 @@ describe('Build Model', () => {
                 })
         );
 
-        it('reject on error', () => {
+        it('resolve on error', () => {
             scmMock.updateCommitStatus.rejects(new Error('nevergonnagiveyouup'));
 
-            return build.updateCommitStatus(pipelineMock, apiUri)
-                .catch((err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.message, 'nevergonnagiveyouup');
+            return build.updateCommitStatus(pipelineMock)
+                .catch(() => {
+                    throw new Error('Should not get here');
                 });
         });
     });


### PR DESCRIPTION
- make `build.updateCommitStatus` always resolve and print out the err otherwise it may fail `build.update()` and `executor.start()`. But that's probably not what we want. Git status update shouldn't be a blocker for these functions.

`executor.start()`: https://github.com/screwdriver-cd/models/blob/master/lib/build.js#L455
`build.update()`: https://github.com/screwdriver-cd/models/blob/master/lib/build.js#L508

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1527