### PR TITLE
fix(1412): Aggregate job metrics daily

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -241,19 +241,20 @@ class Job extends BaseModel {
                 count: MAX_COUNT
             }
         };
-        const findDuration = (start, end) => dayjs(end).diff(dayjs(start), 'second');
+        const findMetrics = ({ id, jobId, eventId, createTime, status, startTime, endTime }) => {
+            const duration = startTime && endTime
+                ? dayjs(endTime).diff(dayjs(startTime), 'second')
+                : null;
+
+            return { id, jobId, eventId, createTime, status, duration };
+        };
 
         if (!config.aggregate) {
             // Get builds during this time range
             const builds = await this.getBuilds(options);
 
             // Generate metrics
-            return builds.map((b) => {
-                const { id, jobId, eventId, createTime, status, startTime, endTime } = b;
-                const duration = findDuration(startTime, endTime);
-
-                return { id, jobId, eventId, createTime, status, duration };
-            });
+            return builds.map(b => findMetrics(b));
         }
 
         const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
@@ -278,6 +279,7 @@ class Job extends BaseModel {
                 if (!dayjs(date).isSame(dayjs(buildDate))) {
                     index += 1;
                     date = buildDate;
+                    buildArray.push([]);
                 }
 
                 buildArray[index].push(currentBuild);
@@ -294,21 +296,21 @@ class Job extends BaseModel {
             return getAllBuilds(opts, buildArray, date, index);
         };
 
-        const metrics = [];
-
         options.paginate.page = 1;
-        const allBuilds = getAllBuilds(options, []);
+        const allBuilds = await getAllBuilds(options, [[]]);
+        const aggregatedMetrics = [];
 
         allBuilds.forEach((arr) => {
-            const avg = arr.reduce((previous, current) => previous + current) / arr.length;
+            const metrics = arr.map(b => findMetrics(b).duration);
+            const avg = metrics.reduce((acc, current) => acc + current) / metrics.length;
 
-            metrics.push({
+            aggregatedMetrics.push({
                 createTime: arr[0].createTime,
                 duration: +avg.toFixed(2)
             });
         });
 
-        return metrics;
+        return aggregatedMetrics;
     }
 
     /**

--- a/lib/job.js
+++ b/lib/job.js
@@ -260,7 +260,7 @@ class Job extends BaseModel {
         const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
 
         // recursively fetching builds until the end
-        const getAllBuilds = async (opts, buildArray, currentDate, currentIndex) => {
+        const getAllBuilds = async (opts, buildArray, date, index) => {
             const builds = await this.getBuilds(opts);
             const length = builds.length;
 
@@ -268,21 +268,21 @@ class Job extends BaseModel {
                 return buildArray;
             }
 
-            let date = currentDate || formatDate(builds[0].createTime);
-            let index = currentIndex || 0;
+            let currentDate = date || formatDate(builds[0].createTime);
+            let currentIndex = index || 0;
 
             // Create an array where each element is an array of builds of the same date
             for (let i = 0; i < length; i += 1) {
                 const currentBuild = builds[i];
                 const buildDate = formatDate(currentBuild.createTime);
 
-                if (!dayjs(date).isSame(dayjs(buildDate))) {
-                    index += 1;
-                    date = buildDate;
+                if (!dayjs(buildDate).isSame(dayjs(currentDate))) {
+                    currentIndex += 1;
+                    currentDate = buildDate;
                     buildArray.push([]);
                 }
 
-                buildArray[index].push(currentBuild);
+                buildArray[currentIndex].push(currentBuild);
             }
 
             // last page
@@ -293,7 +293,7 @@ class Job extends BaseModel {
             // might have more data, continue fetchign
             opts.paginate.page += 1;
 
-            return getAllBuilds(opts, buildArray, date, index);
+            return getAllBuilds(opts, buildArray, currentDate, currentIndex);
         };
 
         options.paginate.page = 1;

--- a/lib/job.js
+++ b/lib/job.js
@@ -2,6 +2,7 @@
 
 const BaseModel = require('./base');
 const hoek = require('hoek');
+const dayjs = require('dayjs');
 const getAnnotations = require('./helper').getAnnotations;
 const START_INDEX = 3;
 const MAX_COUNT = 1000;
@@ -232,22 +233,79 @@ class Job extends BaseModel {
      * @return {Promise}  Resolves to array of metrics for builds belong to this job
      */
     async getMetrics(config = { startTime: null, endTime: null }) {
-        // Get builds during this time range
-        const builds = await this.getBuilds({
+        const options = {
             startTime: config.startTime,
             endTime: config.endTime,
             sort: 'ascending',
             paginate: {
                 count: MAX_COUNT
             }
-        });
+        };
+        const findDuration = (start, end) => dayjs(end).diff(dayjs(start), 'second');
 
-        // Generate metrics
-        const metrics = builds.map((b) => {
-            const { id, jobId, eventId, createTime, status, startTime, endTime } = b;
-            const duration = Math.round((new Date(endTime) - new Date(startTime)) / 1000);
+        if (!config.aggregate) {
+            // Get builds during this time range
+            const builds = await this.getBuilds(options);
 
-            return { id, jobId, eventId, createTime, status, duration };
+            // Generate metrics
+            return builds.map((b) => {
+                const { id, jobId, eventId, createTime, status, startTime, endTime } = b;
+                const duration = findDuration(startTime, endTime);
+
+                return { id, jobId, eventId, createTime, status, duration };
+            });
+        }
+
+        const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
+
+        // recursively fetching builds until the end
+        const getAllBuilds = async (opts, buildArray, currentDate, currentIndex) => {
+            const builds = await this.getBuilds(opts);
+            const length = builds.length;
+
+            if (length === 0) {
+                return buildArray;
+            }
+
+            let date = currentDate || formatDate(builds[0].createTime);
+            let index = currentIndex || 0;
+
+            // Create an array where each element is an array of builds of the same date
+            for (let i = 0; i < length; i += 1) {
+                const currentBuild = builds[i];
+                const buildDate = formatDate(currentBuild.createTime);
+
+                if (!dayjs(date).isSame(dayjs(buildDate))) {
+                    index += 1;
+                    date = buildDate;
+                }
+
+                buildArray[index].push(currentBuild);
+            }
+
+            // last page
+            if (length < MAX_COUNT) {
+                return buildArray;
+            }
+
+            // might have more data, continue fetchign
+            opts.paginate.page += 1;
+
+            return getAllBuilds(opts, buildArray, date, index);
+        };
+
+        const metrics = [];
+
+        options.paginate.page = 1;
+        const allBuilds = getAllBuilds(options, []);
+
+        allBuilds.forEach((arr) => {
+            const avg = arr.reduce((previous, current) => previous + current) / arr.length;
+
+            metrics.push({
+                createTime: arr[0].createTime,
+                duration: +avg.toFixed(2)
+            });
         });
 
         return metrics;

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "async": "^2.6.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
+    "dayjs": "^1.8.10",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",


### PR DESCRIPTION
Accept `config.aggregate`. If `true`, will aggregate it daily. 
Result will be an array where each element is `{createTime, duration}`, where `duration` is the average of all builds run on that day. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1412