### PR TITLE
fix: fix not to push invalid node in updateWorkflowGraph

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -3,6 +3,7 @@
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
 const {
+    TRIGGER,
     EXTERNAL_TRIGGER,
     COMMIT_TRIGGER,
     PR_TRIGGER,
@@ -299,7 +300,7 @@ function updateWorkflowGraph(config) {
     const startNode = eventConfig.startFrom;
 
     // If the start node is missing in the workflowGraph, add it as a detached node
-    if (startNode && !workflowGraph.nodes.find(n => n.name === startNode)) {
+    if (TRIGGER.test(startNode) && !workflowGraph.nodes.find(n => n.name === startNode)) {
         workflowGraph.nodes.push({ name: startNode });
     }
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -831,6 +831,47 @@ describe('Event Factory', () => {
                 });
             });
 
+            it('should not push a invalid node in the workflowGraph', () => {
+                const RewiredEventFactory = rewire('../../lib/eventFactory');
+                // eslint-disable-next-line no-underscore-dangle
+                const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
+                const eventConfig = { startFrom: 'PR-1:test' };
+                const inWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'job-A', id: 22 },
+                        { name: 'job-B', id: 23 }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+                const expectedWorkflowGraph = {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'job-A', id: 22 },
+                        { name: 'job-B', id: 23 }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'job-A' },
+                        { src: '~commit', dest: 'job-A' },
+                        { src: 'job-A', dest: 'job-B' }
+                    ]
+                };
+
+                return updateWorkflowGraph({
+                    pipelineConfig: {},
+                    eventConfig,
+                    workflowGraph: inWorkflowGraph
+                }).then((actualWorkflowGraph) => {
+                    assert.deepEqual(expectedWorkflowGraph, actualWorkflowGraph);
+                });
+            });
+
             it('should create build of the "PR-1:main" job with prChain config', () => {
                 config.startFrom = '~pr';
                 config.prRef = 'branch';

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -849,19 +849,7 @@ describe('Event Factory', () => {
                         { src: 'job-A', dest: 'job-B' }
                     ]
                 };
-                const expectedWorkflowGraph = {
-                    nodes: [
-                        { name: '~pr' },
-                        { name: '~commit' },
-                        { name: 'job-A', id: 22 },
-                        { name: 'job-B', id: 23 }
-                    ],
-                    edges: [
-                        { src: '~pr', dest: 'job-A' },
-                        { src: '~commit', dest: 'job-A' },
-                        { src: 'job-A', dest: 'job-B' }
-                    ]
-                };
+                const expectedWorkflowGraph = inWorkflowGraph;
 
                 return updateWorkflowGraph({
                     pipelineConfig: {},


### PR DESCRIPTION
[This](https://github.com/screwdriver-cd/models/pull/364) PR breaks PR build restart.
That PR allows workflowGraph to show a "startFrom" node every time if the "startFrom" node doesn't exit. But If it restart PR build, the name of the "startFrom" node will be like "PR-1:test", and the node name is invalid.

This PR fix not to push invalid node to workflowGraph.