### PR TITLE
fix(823): always show startFrom node

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -296,6 +296,12 @@ function getLatestWorkflowGraph(config) {
  */
 function updateWorkflowGraph(config) {
     const { pipeline, eventConfig, workflowGraph } = config;
+    const startNode = eventConfig.startFrom;
+
+    // If the start node is missing in the workflowGraph, add it as a detached node
+    if (startNode && !workflowGraph.nodes.find(n => n.name === startNode)) {
+        workflowGraph.nodes.push({ name: startNode });
+    }
 
     if (eventConfig.prRef && pipeline.prChain) {
         // eslint-disable-next-line global-require

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -787,6 +787,50 @@ describe('Event Factory', () => {
                 });
             });
 
+            // eslint-disable-next-line max-len
+            it('should update the workflowGraph properly when a "startFrom" node is missing in the workflowGraph', () => {
+                const RewiredEventFactory = rewire('../../lib/eventFactory');
+                // eslint-disable-next-line no-underscore-dangle
+                const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
+                const eventConfig = { startFrom: '~release' };
+                const inWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'job-A', id: 22 },
+                        { name: 'job-B', id: 23 }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+                const expectedWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'job-A', id: 22 },
+                        { name: 'job-B', id: 23 },
+                        // add a missing startFrom node
+                        { name: '~release' }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+
+                return updateWorkflowGraph({
+                    pipelineConfig: {},
+                    eventConfig,
+                    workflowGraph: inWorkflowGraph
+                }).then((actualWorkflowGraph) => {
+                    assert.deepEqual(expectedWorkflowGraph, actualWorkflowGraph);
+                });
+            });
+
             it('should create build of the "PR-1:main" job with prChain config', () => {
                 config.startFrom = '~pr';
                 config.prRef = 'branch';


### PR DESCRIPTION
`~release` and `~tag` nodes is not showed in workflowGraph if these events isn't required by other jobs. But actually these event is triggerd from github, the `startFrom` node is missing in the workflowGraph like below. It's confusing.
![image](https://user-images.githubusercontent.com/5774825/56024656-70ecac80-5d4b-11e9-996e-0583c97a4af1.png)

This PR fix to show a missing "startFrom" node in the workflowGraph.
After:
![image](https://user-images.githubusercontent.com/5774825/56024966-24ee3780-5d4c-11e9-92d7-f64ef84bcf3f.png)

ref: https://github.com/screwdriver-cd/screwdriver/issues/823#issuecomment-478814234