### PR TITLE
fix(1010): [2] set prRef when event is created

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -457,6 +457,8 @@ class EventFactory extends BaseFactory {
                 }
 
                 if (prRef) {
+                    modelConfig.pr.ref = prRef;
+
                     return p.syncPR(prNum);
                 }
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -138,7 +138,8 @@ describe('Event Factory', () => {
                 parentBuildId: 12345,
                 scmContext,
                 prInfo: {
-                    url: 'https://github.com/screwdriver-cd/screwdriver/pull/1063'
+                    url: 'https://github.com/screwdriver-cd/screwdriver/pull/1063',
+                    ref: 'branch'
                 }
             };
             expected = {
@@ -902,6 +903,7 @@ describe('Event Factory', () => {
 
         it('should create event with pr info if it is pr event', () => {
             config.prNum = 20;
+            config.prRef = 'branch';
 
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);


### PR DESCRIPTION
## Objective
We need to set `prRef` into events model when the event is created.

## Reference
Issue:
https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-478911280

Other PRs:
[1] data-schema: https://github.com/screwdriver-cd/data-schema/pull/327
[3] api: https://github.com/screwdriver-cd/screwdriver/pull/1580