### PR TITLE
fix(1412): use sortBy to sort

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -54,7 +54,8 @@ class EventModel extends BaseModel {
         const builds = await this.getBuilds({
             startTime: config.startTime,
             endTime: config.endTime,
-            sort: 'ascending'
+            sort: 'ascending',
+            sortBy: 'createTime'
         });
 
         const findDuration = (start, end) => (start && end

--- a/lib/job.js
+++ b/lib/job.js
@@ -139,7 +139,7 @@ class Job extends BaseModel {
      * @return {Promise}                            List of builds
      */
     getBuilds(config = {}) {
-        const { sort, status, paginate, startTime, endTime } = config;
+        const { sort, sortBy, status, paginate, startTime, endTime } = config;
         const defaultConfig = {
             params: {
                 jobId: this.id
@@ -155,6 +155,10 @@ class Job extends BaseModel {
 
         if (status) {
             listConfig.params.status = status;
+        }
+
+        if (sortBy) {
+            listConfig.sortBy = sortBy;
         }
 
         // Lazy load factory dependency to prevent circular dependency issues
@@ -261,6 +265,7 @@ class Job extends BaseModel {
             startTime: config.startTime,
             endTime: config.endTime,
             sort: 'ascending',
+            sortBy: 'createTime',
             paginate: {
                 count: MAX_COUNT
             }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1268,6 +1268,7 @@ class PipelineModel extends BaseModel {
             startTime: config.startTime,
             endTime: config.endTime,
             sort: 'ascending',
+            sortBy: 'createTime',
             paginate: {
                 count: MAX_COUNT
             }

--- a/test/lib/event.test.js
+++ b/test/lib/event.test.js
@@ -170,7 +170,8 @@ describe('Event Model', () => {
                 },
                 startTime,
                 endTime,
-                sort: 'ascending'
+                sort: 'ascending',
+                sortBy: 'createTime'
             };
 
             buildFactoryMock.list.resolves([build1, build2]);
@@ -194,7 +195,8 @@ describe('Event Model', () => {
                 params: {
                     eventId: 1234
                 },
-                sort: 'ascending'
+                sort: 'ascending',
+                sortBy: 'createTime'
             };
 
             buildFactoryMock.list.resolves([build1, build2]);

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -499,6 +499,7 @@ describe('Job Model', () => {
                 startTime,
                 endTime,
                 sort: 'ascending',
+                sortBy: 'createTime',
                 paginate: {
                     count: MAX_COUNT
                 }
@@ -527,6 +528,7 @@ describe('Job Model', () => {
                 startTime,
                 endTime,
                 sort: 'ascending',
+                sortBy: 'createTime',
                 paginate: {
                     page: 1,
                     count: FAKE_MAX_COUNT
@@ -584,6 +586,7 @@ describe('Job Model', () => {
                     jobId: 1234
                 },
                 sort: 'ascending',
+                sortBy: 'createTime',
                 paginate: {
                     count: MAX_COUNT
                 }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2066,6 +2066,7 @@ describe('Pipeline Model', () => {
                     type: 'pipeline'
                 },
                 sort: 'ascending',
+                sortBy: 'createTime',
                 paginate: {
                     count: MAX_COUNT
                 },
@@ -2099,6 +2100,7 @@ describe('Pipeline Model', () => {
                 startTime,
                 endTime,
                 sort: 'ascending',
+                sortBy: 'createTime',
                 paginate: {
                     page: 1,
                     count: FAKE_MAX_COUNT
@@ -2210,6 +2212,7 @@ describe('Pipeline Model', () => {
                     type: 'pipeline'
                 },
                 sort: 'ascending',
+                sortBy: 'createTime',
                 paginate: {
                     count: MAX_COUNT
                 }


### PR DESCRIPTION
Need to use `sortBy` since if there are indexes, it will override the default sortKey: https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L397-L398
