### PR TITLE
fix: [small] fix getJobsFromPR function

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -92,7 +92,7 @@ function getJobsFromPR(config) {
     });
 
     const jobsToStart = jobs.filter(
-        j => j.name.startsWith(`PR-${prNum}:`) || nextJobs.includes(j.name)
+        j => nextJobs.includes(j.name)
     );
 
     return jobsToStart.filter(j => j.state === 'ENABLED' && !j.archived);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -508,11 +508,6 @@ describe('Event Factory', () => {
                         eventId: model.id,
                         jobId: 9
                     }));
-                    assert.calledWith(buildFactoryMock.create, sinon.match({
-                        parentBuildId: 12345,
-                        eventId: model.id,
-                        jobId: 10
-                    }));
                 });
             });
 
@@ -775,7 +770,7 @@ describe('Event Factory', () => {
             }, {
                 id: 2,
                 pipelineId: 8765,
-                name: 'PR-1:test',
+                name: 'PR-1:publish',
                 permutations: [{
                     requires: ['~pr'],
                     sourcePaths: ['src/test/']


### PR DESCRIPTION
## Context
When I made PR with chainPR flag true, all jobs had started at same time unintentionally.
This is because jobs are filtered by job name which prefix is `PR-${prNum}:`.

![k9a6a5c80a734df812067c924793b](https://user-images.githubusercontent.com/16560466/54007322-73844100-41a4-11e9-8afc-8d9808bbe45d.png)

## Objective
We don't need to filter jobs by job name. 
`workflowParser.getNextJobs()` method can get proper jobs which is triggered by `startFrom`, whatever its value is `~pr`, `~pr:branch`, `PR-4:jobname`, `jobA`, and so on...