### PR TITLE
feat(823): [5] enable to start job with ~release and ~tag triggers

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -5,7 +5,9 @@ const Event = require('./event');
 const {
     EXTERNAL_TRIGGER,
     COMMIT_TRIGGER,
-    PR_TRIGGER
+    PR_TRIGGER,
+    RELEASE_TRIGGER,
+    TAG_TRIGGER
 } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const winston = require('winston');
@@ -25,10 +27,14 @@ let instance;
  */
 function getJobsFromTrigger(config) {
     const { jobs, pipelineConfig, startFrom, branch } = config;
-    const isExternalTrigger = EXTERNAL_TRIGGER.test(startFrom);
-    const isCommitTrigger = COMMIT_TRIGGER.test(startFrom);
+    const shouldGetJobs = [
+        EXTERNAL_TRIGGER.test(startFrom),
+        COMMIT_TRIGGER.test(startFrom),
+        RELEASE_TRIGGER.test(startFrom),
+        TAG_TRIGGER.test(startFrom)
+    ];
 
-    if (!isExternalTrigger && !isCommitTrigger) {
+    if (!shouldGetJobs.some(t => t === true)) {
         return [];
     }
 
@@ -180,7 +186,7 @@ function createBuilds(config) {
         pipeline.branch,
         pipeline.jobs
     ]).then(([branch, jobs]) => {
-        // When startFrom is ~commit
+        // When startFrom is ~commit, ~release, ~tag, ~sd@
         const jobsFromTrigger = getJobsFromTrigger({
             jobs,
             pipelineConfig,

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
+    "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
     "rewire": "^4.0.1",
-    "sinon": "^4.5.0"
+    "sinon": "^7.2.7"
   },
   "dependencies": {
     "async": "^2.6.2",

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -845,7 +845,7 @@ describe('Build Model', () => {
         };
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
             sandbox.useFakeTimers(now);
             executorMock.start.resolves(null);
             jobFactoryMock.get.resolves({

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -262,7 +262,7 @@ describe('Build Factory', () => {
             bookendMock.getTeardownCommands.resolves([]);
             datastore.save.resolves({});
 
-            sandbox = sinon.sandbox.create({
+            sandbox = sinon.createSandbox({
                 useFakeTimers: false
             });
             sandbox.useFakeTimers(dateNow);

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -112,7 +112,7 @@ describe('Pipeline Factory', () => {
         };
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create({
+            sandbox = sinon.createSandbox({
                 useFakeTimers: false
             });
             sandbox.useFakeTimers(dateNow);
@@ -163,7 +163,7 @@ describe('Pipeline Factory', () => {
         let sandbox;
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
             sandbox.useFakeTimers(now);
             tokenFactoryMock.get.resolves(tokenMock);
             tokenMock.update.resolves(tokenMock);

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -114,7 +114,7 @@ describe('User Factory', () => {
         let sandbox;
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
             sandbox.useFakeTimers(now);
             tokenFactoryMock.get.resolves(tokenMock);
             tokenMock.update.resolves(tokenMock);


### PR DESCRIPTION
This PR enable to start jobs with `~release` and `~tag` triggers by adding regex check target.

Related Issue: https://github.com/screwdriver-cd/screwdriver/issues/823