### PR TITLE
fix: allow get step metrics for all steps for a single job

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -280,36 +280,15 @@ class BuildModel extends BaseModel {
 
     /**
     * Get models for all steps
-    * @param  {String}   [config.startTime]     Search for builds after this startTime
-    * @param  {String}   [config.endTime]       Search for builds before this endTime
-    * @param  {String}   [config.name]          Search for step with this name only
     * @method getSteps
     * @return {Promise}
     */
-    getSteps(config = {}) {
+    getSteps() {
         const listConfig = {
             params: {
                 buildId: this.id
             }
         };
-
-        const { startTime, endTime, name } = config;
-
-        if (startTime) {
-            listConfig.startTime = startTime;
-            // by default, datastore uses the key `createTime` to do time based filtering
-            // since step doesn't have `createTime` field, we use `startTime`
-            listConfig.timeKey = 'startTime';
-        }
-
-        if (endTime) {
-            listConfig.endTime = endTime;
-            listConfig.timeKey = 'startTime';
-        }
-
-        if (name) {
-            listConfig.params.name = name;
-        }
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
@@ -564,13 +543,13 @@ class BuildModel extends BaseModel {
      * @param  {String}   [config.stepName]     Name of step
      * @return {Promise}  Resolves to array of metrics for steps belong to this build
      */
-    async getStepMetrics(config = { startTime: null, endTime: null, stepName: null }) {
-        // Get steps during this time range
-        const steps = await this.getSteps({
-            startTime: config.startTime,
-            endTime: config.endTime,
-            name: config.stepName
-        });
+    getStepMetrics(config = { stepName: null }) {
+        let steps = this.steps;
+
+        // If stepName, get only that step
+        if (config.stepName) {
+            steps = steps.filter(s => s.name === config.stepName);
+        }
 
         // Generate metrics
         const metrics = steps.map((s) => {

--- a/lib/job.js
+++ b/lib/job.js
@@ -265,13 +265,10 @@ class Job extends BaseModel {
         });
 
         // Go through the step for all builds and generate metrics
-        const promiseArray = builds.map(
-            async b => b.getStepMetrics({
-                startTime,
-                endTime,
+        const stepArrays = builds.map(
+            b => b.getStepMetrics({
                 stepName
             }));
-        const stepArrays = await Promise.all(promiseArray);
 
         return [].concat(...stepArrays);
     }

--- a/lib/job.js
+++ b/lib/job.js
@@ -252,12 +252,12 @@ class Job extends BaseModel {
      * getStepMetrics for this job
      * @method getStepMetrics
      * @param  {Object}   config                Configuration object
-     * @param  {String}   config.stepName       Look at this step
+     * @param  {String}   [config.stepName]     Look at this step, if undefined then look at all steps
      * @param  {String}   [config.startTime]    Look at builds created after this startTime
      * @param  {String}   [config.endTime]      Look at builds created before this endTime
      * @return {Promise}  Resolves to array of metrics for steps belong to builds of this job
      */
-    async getStepMetrics({ stepName, startTime = null, endTime = null }) {
+    async getStepMetrics({ stepName = null, startTime = null, endTime = null }) {
         // Get builds during this time range
         const builds = await this.getBuilds({
             startTime,

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1286,8 +1286,6 @@ describe('Build Model', () => {
     });
 
     describe('get metrics', () => {
-        const startTime = '2019-01-20T12:00:00.000Z';
-        const endTime = '2019-01-30T12:00:00.000Z';
         const step1 = {
             id: 11,
             buildId: 9876,
@@ -1325,74 +1323,24 @@ describe('Build Model', () => {
         });
 
         it('generates metrics', () => {
-            const stepListConfig = {
-                params: {
-                    buildId: 9876
-                },
-                startTime,
-                endTime,
-                timeKey: 'startTime'
-            };
+            build.steps = [step1, step2];
 
-            stepFactoryMock.list.resolves([step1, step2]);
-
-            return build.getStepMetrics({ startTime, endTime }).then((result) => {
-                assert.calledWith(stepFactoryMock.list, stepListConfig);
-                assert.deepEqual(result, metrics);
-            });
+            assert.deepEqual(build.getStepMetrics(), metrics);
         });
 
         it('does not fail if empty steps', () => {
-            stepFactoryMock.list.resolves([]);
+            build.steps = [];
 
-            return build.getStepMetrics({ startTime, endTime }).then((result) => {
-                assert.deepEqual(result, []);
-            });
+            assert.deepEqual(build.getStepMetrics(), []);
         });
 
         it('works with no startTime or endTime params passed in', () => {
-            const stepListConfig = {
-                params: {
-                    buildId: 9876,
-                    name: 'sd-setup-scm'
-                },
-                endTime,
-                timeKey: 'startTime'
-            };
+            const stepName = 'sd-setup-scm';
 
-            stepFactoryMock.list.resolves([step1, step2]);
+            build.steps = [step1, step2];
+            metrics = metrics.filter(m => m.name === stepName);
 
-            return build.getStepMetrics({ endTime, stepName: 'sd-setup-scm' }).then((result) => {
-                assert.calledWith(stepFactoryMock.list, stepListConfig);
-                assert.deepEqual(result, metrics);
-            });
-        });
-
-        it('works with no params passed in', () => {
-            const stepListConfig = {
-                params: {
-                    buildId: 9876
-                }
-            };
-
-            stepFactoryMock.list.resolves([step1, step2]);
-
-            return build.getStepMetrics().then((result) => {
-                assert.calledWith(stepFactoryMock.list, stepListConfig);
-                assert.deepEqual(result, metrics);
-            });
-        });
-
-        it('rejects with errors', () => {
-            stepFactoryMock.list.rejects(new Error('cannotgetit'));
-
-            return build.getStepMetrics({ startTime, endTime })
-                .then(() => {
-                    assert.fail('Should not get here');
-                }).catch((err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.message, 'cannotgetit');
-                });
+            assert.deepEqual(build.getStepMetrics({ stepName }), metrics);
         });
     });
 });

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -524,9 +524,9 @@ describe('Job Model', () => {
         let metrics;
 
         beforeEach(() => {
-            build1.getStepMetrics = sinon.stub().resolves([mockMetrics1]);
-            build2.getStepMetrics = sinon.stub().resolves([mockMetrics2]);
-            build3.getStepMetrics = sinon.stub().resolves([mockMetrics3]);
+            build1.getStepMetrics = sinon.stub().returns([mockMetrics1]);
+            build2.getStepMetrics = sinon.stub().returns([mockMetrics2]);
+            build3.getStepMetrics = sinon.stub().returns([mockMetrics3]);
 
             metrics = [mockMetrics1, mockMetrics2, mockMetrics3];
         });
@@ -541,8 +541,6 @@ describe('Job Model', () => {
                 sort: 'descending'
             };
             const getStepMetricsParams = {
-                startTime,
-                endTime,
                 stepName
             };
 


### PR DESCRIPTION
- No actual changes is required, `build.getSteps()` already supports get all steps if `name` is undefined.

https://github.com/screwdriver-cd/models/blob/master/lib/build.js#L310

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1412

