### PR TITLE
fix(1412): include steps metrics in builds

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseModel = require('./base');
+const dayjs = require('dayjs');
 const hoek = require('hoek');
 const winston = require('winston');
 const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
@@ -575,10 +576,12 @@ class BuildModel extends BaseModel {
             if (!s.buildId) {
                 s.buildId = this.id;
             }
-            const { id, buildId, name, code, startTime, endTime } = s;
-            const duration = Math.round((new Date(endTime) - new Date(startTime)) / 1000);
+            const { id, name, code, startTime, endTime } = s;
+            const duration = startTime && endTime
+                ? dayjs(endTime).diff(dayjs(startTime), 'second')
+                : null;
 
-            return { id, buildId, name, code, duration, createTime };
+            return { id, name, code, duration, createTime };
         });
 
         return metrics;

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const hoek = require('hoek');
 const BaseModel = require('./base');
+const dayjs = require('dayjs');
+const hoek = require('hoek');
 
 class EventModel extends BaseModel {
     /**
@@ -56,7 +57,8 @@ class EventModel extends BaseModel {
             sort: 'ascending'
         });
 
-        const findDuration = (start, end) => Math.round((new Date(end) - new Date(start)) / 1000);
+        const findDuration = (start, end) => (start && end
+            ? dayjs(end).diff(dayjs(start), 'second') : null);
 
         // Generate metrics
         const metrics = builds.map((b) => {

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const BaseModel = require('./base');
-const hoek = require('hoek');
 const dayjs = require('dayjs');
+const hoek = require('hoek');
 const getAnnotations = require('./helper').getAnnotations;
-const START_INDEX = 3;
-const MAX_COUNT = 1000;
 const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
+const START_INDEX = 3;
+const MAX_COUNT = 1000;
 
 class Job extends BaseModel {
     /**
@@ -230,9 +230,10 @@ class Job extends BaseModel {
      * @param  {Object}   [config]              Configuration object
      * @param  {String}   [config.startTime]    Look at builds created after this startTime
      * @param  {String}   [config.endTime]      Look at builds created before this endTime
+     * @param  {String}   [config.stepName]     Only include this step
      * @return {Promise}  Resolves to array of metrics for builds belong to this job
      */
-    async getMetrics(config = { startTime: null, endTime: null }) {
+    async getMetrics(config = { startTime: null, endTime: null, stepName: null }) {
         const options = {
             startTime: config.startTime,
             endTime: config.endTime,
@@ -241,12 +242,15 @@ class Job extends BaseModel {
                 count: MAX_COUNT
             }
         };
-        const findMetrics = ({ id, jobId, eventId, createTime, status, startTime, endTime }) => {
+        const findMetrics = (build) => {
+            const { id, jobId, eventId, createTime, status, startTime, endTime } = build;
             const duration = startTime && endTime
                 ? dayjs(endTime).diff(dayjs(startTime), 'second')
                 : null;
 
-            return { id, jobId, eventId, createTime, status, duration };
+            const steps = build.getMetrics({ stepName: config.stepName });
+
+            return { id, jobId, eventId, createTime, status, duration, steps };
         };
 
         if (!config.aggregate) {
@@ -311,32 +315,6 @@ class Job extends BaseModel {
         });
 
         return aggregatedMetrics;
-    }
-
-    /**
-     * getStepMetrics for this job
-     * @method getStepMetrics
-     * @param  {Object}   config                Configuration object
-     * @param  {String}   [config.stepName]     Look at this step, if undefined then look at all steps
-     * @param  {String}   [config.startTime]    Look at builds created after this startTime
-     * @param  {String}   [config.endTime]      Look at builds created before this endTime
-     * @return {Promise}  Resolves to array of metrics for steps belong to builds of this job
-     */
-    async getStepMetrics({ stepName = null, startTime = null, endTime = null }) {
-        // Get builds during this time range
-        const builds = await this.getBuilds({
-            startTime,
-            endTime,
-            sort: 'ascending',
-            paginate: {
-                count: MAX_COUNT
-            }
-        });
-
-        // Go through the step for all builds and generate metrics
-        const stepArrays = builds.map(b => b.getMetrics({ stepName }));
-
-        return [].concat(...stepArrays);
     }
 }
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -10,6 +10,28 @@ const apiUri = Symbol('apiUri');
 const START_INDEX = 3;
 const MAX_COUNT = 1000;
 
+/**
+ * Find metrics and step metrics related to the build
+ * @method findMetrics
+ * @param  {Object}    build      build object
+ * @param  {String}    stepName   only include this step
+ * @param  {Boolean}   aggregate  Whether to include step metrics
+ * @return {Array}                Array of metrics
+ */
+function findMetrics(build, stepName, aggregate) {
+    const { id, jobId, eventId, createTime, status, startTime, endTime } = build;
+    const duration = startTime && endTime
+        ? dayjs(endTime).diff(dayjs(startTime), 'second')
+        : null;
+    const metrics = { id, jobId, eventId, createTime, status, duration };
+
+    if (!aggregate) {
+        metrics.steps = build.getMetrics({ stepName });
+    }
+
+    return metrics;
+}
+
 class Job extends BaseModel {
     /**
      * Constructs a Job Model
@@ -242,27 +264,16 @@ class Job extends BaseModel {
                 count: MAX_COUNT
             }
         };
-        const findMetrics = (build) => {
-            const { id, jobId, eventId, createTime, status, startTime, endTime } = build;
-            const duration = startTime && endTime
-                ? dayjs(endTime).diff(dayjs(startTime), 'second')
-                : null;
-
-            const steps = build.getMetrics({ stepName: config.stepName });
-
-            return { id, jobId, eventId, createTime, status, duration, steps };
-        };
 
         if (!config.aggregate) {
             // Get builds during this time range
             const builds = await this.getBuilds(options);
 
             // Generate metrics
-            return builds.map(b => findMetrics(b));
+            return builds.map(b => findMetrics(b, config.stepName, config.aggregate));
         }
 
         const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
-
         // recursively fetching builds until the end
         const getAllBuilds = async (opts, buildArray, date, index) => {
             const builds = await this.getBuilds(opts);
@@ -305,7 +316,8 @@ class Job extends BaseModel {
         const aggregatedMetrics = [];
 
         allBuilds.forEach((arr) => {
-            const metrics = arr.map(b => findMetrics(b).duration);
+            const metrics = arr.map(b =>
+                findMetrics(b, config.stepName, config.aggregate).duration);
             const avg = metrics.reduce((acc, current) => acc + current) / metrics.length;
 
             aggregatedMetrics.push({

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -9,6 +9,7 @@ const workflowParser = require('screwdriver-workflow-parser');
 const hoek = require('hoek');
 const winston = require('winston');
 const _ = require('lodash');
+const dayjs = require('dayjs');
 const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
@@ -1231,7 +1232,7 @@ class PipelineModel extends BaseModel {
             }
 
             return {
-                duration: Math.round((maxEndTime - minStartTime) / 1000), // round in seconds
+                duration: dayjs(maxEndTime).diff(dayjs(minStartTime), 'second'), // round in seconds
                 queuedTime: totalQueuedTime,
                 imagePullTime: totalImagePullTime,
                 status: eventStatus,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1232,7 +1232,7 @@ class PipelineModel extends BaseModel {
             }
 
             return {
-                duration: dayjs(maxEndTime).diff(dayjs(minStartTime), 'second'), // round in seconds
+                duration: dayjs(maxEndTime).diff(dayjs(minStartTime), 'second'),
                 queuedTime: totalQueuedTime,
                 imagePullTime: totalImagePullTime,
                 status: eventStatus,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "async": "^2.6.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
-    "dayjs": "^1.8.10",
+    "dayjs": "^1.8.11",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1328,21 +1328,18 @@ describe('Build Model', () => {
         beforeEach(() => {
             metrics = [{
                 id: step1.id,
-                buildId,
                 name: step1.name,
                 code: step1.code,
                 duration: duration1,
                 createTime: build.createTime
             }, {
                 id: step2.id,
-                buildId,
                 name: step2.name,
                 code: step2.code,
                 duration: duration2,
                 createTime: build.createTime
             }, {
                 id: undefined,
-                buildId,
                 name: step3.name,
                 code: step3.code,
                 duration: duration3,


### PR DESCRIPTION
This is so that UI will not need to make separate calls to get steps.
Step metrics will be included as part of `job/id/metrics`. The results will look like this:
```node
// builds for this job
[{
id: 1234 //build id
duration: ...
steps: [{
   id: 1 // step id
   duration: ...
}, {
   id: 2
   duration ... 
}]
}, ... ]
```
Related: https://github.com/screwdriver-cd/screwdriver/issues/1412