### PR TITLE
feat(1010): [2] insert prNum when event create

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -413,7 +413,8 @@ class EventFactory extends BaseFactory {
             startFrom,
             causeMessage: config.causeMessage || `Started by ${displayName}`,
             meta: config.meta || {},
-            pr: {}
+            pr: {},
+            prNum
         };
 
         return pipelineFactory.get(pipelineId)

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -900,6 +900,16 @@ describe('Event Factory', () => {
             });
         });
 
+        it('should create event with pr info if it is pr event', () => {
+            config.prNum = 20;
+
+            return eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.deepEqual(model.pr, config.prInfo);
+                assert.deepEqual(model.prNum, config.prNum);
+            });
+        });
+
         it('throw error if sourcepaths is not supported', () => {
             jobsMock = [{
                 id: 1,


### PR DESCRIPTION
## Context
We have to get all the events including which is not PR or have other PR number, because there are no way to get exact event list with pr number in API.

## Objective
Set `prNum` to the event model when the event is created.

## References
other PR: 
[1] data-schema: https://github.com/screwdriver-cd/data-schema/pull/326
[3] api: https://github.com/screwdriver-cd/screwdriver/pull/1550

Issue: https://github.com/screwdriver-cd/screwdriver/issues/1010