### PR TITLE
fix: getStepMetrics function is renamed

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -265,10 +265,7 @@ class Job extends BaseModel {
         });
 
         // Go through the step for all builds and generate metrics
-        const stepArrays = builds.map(
-            b => b.getStepMetrics({
-                stepName
-            }));
+        const stepArrays = builds.map(b => b.getMetrics({ stepName }));
 
         return [].concat(...stepArrays);
     }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.0",
-    "screwdriver-data-schema": "^18.44.1",
+    "screwdriver-data-schema": "^18.45.0",
     "screwdriver-workflow-parser": "^1.8.3",
     "winston": "^2.4.4"
   }

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -524,9 +524,9 @@ describe('Job Model', () => {
         let metrics;
 
         beforeEach(() => {
-            build1.getStepMetrics = sinon.stub().returns([mockMetrics1]);
-            build2.getStepMetrics = sinon.stub().returns([mockMetrics2]);
-            build3.getStepMetrics = sinon.stub().returns([mockMetrics3]);
+            build1.getMetrics = sinon.stub().returns([mockMetrics1]);
+            build2.getMetrics = sinon.stub().returns([mockMetrics2]);
+            build3.getMetrics = sinon.stub().returns([mockMetrics3]);
 
             metrics = [mockMetrics1, mockMetrics2, mockMetrics3];
         });
@@ -540,7 +540,7 @@ describe('Job Model', () => {
                 endTime,
                 sort: 'descending'
             };
-            const getStepMetricsParams = {
+            const getMetricsParams = {
                 stepName
             };
 
@@ -548,9 +548,9 @@ describe('Job Model', () => {
 
             return job.getStepMetrics({ startTime, endTime, stepName }).then((result) => {
                 assert.calledWith(buildFactoryMock.list, buildListConfig);
-                assert.calledWith(build1.getStepMetrics, getStepMetricsParams);
-                assert.calledWith(build2.getStepMetrics, getStepMetricsParams);
-                assert.calledWith(build3.getStepMetrics, getStepMetricsParams);
+                assert.calledWith(build1.getMetrics, getMetricsParams);
+                assert.calledWith(build2.getMetrics, getMetricsParams);
+                assert.calledWith(build3.getMetrics, getMetricsParams);
                 assert.deepEqual(result, metrics);
             });
         });


### PR DESCRIPTION
`b.getStepMetrics` should be `b.getMetrics` now: https://github.com/screwdriver-cd/models/blob/master/lib/build.js#L561

Related: https://github.com/screwdriver-cd/screwdriver/issues/1412