### PR TITLE
fix: do not fail getJobs for getOpenedPRs

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1005,10 +1005,6 @@ class PipelineModel extends BaseModel {
                             scmUri: this.scmUri,
                             scmContext: this.scmContext,
                             token: await this.token
-                        }).catch((err) => {
-                            winston.error(`Failed to getOpenedPRs: ${err}`);
-
-                            return Promise.resolve([]);
                         });
                         const openedPRsMap = openPrs.reduce((map, pr) => {
                             map[pr.name] = pr;
@@ -1030,7 +1026,7 @@ class PipelineModel extends BaseModel {
                             return pr;
                         });
                     } catch (e) {
-                        throw logger.error('Failed to fetch opened PRs', e);
+                        winston.error('Failed to fetch opened PRs', e);
                     }
                 }
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
-    "screwdriver-config-parser": "^4.10.0",
+    "screwdriver-config-parser": "^4.11.0",
     "screwdriver-data-schema": "^18.44.1",
     "screwdriver-workflow-parser": "^1.8.3",
     "winston": "^2.4.4"


### PR DESCRIPTION
-  do not fail getJobs for getOpenedPRs
- it turned out you cannot do `.catch(err)` after a async function call