### PR TITLE
fix(1412): ascending sort and limit counts for metrics

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -18,6 +18,7 @@ class EventModel extends BaseModel {
      * Return builds that belong to this event
      * @param  {String}   [config.startTime]     Search for builds after this startTime
      * @param  {String}   [config.endTime]       Search for builds before this endTime
+     * @param  {String}   [config.sort]          Ascending or descending
      * @return {Promise}  Resolves to an array of builds
      */
     getBuilds(config) {
@@ -51,7 +52,8 @@ class EventModel extends BaseModel {
         // Get builds during this time range
         const builds = await this.getBuilds({
             startTime: config.startTime,
-            endTime: config.endTime
+            endTime: config.endTime,
+            sort: 'ascending'
         });
 
         const findDuration = (start, end) => Math.round((new Date(end) - new Date(start)) / 1000);

--- a/lib/job.js
+++ b/lib/job.js
@@ -4,6 +4,7 @@ const BaseModel = require('./base');
 const hoek = require('hoek');
 const getAnnotations = require('./helper').getAnnotations;
 const START_INDEX = 3;
+const MAX_COUNT = 1000;
 const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
@@ -234,7 +235,8 @@ class Job extends BaseModel {
         // Get builds during this time range
         const builds = await this.getBuilds({
             startTime: config.startTime,
-            endTime: config.endTime
+            endTime: config.endTime,
+            sort: 'ascending'
         });
 
         // Generate metrics
@@ -261,7 +263,11 @@ class Job extends BaseModel {
         // Get builds during this time range
         const builds = await this.getBuilds({
             startTime,
-            endTime
+            endTime,
+            sort: 'ascending',
+            paginate: {
+                count: MAX_COUNT
+            }
         });
 
         // Go through the step for all builds and generate metrics

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -14,6 +14,7 @@ const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
     job: 2 // main or undefined if using legacy
 };
+const MAX_COUNT = 1000;
 
 winston.level = process.env.LOG_LEVEL || 'info';
 const logger = new (winston.Logger)({
@@ -1166,7 +1167,11 @@ class PipelineModel extends BaseModel {
         // Get events during this time range
         const events = await this.getEvents({
             startTime: config.startTime,
-            endTime: config.endTime
+            endTime: config.endTime,
+            sort: 'ascending',
+            paginate: {
+                count: MAX_COUNT
+            }
         });
 
         // Calculate event duration by using max endTime - min startTime of builds

--- a/test/lib/event.test.js
+++ b/test/lib/event.test.js
@@ -169,7 +169,8 @@ describe('Event Model', () => {
                     eventId: 1234
                 },
                 startTime,
-                endTime
+                endTime,
+                sort: 'ascending'
             };
 
             buildFactoryMock.list.resolves([build1, build2]);
@@ -192,7 +193,8 @@ describe('Event Model', () => {
             const buildListConfig = {
                 params: {
                     eventId: 1234
-                }
+                },
+                sort: 'ascending'
             };
 
             buildFactoryMock.list.resolves([build1, build2]);

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -460,7 +460,7 @@ describe('Job Model', () => {
                 },
                 startTime,
                 endTime,
-                sort: 'descending'
+                sort: 'ascending'
             };
 
             buildFactoryMock.list.resolves([build1, build2, build3]);
@@ -484,7 +484,7 @@ describe('Job Model', () => {
                 params: {
                     jobId: 1234
                 },
-                sort: 'descending'
+                sort: 'ascending'
             };
 
             buildFactoryMock.list.resolves([build1, build2, build3]);
@@ -538,7 +538,10 @@ describe('Job Model', () => {
                 },
                 startTime,
                 endTime,
-                sort: 'descending'
+                paginate: {
+                    count: 1000
+                },
+                sort: 'ascending'
             };
             const getMetricsParams = {
                 stepName
@@ -568,7 +571,10 @@ describe('Job Model', () => {
                 params: {
                     jobId: 1234
                 },
-                sort: 'descending'
+                sort: 'ascending',
+                paginate: {
+                    count: 1000
+                }
             };
 
             buildFactoryMock.list.resolves([build1, build2, build3]);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2061,7 +2061,10 @@ describe('Pipeline Model', () => {
                     pipelineId: 123,
                     type: 'pipeline'
                 },
-                sort: 'descending',
+                sort: 'ascending',
+                paginate: {
+                    count: 1000
+                },
                 startTime,
                 endTime
             };
@@ -2139,7 +2142,10 @@ describe('Pipeline Model', () => {
                     pipelineId: 123,
                     type: 'pipeline'
                 },
-                sort: 'descending'
+                sort: 'ascending',
+                paginate: {
+                    count: 1000
+                }
             };
 
             eventFactoryMock.list.resolves([event1, event2]);


### PR DESCRIPTION
Ascending sort per @DekusDenial 's request for the UI to display. 

Also limit the `count` to `1000` for now as we are not doing aggregation yet, and don't want to risk crashing the API. Only added to `pipeline` and `job` since I don't think `event` will have more than 1000 builds, or `build` will have more than 1000 steps. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1412