### PR TITLE
fix(1010): [2][small] replace prChain flag with chainPR annotation.

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -373,6 +373,7 @@ class EventFactory extends BaseFactory {
      * @param  {Boolean} [config.webhooks]          If the create came from a webhook (pr or push) or not
      * @param  {Object}  [config.meta]              Metadata tied to this event
      * @param  {String}  [config.skipMessage]       Message to skip starting builds
+     * @param  {Boolean} [config.chainPR]           Chain PR flag
      * @return {Promise}
      */
     create(config) {
@@ -383,7 +384,7 @@ class EventFactory extends BaseFactory {
         const pipelineFactory = PipelineFactory.getInstance();
         const { pipelineId, configPipelineSha, username, scmContext,
             parentEventId, sha, startFrom, changedFiles, webhooks,
-            prInfo, prTitle, prRef, prNum, skipMessage } = config;
+            prInfo, prTitle, prRef, prNum, skipMessage, chainPR } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
         const modelConfig = {
@@ -408,10 +409,10 @@ class EventFactory extends BaseFactory {
                     if (configPipelineSha) {
                         modelConfig.configPipelineSha = configPipelineSha;
 
-                        return p.sync(configPipelineSha);
+                        return p.sync(configPipelineSha, chainPR);
                     }
 
-                    return p.sync(config.sha);
+                    return p.sync(config.sha, chainPR);
                 }
 
                 // for child pipelines, get config pipeline sha and sync with that
@@ -421,11 +422,11 @@ class EventFactory extends BaseFactory {
                         .then((commitSha) => {
                             modelConfig.configPipelineSha = commitSha;
 
-                            return p.sync(commitSha);
+                            return p.sync(commitSha, chainPR);
                         });
                 }
 
-                return p.sync();
+                return p.sync(null, chainPR);
             })
             .then((p) => {
                 if (prInfo && prInfo.url) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -603,10 +603,11 @@ class PipelineModel extends BaseModel {
      * Create, update, or disable jobs if necessary.
      * Store/update the pipeline workflowGraph
      * @method sync
-     * @param {String} [ref]  A reference to fetch the screwdriver.yaml, can be branch/tag/commit
+     * @param {String}  [ref]     A reference to fetch the screwdriver.yaml, can be branch/tag/commit
+     * @param {Boolean} [chainPR] Chain PR flag
      * @return {Promise}
      */
-    sync(ref) {
+    sync(ref, chainPR = false) {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -631,7 +632,9 @@ class PipelineModel extends BaseModel {
 
                 return parsedConfig;
             }).then((parsedConfig) => {
-                this.prChain = parsedConfig.prChain;
+                const annotChainPR = parsedConfig.annotations['screwdriver.cd/chainPR'];
+
+                this.prChain = typeof annotChainPR === 'undefined' ? chainPR : annotChainPR;
                 this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 

--- a/test/data/parser.json
+++ b/test/data/parser.json
@@ -91,6 +91,7 @@
         ]
     },
     "annotations": {
-        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
+        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm",
+        "screwdriver.cd/chainPR" : true
     }
 }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -21,7 +21,7 @@ const EXTERNAL_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML, {
     }
 });
 const NON_PRCHAIN_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML_PR, {
-    prChain: false
+    annotations: { 'screwdriver.cd/chainPR': false }
 });
 
 describe('Pipeline Model', () => {
@@ -527,15 +527,16 @@ describe('Pipeline Model', () => {
 
             return pipeline.sync().then(() => {
                 assert.deepEqual(pipeline.annotations, {
-                    'beta.screwdriver.cd/executor': 'screwdriver-executor-vm'
+                    'beta.screwdriver.cd/executor': 'screwdriver-executor-vm',
+                    'screwdriver.cd/chainPR': true
                 });
             });
         });
 
         it('stores prChain to pipeline', () => {
             const configMock = Object.assign({}, PARSED_YAML);
+            const defatulChainPR = false;
 
-            configMock.prChain = true;
             parserMock.withArgs('superyamlcontent', templateFactoryMock)
                 .resolves(configMock);
             jobs = [];
@@ -543,7 +544,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
             jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
 
-            return pipeline.sync().then(() => {
+            return pipeline.sync(null, defatulChainPR).then(() => {
                 assert.equal(pipeline.prChain, true);
             });
         });


### PR DESCRIPTION
## Context

We moves prChain flag from the top level setting `prChain` to the pipeline level annotation `chainPR`.

## Note

This PR persists the annotation value to the **existing** `pipeline.prChain` property, therefore it does not impact the others (e.g. UI). 
https://github.com/screwdriver-cd/models/pull/344/files#diff-679e90b5b15ab1b73ddb7ed2377e7413R637

## References

- https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-466188824
- https://github.com/screwdriver-cd/screwdriver/pull/1532
