### PR TITLE
feat(1412): include build metrics in events

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ model.tokens
 #### Get Event Metrics
 Get all the event durations for this pipeline within time range
 ```js
-model.getEventMetrics()
+model.getMetrics()
     .then((metrics) => {
         // do stuff with metrics
     });
@@ -277,7 +277,7 @@ model.getRunningBuilds()
 #### Get Build Metrics
 Get all the build durations for this job within time range
 ```js
-model.getBuildMetrics()
+model.getMetrics()
     .then((metrics) => {
         // do stuff with metrics
     });
@@ -286,7 +286,7 @@ model.getBuildMetrics()
 #### Get Step Metrics
 Get all the durations for a specific step of this job within time range
 ```js
-model.getStepMetrics()
+model.getMetrics()
     .then((metrics) => {
         // do stuff with metrics
     });
@@ -794,7 +794,7 @@ model.getBuilds()
 #### Get Build Metrics
 Get all the build durations for this event within time range
 ```js
-model.getBuildMetrics()
+model.getMetrics()
     .then((metrics) => {
         // do stuff with metrics
     });

--- a/lib/build.js
+++ b/lib/build.js
@@ -535,15 +535,15 @@ class BuildModel extends BaseModel {
     }
 
     /**
-     * getStepMetrics for this build
-     * @method getStepMetrics
+     * getMetrics for this build
+     * @method getMetrics
      * @param  {Object}   [config]              Configuration object
      * @param  {String}   [config.startTime]    Look at steps created after this startTime
      * @param  {String}   [config.endTime]      Look at steps created before this endTime
      * @param  {String}   [config.stepName]     Name of step
      * @return {Promise}  Resolves to array of metrics for steps belong to this build
      */
-    getStepMetrics(config = { stepName: null }) {
+    getMetrics(config = { stepName: null }) {
         let steps = this.steps;
 
         // If stepName, get only that step

--- a/lib/event.js
+++ b/lib/event.js
@@ -40,14 +40,14 @@ class EventModel extends BaseModel {
     }
 
     /**
-     * getBuildMetrics for this event
-     * @method getBuildMetrics
+     * getMetrics for this event
+     * @method getMetrics
      * @param  {Object}   [config]              Configuration object
      * @param  {String}   [config.startTime]    Look at builds created after this startTime
      * @param  {String}   [config.endTime]      Look at builds created before this endTime
      * @return {Promise}  Resolves to array of metrics for builds belong to this event
      */
-    async getBuildMetrics(config = { startTime: null, endTime: null }) {
+    async getMetrics(config = { startTime: null, endTime: null }) {
         // Get builds during this time range
         const builds = await this.getBuilds({
             startTime: config.startTime,

--- a/lib/job.js
+++ b/lib/job.js
@@ -223,14 +223,14 @@ class Job extends BaseModel {
     }
 
     /**
-     * getBuildMetrics for this job
-     * @method getBuildMetrics
+     * getMetrics for this job
+     * @method getMetrics
      * @param  {Object}   [config]              Configuration object
      * @param  {String}   [config.startTime]    Look at builds created after this startTime
      * @param  {String}   [config.endTime]      Look at builds created before this endTime
      * @return {Promise}  Resolves to array of metrics for builds belong to this job
      */
-    async getBuildMetrics(config = { startTime: null, endTime: null }) {
+    async getMetrics(config = { startTime: null, endTime: null }) {
         // Get builds during this time range
         const builds = await this.getBuilds({
             startTime: config.startTime,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1180,7 +1180,8 @@ class PipelineModel extends BaseModel {
                 return {
                     duration: 0,
                     queuedTime: 0,
-                    imagePullTime: 0
+                    imagePullTime: 0,
+                    builds: []
                 };
             }
 
@@ -1197,7 +1198,7 @@ class PipelineModel extends BaseModel {
             for (let i = 1; i < buildMetrics.length; i += 1) {
                 ({
                     id, jobId, duration, startTime, endTime, queuedTime, imagePullTime, status
-                }) = buildMetrics[i];
+                } = buildMetrics[i]);
                 const s = new Date(startTime);
                 const e = new Date(endTime);
 
@@ -1237,10 +1238,18 @@ class PipelineModel extends BaseModel {
         // Generate metrics
         const promiseArray = events.map(async (e) => {
             const { id, createTime, causeMessage, sha } = e;
-            const { duration, status, queuedTime, imagePullTime } = await eventMetrics(e);
+            const { duration, status, queuedTime, imagePullTime, builds } = await eventMetrics(e);
 
             return {
-                id, createTime, causeMessage, sha, queuedTime, imagePullTime, duration, status
+                id,
+                createTime,
+                causeMessage,
+                sha,
+                queuedTime,
+                imagePullTime,
+                duration,
+                status,
+                builds
             };
         });
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1156,14 +1156,14 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * getEventMetrics for this pipeline
-     * @method getEventMetrics
+     * getMetrics for this pipeline
+     * @method getMetrics
      * @param  {Object}   [config]              Configuration object
      * @param  {String}   [config.startTime]    Look at events created after this startTime
      * @param  {String}   [config.endTime]      Look at events created before this endTime
      * @return {Promise}  Resolves to array of metrics for events belong to this pipeline
      */
-    async getEventMetrics(config = { startTime: null, endTime: null }) {
+    async getMetrics(config = { startTime: null, endTime: null }) {
         // Get events during this time range
         const events = await this.getEvents({
             startTime: config.startTime,
@@ -1173,7 +1173,7 @@ class PipelineModel extends BaseModel {
         // Calculate event duration by using max endTime - min startTime of builds
         // that belong this event
         const eventMetrics = async (event) => {
-            const buildMetrics = await event.getBuildMetrics();
+            const buildMetrics = await event.getMetrics();
 
             // Somehow this event doesn't have any builds
             if (!buildMetrics || buildMetrics.length === 0) {
@@ -1184,14 +1184,20 @@ class PipelineModel extends BaseModel {
                 };
             }
 
-            let minStartTime = new Date(buildMetrics[0].startTime);
-            let maxEndTime = new Date(buildMetrics[0].endTime);
-            let eventStatus = buildMetrics[0].status;
-            let totalQueuedTime = buildMetrics[0].queuedTime || 0;
-            let totalImagePullTime = buildMetrics[0].imagePullTime || 0;
+            let {
+                id, jobId, duration, startTime, endTime, queuedTime, imagePullTime, status
+            } = buildMetrics[0];
+            let minStartTime = new Date(startTime);
+            let maxEndTime = new Date(endTime);
+            let eventStatus = status;
+            let totalQueuedTime = queuedTime || 0;
+            let totalImagePullTime = imagePullTime || 0;
+            const builds = [{ id, jobId, duration, status }];
 
             for (let i = 1; i < buildMetrics.length; i += 1) {
-                const { startTime, endTime, queuedTime, imagePullTime, status } = buildMetrics[i];
+                ({
+                    id, jobId, duration, startTime, endTime, queuedTime, imagePullTime, status
+                }) = buildMetrics[i];
                 const s = new Date(startTime);
                 const e = new Date(endTime);
 
@@ -1209,13 +1215,22 @@ class PipelineModel extends BaseModel {
                 if (imagePullTime) {
                     totalImagePullTime += imagePullTime;
                 }
+
+                builds.push({
+                    id,
+                    jobId,
+                    startTime,
+                    duration,
+                    status
+                });
             }
 
             return {
                 duration: Math.round((maxEndTime - minStartTime) / 1000), // round in seconds
                 queuedTime: totalQueuedTime,
                 imagePullTime: totalImagePullTime,
-                status: eventStatus
+                status: eventStatus,
+                builds: buildMetrics
             };
         };
 

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.10.0",
-    "screwdriver-data-schema": "^18.43.3",
-    "screwdriver-workflow-parser": "^1.8.1",
+    "screwdriver-data-schema": "^18.44.1",
+    "screwdriver-workflow-parser": "^1.8.3",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1325,13 +1325,13 @@ describe('Build Model', () => {
         it('generates metrics', () => {
             build.steps = [step1, step2];
 
-            assert.deepEqual(build.getStepMetrics(), metrics);
+            assert.deepEqual(build.getMetrics(), metrics);
         });
 
         it('does not fail if empty steps', () => {
             build.steps = [];
 
-            assert.deepEqual(build.getStepMetrics(), []);
+            assert.deepEqual(build.getMetrics(), []);
         });
 
         it('works with no startTime or endTime params passed in', () => {
@@ -1340,7 +1340,7 @@ describe('Build Model', () => {
             build.steps = [step1, step2];
             metrics = metrics.filter(m => m.name === stepName);
 
-            assert.deepEqual(build.getStepMetrics({ stepName }), metrics);
+            assert.deepEqual(build.getMetrics({ stepName }), metrics);
         });
     });
 });

--- a/test/lib/event.test.js
+++ b/test/lib/event.test.js
@@ -174,7 +174,7 @@ describe('Event Model', () => {
 
             buildFactoryMock.list.resolves([build1, build2]);
 
-            return event.getBuildMetrics({ startTime, endTime }).then((result) => {
+            return event.getMetrics({ startTime, endTime }).then((result) => {
                 assert.calledWith(buildFactoryMock.list, buildListConfig);
                 assert.deepEqual(result, metrics);
             });
@@ -183,7 +183,7 @@ describe('Event Model', () => {
         it('does not fail if empty builds', () => {
             buildFactoryMock.list.resolves([]);
 
-            return event.getBuildMetrics({ startTime, endTime }).then((result) => {
+            return event.getMetrics({ startTime, endTime }).then((result) => {
                 assert.deepEqual(result, []);
             });
         });
@@ -197,7 +197,7 @@ describe('Event Model', () => {
 
             buildFactoryMock.list.resolves([build1, build2]);
 
-            return event.getBuildMetrics().then((result) => {
+            return event.getMetrics().then((result) => {
                 assert.calledWith(buildFactoryMock.list, buildListConfig);
                 assert.deepEqual(result, metrics);
             });
@@ -206,7 +206,7 @@ describe('Event Model', () => {
         it('rejects with errors', () => {
             buildFactoryMock.list.rejects(new Error('cannotgetit'));
 
-            return event.getBuildMetrics({ startTime, endTime })
+            return event.getMetrics({ startTime, endTime })
                 .then(() => {
                     assert.fail('Should not get here');
                 }).catch((err) => {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -465,7 +465,7 @@ describe('Job Model', () => {
 
             buildFactoryMock.list.resolves([build1, build2, build3]);
 
-            return job.getBuildMetrics({ startTime, endTime }).then((result) => {
+            return job.getMetrics({ startTime, endTime }).then((result) => {
                 assert.calledWith(buildFactoryMock.list, buildListConfig);
                 assert.deepEqual(result, metrics);
             });
@@ -474,7 +474,7 @@ describe('Job Model', () => {
         it('does not fail if empty builds', () => {
             buildFactoryMock.list.resolves([]);
 
-            return job.getBuildMetrics({ startTime, endTime }).then((result) => {
+            return job.getMetrics({ startTime, endTime }).then((result) => {
                 assert.deepEqual(result, []);
             });
         });
@@ -489,7 +489,7 @@ describe('Job Model', () => {
 
             buildFactoryMock.list.resolves([build1, build2, build3]);
 
-            return job.getBuildMetrics().then((result) => {
+            return job.getMetrics().then((result) => {
                 assert.calledWith(buildFactoryMock.list, buildListConfig);
                 assert.deepEqual(result, metrics);
             });
@@ -498,7 +498,7 @@ describe('Job Model', () => {
         it('rejects with errors', () => {
             buildFactoryMock.list.rejects(new Error('cannotgetit'));
 
-            return job.getBuildMetrics({ startTime, endTime })
+            return job.getMetrics({ startTime, endTime })
                 .then(() => {
                     assert.fail('Should not get here');
                 }).catch((err) => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2039,7 +2039,8 @@ describe('Pipeline Model', () => {
                 duration: duration1,
                 status: build12.status,
                 imagePullTime: build11.imagePullTime + build12.imagePullTime,
-                queuedTime: build11.queuedTime + build12.queuedTime
+                queuedTime: build11.queuedTime + build12.queuedTime,
+                builds: [build11, build12]
             }, {
                 id: event2.id,
                 createTime: event2.createTime,
@@ -2048,7 +2049,8 @@ describe('Pipeline Model', () => {
                 duration: duration2,
                 status: build22.status,
                 imagePullTime: build21.imagePullTime + build22.imagePullTime,
-                queuedTime: build21.queuedTime + build22.queuedTime
+                queuedTime: build21.queuedTime + build22.queuedTime,
+                builds: [build21, build22]
             }];
         });
 
@@ -2083,6 +2085,7 @@ describe('Pipeline Model', () => {
             };
 
             event1.getMetrics = sinon.stub().resolves([build11, build12, build13]);
+            metrics[0].builds = [build11, build12, build13];
 
             eventFactoryMock.list.resolves([event1, event2]);
 
@@ -2103,7 +2106,7 @@ describe('Pipeline Model', () => {
             };
 
             event1.getMetrics = sinon.stub().resolves([build13, build12, build11]);
-
+            metrics[0].builds = [build13, build12, build11];
             eventFactoryMock.list.resolves([event1, event2]);
 
             return pipeline.getMetrics({ startTime, endTime }).then((result) => {
@@ -2120,7 +2123,8 @@ describe('Pipeline Model', () => {
                 duration: 0,
                 queuedTime: 0,
                 imagePullTime: 0,
-                status: undefined
+                status: undefined,
+                builds: []
             });
 
             return pipeline.getMetrics({ startTime, endTime }).then((result) => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2023,13 +2023,13 @@ describe('Pipeline Model', () => {
                 },
                 pr: {},
                 duration: 25,
-                getBuildMetrics: sinon.stub().resolves([build11, build12])
+                getMetrics: sinon.stub().resolves([build11, build12])
             };
             event2 = Object.assign({}, {
                 id: 1234,
                 createTime: '2019-01-24T11:25:00.610Z',
                 sha: '14b920bef306eb1bde8ec0b6a32372eebecc6d0e',
-                getBuildMetrics: sinon.stub().resolves([build21, build22])
+                getMetrics: sinon.stub().resolves([build21, build22])
             });
             metrics = [{
                 id: event1.id,
@@ -2065,10 +2065,10 @@ describe('Pipeline Model', () => {
 
             eventFactoryMock.list.resolves([event1, event2]);
 
-            return pipeline.getEventMetrics({ startTime, endTime }).then((result) => {
+            return pipeline.getMetrics({ startTime, endTime }).then((result) => {
                 assert.calledWith(eventFactoryMock.list, eventListConfig);
-                assert.calledOnce(event1.getBuildMetrics);
-                assert.calledOnce(event2.getBuildMetrics);
+                assert.calledOnce(event1.getMetrics);
+                assert.calledOnce(event2.getMetrics);
                 assert.deepEqual(result, metrics);
             });
         });
@@ -2082,13 +2082,13 @@ describe('Pipeline Model', () => {
                 status: 'SUCCESS'
             };
 
-            event1.getBuildMetrics = sinon.stub().resolves([build11, build12, build13]);
+            event1.getMetrics = sinon.stub().resolves([build11, build12, build13]);
 
             eventFactoryMock.list.resolves([event1, event2]);
 
-            return pipeline.getEventMetrics({ startTime, endTime }).then((result) => {
-                assert.calledOnce(event1.getBuildMetrics);
-                assert.calledOnce(event2.getBuildMetrics);
+            return pipeline.getMetrics({ startTime, endTime }).then((result) => {
+                assert.calledOnce(event1.getMetrics);
+                assert.calledOnce(event2.getMetrics);
                 assert.deepEqual(result, metrics);
             });
         });
@@ -2102,20 +2102,20 @@ describe('Pipeline Model', () => {
                 status: 'SUCCESS'
             };
 
-            event1.getBuildMetrics = sinon.stub().resolves([build13, build12, build11]);
+            event1.getMetrics = sinon.stub().resolves([build13, build12, build11]);
 
             eventFactoryMock.list.resolves([event1, event2]);
 
-            return pipeline.getEventMetrics({ startTime, endTime }).then((result) => {
-                assert.calledOnce(event1.getBuildMetrics);
-                assert.calledOnce(event2.getBuildMetrics);
+            return pipeline.getMetrics({ startTime, endTime }).then((result) => {
+                assert.calledOnce(event1.getMetrics);
+                assert.calledOnce(event2.getMetrics);
                 assert.deepEqual(result, metrics);
             });
         });
 
         it('does not fail if empty builds', () => {
             eventFactoryMock.list.resolves([event1, event2]);
-            event1.getBuildMetrics = sinon.stub().resolves([]);
+            event1.getMetrics = sinon.stub().resolves([]);
             metrics[0] = Object.assign({}, metrics[0], {
                 duration: 0,
                 queuedTime: 0,
@@ -2123,7 +2123,7 @@ describe('Pipeline Model', () => {
                 status: undefined
             });
 
-            return pipeline.getEventMetrics({ startTime, endTime }).then((result) => {
+            return pipeline.getMetrics({ startTime, endTime }).then((result) => {
                 assert.deepEqual(result, metrics);
             });
         });
@@ -2139,7 +2139,7 @@ describe('Pipeline Model', () => {
 
             eventFactoryMock.list.resolves([event1, event2]);
 
-            return pipeline.getEventMetrics().then((result) => {
+            return pipeline.getMetrics().then((result) => {
                 assert.calledWith(eventFactoryMock.list, eventListConfig);
                 assert.deepEqual(result, metrics);
             });
@@ -2148,7 +2148,7 @@ describe('Pipeline Model', () => {
         it('rejects with errors', () => {
             eventFactoryMock.list.rejects(new Error('cannotgetit'));
 
-            return pipeline.getEventMetrics({ startTime, endTime })
+            return pipeline.getMetrics({ startTime, endTime })
                 .then(() => {
                     assert.fail('Should not get here');
                 }).catch((err) => {


### PR DESCRIPTION
So that we only need to make 1 API call. 
Also change the names to be more generic, especially now it's not really `pipeline.getEventMetrics`, it actually gets build metrics as well. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1412