### PR TITLE
fix: do not fail pipeline.getJobs if cannot decorate open PRs

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -998,11 +998,16 @@ class PipelineModel extends BaseModel {
 
                 if (prJobs.length) {
                     try {
-                        const openedPRsMap = (await this.scm.getOpenedPRs({
+                        const openPrs = await this.scm.getOpenedPRs({
                             scmUri: this.scmUri,
                             scmContext: this.scmContext,
                             token: await this.token
-                        }) || []).reduce((map, pr) => {
+                        }).catch((err) => {
+                            winston.error(`Failed to getOpenedPRs: ${err}`);
+
+                            return Promise.resolve([]);
+                        });
+                        const openedPRsMap = openPrs.reduce((map, pr) => {
                             map[pr.name] = pr;
 
                             return map;

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1363,6 +1363,28 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('still gets PR jobs if scm.getOpenedPRs failed', () => {
+            const config = {
+                type: 'pr'
+            };
+            const expected = {
+                params: {
+                    pipelineId: 123,
+                    archived: false
+                }
+            };
+            const jobList = [publishJob, mainJob, pr10, pr3];
+            const expectedJobs = [pr3, pr10];
+
+            jobFactoryMock.list.resolves(jobList);
+            scmMock.getOpenedPRs.rejects(new Error('user account suspened'));
+
+            return pipeline.getJobs(config).then((result) => {
+                assert.calledWith(jobFactoryMock.list, expected);
+                assert.deepEqual(result, expectedJobs);
+            });
+        });
+
         it('only gets Pipeline jobs', () => {
             const config = {
                 type: 'pipeline'


### PR DESCRIPTION
If pipeline admin's git account is suspended, the pipeline page cannot load and other user cannot sync to update admin because `pipeline.getJobs` will failed at `scm.getOpenedPRs`. 