### PR TITLE
feat(1590): support read only db

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -12,12 +12,14 @@ class BaseFactory {
      * @param  {String}    modelName            Name of the model to get from data-schema
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {Object}   [config.datastoreRO]  Read only datastore
      * @param  {Object}    config.scm           Object that will perform operations on scm resource
      */
     constructor(modelName, config) {
         this.model = schema.models[modelName];
         this.table = this.model.tableName;
         this.datastore = config.datastore;
+        this.datastoreRO = config.datastoreRO || config.datastore;
         this.scm = config.scm;
     }
 
@@ -121,6 +123,7 @@ class BaseFactory {
      * @param  {String}         [config.timeKey]          Key used for timerange search
      * @param  {String}         [config.startTime]        Search for records with timeKey >= startTime
      * @param  {String}         [config.endTime]          Search for records with timeKey <= endTime
+     * @param  {Boolean}        [config.readOnly]         Use readOnly datastore
      * @return {Promise}
      */
     list(config) {
@@ -128,6 +131,14 @@ class BaseFactory {
             table: this.table,
             params: hoek.reach(config, 'params', { default: {} })
         };
+
+        // use read only datastore if it is configured
+        const readOnly = hoek.reach(config, 'readOnly', { default: false });
+        let datastoreForLookup = this.datastore;
+
+        if (readOnly) {
+            datastoreForLookup = this.datastoreRO;
+        }
 
         if (config) {
             const {
@@ -175,11 +186,11 @@ class BaseFactory {
             }
 
             if (raw) {
-                return this.datastore.scan(scanConfig);
+                return datastoreForLookup.scan(scanConfig);
             }
         }
 
-        return this.datastore.scan(scanConfig)
+        return datastoreForLookup.scan(scanConfig)
             .then((data) => {
                 if (!Array.isArray(data)) {
                     throw new Error('Unexpected response from datastore, ' +
@@ -189,7 +200,7 @@ class BaseFactory {
                 const result = [];
 
                 data.forEach((item) => {
-                    item.datastore = this.datastore;
+                    item.datastore = datastoreForLookup;
                     item.scm = this.scm;
 
                     result.push(this.createClass(item));

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -132,9 +132,9 @@ class BaseFactory {
             params: hoek.reach(config, 'params', { default: {} })
         };
 
+        let datastoreForLookup = this.datastore;
         // use read only datastore if it is configured
         const readOnly = hoek.reach(config, 'readOnly', { default: false });
-        let datastoreForLookup = this.datastore;
 
         if (readOnly) {
             datastoreForLookup = this.datastoreRO;

--- a/lib/event.js
+++ b/lib/event.js
@@ -20,6 +20,7 @@ class EventModel extends BaseModel {
      * @param  {String}   [config.startTime]     Search for builds after this startTime
      * @param  {String}   [config.endTime]       Search for builds before this endTime
      * @param  {String}   [config.sort]          Ascending or descending
+     * @param  {Boolean}  [config.readOnly]      Use readOnly datastore
      * @return {Promise}  Resolves to an array of builds
      */
     getBuilds(config) {
@@ -55,7 +56,8 @@ class EventModel extends BaseModel {
             startTime: config.startTime,
             endTime: config.endTime,
             sort: 'ascending',
-            sortBy: 'id'
+            sortBy: 'id',
+            readOnly: true
         });
 
         const findDuration = (start, end) => (start && end

--- a/lib/job.js
+++ b/lib/job.js
@@ -136,10 +136,11 @@ class Job extends BaseModel {
      * @param  {String}   [config.status]           List only builds with this status
      * @param  {String}   [config.startTime]        Search for builds created after this startTime
      * @param  {String}   [config.endTime]          Search for builds created before this endTime
+     * @param  {Boolean}  [config.readOnly]         Use readOnly datastore
      * @return {Promise}                            List of builds
      */
     getBuilds(config = {}) {
-        const { sort, sortBy, status, paginate, startTime, endTime } = config;
+        const { sort, sortBy, status, paginate, startTime, endTime, readOnly } = config;
         const defaultConfig = {
             params: {
                 jobId: this.id
@@ -159,6 +160,10 @@ class Job extends BaseModel {
 
         if (sortBy) {
             listConfig.sortBy = sortBy;
+        }
+
+        if (readOnly) {
+            listConfig.readOnly = readOnly;
         }
 
         // Lazy load factory dependency to prevent circular dependency issues
@@ -268,7 +273,8 @@ class Job extends BaseModel {
             sortBy: 'id',
             paginate: {
                 count: MAX_COUNT
-            }
+            },
+            readOnly: true
         };
 
         if (!config.aggregateInterval) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1148,6 +1148,7 @@ class PipelineModel extends BaseModel {
      * @param  {Number}   [config.paginate.page]                Specific page of the set to return
      * @param  {String}   [config.startTime]                    Search for events after this startTime
      * @param  {String}   [config.endTime]                      Search for events before this endTime
+     * @param  {Boolean}  [config.readOnly]                     Use readOnly datastore
      * @return {Promise}  Resolves to an array of events
      */
     getEvents(config) {
@@ -1271,7 +1272,8 @@ class PipelineModel extends BaseModel {
             sortBy: 'id',
             paginate: {
                 count: MAX_COUNT
-            }
+            },
+            readOnly: true
         };
 
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {

--- a/test/lib/event.test.js
+++ b/test/lib/event.test.js
@@ -171,7 +171,8 @@ describe('Event Model', () => {
                 startTime,
                 endTime,
                 sort: 'ascending',
-                sortBy: 'id'
+                sortBy: 'id',
+                readOnly: true
             };
 
             buildFactoryMock.list.resolves([build1, build2]);
@@ -196,7 +197,8 @@ describe('Event Model', () => {
                     eventId: 1234
                 },
                 sort: 'ascending',
-                sortBy: 'id'
+                sortBy: 'id',
+                readOnly: true
             };
 
             buildFactoryMock.list.resolves([build1, build2]);

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -502,7 +502,8 @@ describe('Job Model', () => {
                 sortBy: 'id',
                 paginate: {
                     count: MAX_COUNT
-                }
+                },
+                readOnly: true
             };
 
             buildFactoryMock.list.resolves([build1, build2, build3]);
@@ -533,7 +534,8 @@ describe('Job Model', () => {
                     paginate: {
                         page: 1,
                         count: FAKE_MAX_COUNT
-                    }
+                    },
+                    readOnly: true
                 };
 
                 const testBuilds = [];
@@ -613,7 +615,8 @@ describe('Job Model', () => {
                 sortBy: 'id',
                 paginate: {
                     count: MAX_COUNT
-                }
+                },
+                readOnly: true
             };
 
             buildFactoryMock.list.resolves([build1, build2, build3]);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2078,7 +2078,8 @@ describe('Pipeline Model', () => {
                     count: MAX_COUNT
                 },
                 startTime,
-                endTime
+                endTime,
+                readOnly: true
             };
 
             eventFactoryMock.list.resolves([event1, event0, event2]);
@@ -2112,7 +2113,8 @@ describe('Pipeline Model', () => {
                     paginate: {
                         page: 1,
                         count: FAKE_MAX_COUNT
-                    }
+                    },
+                    readOnly: true
                 };
                 const testEvents = [];
                 let currentDay = event1.createTime;
@@ -2257,7 +2259,8 @@ describe('Pipeline Model', () => {
                 sortBy: 'id',
                 paginate: {
                     count: MAX_COUNT
-                }
+                },
+                readOnly: true
             };
 
             eventFactoryMock.list.resolves([event1, event2]);


### PR DESCRIPTION
For get metrics functions, use read only datastore instance. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1590
Blocked by: https://github.com/screwdriver-cd/screwdriver/pull/1591