### PR TITLE
fix: [3] convert prChain to chainPR

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -81,11 +81,11 @@ function getJobsFromJobName(config) {
  * @param  {Object}    config.pipelineConfig
  * @param  {Object}    config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
  * @param  {String}    config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
- * @param  {Boolean}   config.prChain                        Flag of triggering subsequent job after pull request job
+ * @param  {Boolean}   config.chainPR                        Flag of triggering subsequent job after pull request job
  * @resolves {Array}                                         Array of PR jobs to start
  */
 function getJobsFromPR(config) {
-    const { jobs, prNum, pipelineConfig, startFrom, prChain } = config;
+    const { jobs, prNum, pipelineConfig, startFrom, chainPR } = config;
     const isPRTrigger = PR_TRIGGER.test(startFrom);
 
     if (!isPRTrigger) {
@@ -95,7 +95,7 @@ function getJobsFromPR(config) {
     const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
         trigger: startFrom,
         prNum,
-        prChain
+        chainPR
     });
 
     const jobsToStart = jobs.filter(
@@ -215,7 +215,7 @@ function createBuilds(config) {
             prNum: eventConfig.prNum,
             pipelineConfig,
             startFrom,
-            prChain: pipeline.prChain
+            chainPR: pipeline.chainPR
         });
 
         return Promise.all([jobsFromTrigger, jobsFromJobName, jobsFromPR])
@@ -304,7 +304,7 @@ function updateWorkflowGraph(config) {
         workflowGraph.nodes.push({ name: startNode });
     }
 
-    if (eventConfig.prRef && pipeline.prChain) {
+    if (eventConfig.prRef && pipeline.chainPR) {
         // eslint-disable-next-line global-require
         const JobFactory = require('./jobFactory');
         const jobFactory = JobFactory.getInstance();
@@ -313,10 +313,10 @@ function updateWorkflowGraph(config) {
             params: { pipelineId: pipeline.id, archived: false },
             search: { field: 'name', keyword: `PR-${eventConfig.prNum}:%` }
         })
-            .then((prChainedJobs) => {
+            .then((chainedPRJobs) => {
                 const nodes = workflowGraph.nodes;
 
-                prChainedJobs.forEach((job) => {
+                chainedPRJobs.forEach((job) => {
                     // Add jobId to workflowGraph.nodes
                     nodes.forEach((node) => {
                         if (`PR-${eventConfig.prNum}:${node.name}` === job.name) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -293,9 +293,9 @@ class PipelineModel extends BaseModel {
         openedPRsNames.forEach((name, i) => {
             const matchedPRs = existingPRs.filter(job => job.name.startsWith(name));
 
-            // if opened PR was previously archived and prChain flag is false, unarchive it
+            // if opened PR was previously archived and chainPR flag is false, unarchive it
             matchedPRs.forEach((job) => {
-                if (job.archived && this.prChain === false) {
+                if (job.archived && this.chainPR === false) {
                     jobList.toUnarchive.push(job);
                 }
             });
@@ -460,7 +460,7 @@ class PipelineModel extends BaseModel {
                 this.jobs
             ]))
             .then(([parsedConfig, jobs]) => {
-                logger.info(`pipelineId:${this.id}: prChain flag is ${this.prChain}.`);
+                logger.info(`pipelineId:${this.id}: chainPR flag is ${this.chainPR}.`);
 
                 const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
 
@@ -468,17 +468,17 @@ class PipelineModel extends BaseModel {
                 let nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
                     trigger: '~pr',
                     prNum,
-                    prChain: this.prChain
+                    chainPR: this.chainPR
                 });
 
-                // Get all chained jobs if prChain is true
-                if (this.prChain) {
+                // Get all chained jobs if chainPR is true
+                if (this.chainPR) {
                     let triggerJobs = nextJobs.concat();
 
                     while (triggerJobs.length > 0) {
                         const chainedJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
                             trigger: triggerJobs[0],
-                            prChain: this.prChain
+                            chainPR: this.chainPR
                         });
 
                         triggerJobs.splice(0, 1);
@@ -734,7 +734,7 @@ class PipelineModel extends BaseModel {
             }).then((parsedConfig) => {
                 const annotChainPR = parsedConfig.annotations['screwdriver.cd/chainPR'];
 
-                this.prChain = typeof annotChainPR === 'undefined' ? chainPR : annotChainPR;
+                this.chainPR = typeof annotChainPR === 'undefined' ? chainPR : annotChainPR;
                 this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
 
@@ -1308,6 +1308,23 @@ class PipelineModel extends BaseModel {
                 imagePullTime: +(totalImagePullTime / length).toFixed(2)
             };
         }));
+    }
+
+    /**
+     * Fetch the value of prChain via chainPR property.
+     * @property chainPR
+     * @return {boolean}
+    */
+    get chainPR() {
+        return this.prChain;
+    }
+
+    /**
+     * Set the value of prChain via chainPR property.
+     * @property chainPR
+    */
+    set chainPR(chainPR) {
+        this.prChain = chainPR;
     }
 }
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -671,11 +671,11 @@ describe('Event Factory', () => {
             });
 
             // Private function test
-            it('should keep the workflowGraph as is with non pr event and prChain = true', () => {
+            it('should keep the workflowGraph as is with non pr event and chainPR = true', () => {
                 const RewiredEventFactory = rewire('../../lib/eventFactory');
                 // eslint-disable-next-line no-underscore-dangle
                 const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
-                const pipeline = { id: 1234, prChain: true };
+                const pipeline = { id: 1234, chainPR: true };
                 const eventConfig = {}; // non pr event
                 const inWorkflowGraph = {
                     nodes: [
@@ -702,11 +702,11 @@ describe('Event Factory', () => {
                 });
             });
 
-            it('should keep the workflowGraph as is with pr event and prChain = false', () => {
+            it('should keep the workflowGraph as is with pr event and chainPR = false', () => {
                 const RewiredEventFactory = rewire('../../lib/eventFactory');
                 // eslint-disable-next-line no-underscore-dangle
                 const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
-                const pipeline = { id: 1234, prChain: false };
+                const pipeline = { id: 1234, chainPR: false };
                 const eventConfig = { prRef: 'branch', prNum: 1 };
                 const inWorkflowGraph = {
                     nodes: [
@@ -733,11 +733,11 @@ describe('Event Factory', () => {
                 });
             });
 
-            it('should update the workflowGraph properly with pr event and prChain = true', () => {
+            it('should update the workflowGraph properly with pr event and chainPR = true', () => {
                 const RewiredEventFactory = rewire('../../lib/eventFactory');
                 // eslint-disable-next-line no-underscore-dangle
                 const updateWorkflowGraph = RewiredEventFactory.__get__('updateWorkflowGraph');
-                const pipeline = { id: 1234, prChain: true };
+                const pipeline = { id: 1234, chainPR: true };
                 const eventConfig = { prRef: 'branch', prNum: 1 };
                 const inWorkflowGraph = {
                     nodes: [
@@ -860,7 +860,7 @@ describe('Event Factory', () => {
                 });
             });
 
-            it('should create build of the "PR-1:main" job with prChain config', () => {
+            it('should create build of the "PR-1:main" job with chainPR config', () => {
                 config.startFrom = '~pr';
                 config.prRef = 'branch';
                 config.prNum = 1;
@@ -868,7 +868,7 @@ describe('Event Factory', () => {
                 config.webhooks = true;
 
                 afterSyncedPRPipelineMock.jobs = Promise.resolve(jobsMock);
-                afterSyncedPRPipelineMock.prChain = true;
+                afterSyncedPRPipelineMock.chainPR = true;
                 afterSyncedPRPipelineMock.update = sinon.stub().resolves(afterSyncedPRPipelineMock);
                 // This function is called in updateWorkflowGraph() which is tested in another unit test.
                 jobFactoryMock.list.resolves([]);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -22,7 +22,7 @@ const EXTERNAL_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML, {
         scmUrls: SCM_URLS
     }
 });
-const NON_PRCHAIN_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML_PR, {
+const NON_CHAINPR_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML_PR, {
     annotations: { 'screwdriver.cd/chainPR': false }
 });
 const MAX_COUNT = 1000;
@@ -537,7 +537,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('stores prChain to pipeline', () => {
+        it('stores chainPR to pipeline', () => {
             const configMock = Object.assign({}, PARSED_YAML);
             const defatulChainPR = false;
 
@@ -549,7 +549,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
 
             return pipeline.sync(null, defatulChainPR).then(() => {
-                assert.equal(pipeline.prChain, true);
+                assert.equal(pipeline.chainPR, true);
             });
         });
 
@@ -957,7 +957,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('updates PR config, but it can not override prChain flag', () => {
+        it('updates PR config, but it can not override chainPR flag', () => {
             const firstPRJob = {
                 update: sinon.stub().resolves(null),
                 isPR: sinon.stub().returns(true),
@@ -966,8 +966,8 @@ describe('Pipeline Model', () => {
                 archived: false
             };
 
-            pipeline.prChain = true;
-            const clonedYAML = JSON.parse(JSON.stringify(NON_PRCHAIN_PARSED_YAML));
+            pipeline.chainPR = true;
+            const clonedYAML = JSON.parse(JSON.stringify(NON_CHAINPR_PARSED_YAML));
 
             jobFactoryMock.list.onCall(0).resolves([mainJob, publishJob, testJob, firstPRJob]); // all jobs
             jobFactoryMock.list.onCall(1).resolves([mainJob, publishJob, testJob]); // pipeline jobs
@@ -1078,8 +1078,8 @@ describe('Pipeline Model', () => {
                 });
         });
 
-        it('unarchive PR job if it was previously archived and prChain is false.', () => {
-            pipeline.prChain = false;
+        it('unarchive PR job if it was previously archived and chainPR is false.', () => {
+            pipeline.chainPR = false;
             prJob.archived = true;
             scmMock.getOpenedPRs.resolves([{ name: 'PR-1', ref: 'abc' }]);
 


### PR DESCRIPTION
## Context
Now there are orthographical variants like 'prChain' and 'chainPR' .
We want to unify these to `chainPR`.

## Objective
Add `chainPR` setter/getter method to pipeline model in order to convert the `prChain` to `chainPR`.
We don't change `prChain` property itself because it is already used in data-schema and it takes too much cost to change this.

## note
**Firstly, workflow-parser should be merged to pass the unit test.**

## References
https://github.com/screwdriver-cd/workflow-parser/pull/21
https://github.com/screwdriver-cd/data-schema/pull/330
https://github.com/screwdriver-cd/screwdriver/pull/1593