### PR TITLE
fix(1412): edge cases for aggregated metrics

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -289,7 +289,7 @@ class Job extends BaseModel {
                 findMetrics(b, config.stepName, config.aggregateInterval).duration);
             let emptyCount = 0;
 
-            const avg = (metrics.reduce((acc, current) => {
+            const totalDuration = metrics.reduce((acc, current) => {
                 if (current) {
                     return acc + current;
                 }
@@ -297,11 +297,14 @@ class Job extends BaseModel {
                 emptyCount += 1;
 
                 return acc;
-            })) / (metrics.length - emptyCount);
+            });
+            const duration = metrics.length > emptyCount
+                ? +(totalDuration / (metrics.length - emptyCount)).toFixed(2)
+                : null;
 
             aggregatedMetrics.push({
                 createTime: sameIntervalBuilds[0].createTime,
-                duration: +avg.toFixed(2)
+                duration
             });
         });
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -8,7 +8,7 @@ const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
 const START_INDEX = 3;
-const MAX_COUNT = 1000;
+const MAX_COUNT = 2000;
 
 /**
  * Find metrics and step metrics related to the build
@@ -284,13 +284,23 @@ class Job extends BaseModel {
             'getBuilds', config.aggregateInterval, options, [[]]);
         const aggregatedMetrics = [];
 
-        allBuilds.forEach((sameDateBuilds) => {
-            const metrics = sameDateBuilds.map(b =>
+        allBuilds.forEach((sameIntervalBuilds) => {
+            const metrics = sameIntervalBuilds.map(b =>
                 findMetrics(b, config.stepName, config.aggregateInterval).duration);
-            const avg = metrics.reduce((acc, current) => acc + current) / metrics.length;
+            let emptyCount = 0;
+
+            const avg = (metrics.reduce((acc, current) => {
+                if (current) {
+                    return acc + current;
+                }
+
+                emptyCount += 1;
+
+                return acc;
+            })) / (metrics.length - emptyCount);
 
             aggregatedMetrics.push({
-                createTime: sameDateBuilds[0].createTime,
+                createTime: sameIntervalBuilds[0].createTime,
                 duration: +avg.toFixed(2)
             });
         });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -16,7 +16,7 @@ const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
     job: 2 // main or undefined if using legacy
 };
-const MAX_COUNT = 1000;
+const MAX_COUNT = 2000;
 
 winston.level = process.env.LOG_LEVEL || 'info';
 const logger = new (winston.Logger)({
@@ -95,21 +95,37 @@ const sumAggregatedEventMetrics = async (events) => {
     let totalQueuedTime = 0;
     let totalImagePullTime = 0;
     let totalDuration = 0;
-    let emptyEvent = 0;
+    const emptyCount = {
+        event: 0,
+        queuedTime: 0,
+        imagePullTime: 0,
+        duration: 0
+    };
+
+    const checkForEmpty = (fieldName, time) => {
+        if (time) {
+            return time;
+        }
+
+        emptyCount[fieldName] += 1;
+
+        return 0;
+    };
 
     const promiseArray = events.map(async (e) => {
         const metrics = await eventMetrics(e);
 
         if (!metrics) {
-            emptyEvent += 1;
+            emptyCount.event += 1;
+            emptyCount.queuedTime += 1;
+            emptyCount.imagePullTime += 1;
+            emptyCount.duration += 1;
 
             return;
         }
-        const { queuedTime, imagePullTime, duration } = metrics;
-
-        totalQueuedTime += queuedTime;
-        totalImagePullTime += imagePullTime;
-        totalDuration += duration;
+        totalQueuedTime += checkForEmpty('queuedTime', metrics.queuedTime);
+        totalImagePullTime += checkForEmpty('imagePullTime', metrics.imagePullTime);
+        totalDuration += checkForEmpty('duration', metrics.duration);
     });
 
     await Promise.all(promiseArray);
@@ -118,7 +134,7 @@ const sumAggregatedEventMetrics = async (events) => {
         totalQueuedTime,
         totalImagePullTime,
         totalDuration,
-        emptyEvent
+        emptyCount
     };
 };
 
@@ -1296,16 +1312,19 @@ class PipelineModel extends BaseModel {
         const allEvents = await getAllRecords.call(this,
             'getEvents', config.aggregateInterval, options, [[]]);
 
-        return Promise.all(allEvents.map(async (sameDateEvents) => {
-            const { totalQueuedTime, totalImagePullTime, totalDuration, emptyEvent }
-                = await sumAggregatedEventMetrics(sameDateEvents);
-            const length = sameDateEvents.length - emptyEvent;
+        return Promise.all(allEvents.map(async (sameIntervalEvents) => {
+            const length = sameIntervalEvents.length;
+            const { totalQueuedTime, totalImagePullTime, totalDuration, emptyCount }
+                = await sumAggregatedEventMetrics(sameIntervalEvents);
 
             return {
-                createTime: sameDateEvents[0].createTime,
-                duration: +(totalDuration / length).toFixed(2),
-                queuedTime: +(totalQueuedTime / length).toFixed(2),
-                imagePullTime: +(totalImagePullTime / length).toFixed(2)
+                createTime: sameIntervalEvents[0].createTime,
+                duration: +(totalDuration / (length - emptyCount.duration))
+                    .toFixed(2),
+                queuedTime: +(totalQueuedTime / (length - emptyCount.queuedTime))
+                    .toFixed(2),
+                imagePullTime: +(totalImagePullTime / (length - emptyCount.imagePullTime))
+                    .toFixed(2)
             };
         }));
     }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -102,6 +102,7 @@ const sumAggregatedEventMetrics = async (events) => {
         duration: 0
     };
 
+    // increment emptyCount and returns 0 if the field is null, otherwise return its value
     const checkForEmpty = (fieldName, time) => {
         if (time) {
             return time;
@@ -1316,15 +1317,21 @@ class PipelineModel extends BaseModel {
             const length = sameIntervalEvents.length;
             const { totalQueuedTime, totalImagePullTime, totalDuration, emptyCount }
                 = await sumAggregatedEventMetrics(sameIntervalEvents);
+            const duration = length > emptyCount.duration
+                ? +(totalDuration / (length - emptyCount.duration)).toFixed(2)
+                : null;
+            const queuedTime = length > emptyCount.queuedTime
+                ? +(totalQueuedTime / (length - emptyCount.queuedTime)).toFixed(2)
+                : null;
+            const imagePullTime = length > emptyCount.imagePullTime
+                ? +(totalImagePullTime / (length - emptyCount.imagePullTime)).toFixed(2)
+                : null;
 
             return {
                 createTime: sameIntervalEvents[0].createTime,
-                duration: +(totalDuration / (length - emptyCount.duration))
-                    .toFixed(2),
-                queuedTime: +(totalQueuedTime / (length - emptyCount.queuedTime))
-                    .toFixed(2),
-                imagePullTime: +(totalImagePullTime / (length - emptyCount.imagePullTime))
-                    .toFixed(2)
+                duration,
+                queuedTime,
+                imagePullTime
             };
         }));
     }

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -7,7 +7,7 @@ const schema = require('screwdriver-data-schema');
 const hoek = require('hoek');
 const rewire = require('rewire');
 const dayjs = require('dayjs');
-const MAX_COUNT = 1000;
+const MAX_COUNT = 2000;
 const FAKE_MAX_COUNT = 5;
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -591,6 +591,25 @@ describe('Job Model', () => {
                         buildListConfig.paginate.page = 2;
                         assert.calledWith(buildFactoryMock.list.secondCall, buildListConfig);
 
+                        assert.deepEqual(result, metrics);
+                    });
+            });
+
+            it('filters out bad values', () => {
+                const badBuild = Object.assign({}, build3);
+
+                delete badBuild.endTime;
+
+                buildFactoryMock.list.onCall(0).resolves([build3, badBuild]);
+
+                metrics = [{
+                    createTime: '2019-01-22T21:00:00.000Z', duration: 4140
+                }];
+
+                return job.getMetrics({ startTime, endTime, aggregateInterval: 'month' })
+                    .then((result) => {
+                        assert.calledOnce(buildFactoryMock.list);
+                        assert.calledWith(buildFactoryMock.list.firstCall, buildListConfig);
                         assert.deepEqual(result, metrics);
                     });
             });


### PR DESCRIPTION
Address some edge cases for aggregation:

If one of the events in the aggregate interval has duration `null`, then it makes the whole thing `null`
Similar for job metrics.

Related: https://github.com/screwdriver-cd/screwdriver/issues/1412