### PR TITLE
fix: Make sure user exists when checking admin permission

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -460,6 +460,10 @@ class PipelineModel extends BaseModel {
                 scmContext: this.scmContext
             });
 
+            if (!user) {
+                return false;
+            }
+
             // eslint-disable-next-line no-await-in-loop
             const permission = await user.getPermissions(scmUri);
 
@@ -473,7 +477,7 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Get a pipeline given a scmUrl
+     * Get a scmUri given a scmUrl
      * @method _getScmUri
      * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
@@ -779,7 +783,7 @@ class PipelineModel extends BaseModel {
 
     /**
      * This function deletes admins who does not have proper
-     * GitHub permission, and returns an proper admin.
+     * GitHub permission, and returns a proper admin.
      * @method getFirstAdmin
      * @return {Promise}
      */
@@ -801,14 +805,21 @@ class PipelineModel extends BaseModel {
                 scmContext: this.scmContext
             });
 
-            // eslint-disable-next-line no-await-in-loop
-            const permission = await user.getPermissions(this.scmUri);
-
-            if (!permission.push) {
+            if (!user) {
                 delete newAdmins[username];
-                logger.info(`pipelineId:${this.id}: ${username} has been removed from admins.`);
+                logger.info(`pipelineId:${this.id}: ${username} has been removed from admins.` +
+                    ' User does not exist.');
             } else {
-                break;
+                // eslint-disable-next-line no-await-in-loop
+                const permission = await user.getPermissions(this.scmUri);
+
+                if (!permission.push) {
+                    delete newAdmins[username];
+                    logger.info(`pipelineId:${this.id}: ${username} has been removed from admins.` +
+                        ' User does not have push permission.');
+                } else {
+                    break;
+                }
             }
         }
         /* eslint-enable no-restricted-syntax */

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -734,6 +734,23 @@ describe('Pipeline Model', () => {
                 });
         });
 
+        it('does not fail if admin is not a user and has no admin permissions', () => {
+            userFactoryMock.get.withArgs({ username: 'batman', scmContext }).resolves(null);
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'foo.git'
+            })).resolves('foo');
+            pipelineFactoryMock.get.resolves(null);
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+
+            return pipeline.sync()
+                .then((p) => {
+                    assert.equal(p.id, testId);
+                    assert.notCalled(pipelineFactoryMock.create);
+                });
+        });
+
         it('does not update child pipelines if does not belong to this parent', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);


### PR DESCRIPTION
Fixing a small bug
Only happens if an admin is added manually in the DB to the Screwdriver admins list that does not exist as a Screwdriver user