### PR TITLE
fix: not to call sync with SHA of parent event if it is pr event

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -421,7 +421,7 @@ class EventFactory extends BaseFactory {
             // Sync pipeline to make sure workflowGraph is generated
             .then((p) => {
                 // Sync pipeline with the parentEvent sha and create jobs based on that sha
-                if (parentEventId) {
+                if (parentEventId && !prRef) {
                     modelConfig.parentEventId = parentEventId;
 
                     // for child pipelines restart event, sync with configPipelineSha

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -910,6 +910,22 @@ describe('Event Factory', () => {
             });
         });
 
+        it('should not call pipeline sync with configPipelineSha if it is pr event', () => {
+            config.parentEventId = 222;
+            config.configPipelineSha = 'configpipelinesha';
+            config.sha = 'configsha';
+            config.prRef = 'branch';
+            config.prNum = 20;
+
+            return eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.neverCalledWith(pipelineMock.sync, config.configPipelineSha);
+                assert.neverCalledWith(pipelineMock.sync, config.sha);
+                assert.deepEqual(model.pr, config.prInfo);
+                assert.deepEqual(model.prNum, config.prNum);
+            });
+        });
+
         it('throw error if sourcepaths is not supported', () => {
             jobsMock = [{
                 id: 1,


### PR DESCRIPTION
## Context
Now, pipeline `sync()` method is called with parent event sha even if it is PR event.
This cause to create a new job with parent PR event config as a commit event.
Created new job doesn't have `PR-` prefix.

## Objective
Do not call `sync()` with parent event sha if it is PR event. 