### PR TITLE
fix: Gracefully handle case when blockedby pipeline id does not exist

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -84,7 +84,14 @@ function getBlockedByIds(pipeline, job) {
                 const [, pid, jobname] = fullname.match(EXTERNAL_TRIGGER);
 
                 return pipelineFactory.get(parseInt(pid, 10)) // convert pid from string to number
-                    .then(p => p.jobs)
+                    .then((p) => {
+                        // If pipeline doesn't exist, don't try to get pipeline jobs
+                        if (!p) {
+                            return [];
+                        }
+
+                        return p.jobs;
+                    })
                     .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));
             }))
             // Merge the results

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
     "rewire": "^4.0.1",
-    "sinon": "^7.2.7"
+    "sinon": "^7.3.1"
   },
   "dependencies": {
     "async": "^2.6.2",
@@ -54,7 +54,7 @@
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.0",
-    "screwdriver-data-schema": "^18.45.0",
+    "screwdriver-data-schema": "^18.45.1",
     "screwdriver-workflow-parser": "^1.8.3",
     "winston": "^2.4.4"
   }


### PR DESCRIPTION
## Context
Sometimes users might use `blockedBy` IDs that are not valid pipeline IDs. This issue can cause builds to get stuck in the `init` step. 

## Objective
This change handles that case and returns empty array if pipeline does not exist instead of trying to get the pipeline's jobs.