### PR TITLE
feat(1333): Add function to get triggers given a pipeline id (1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,27 @@ factory.list({
     // do things with the records
 );
 ```
+
+#### Get Triggers
+Get triggers based on pipeline ID.
+```js
+factory.getTriggers({pipelineId}).then(result => {
+    console.log(result);
+    // [{
+    //     jobName1,
+    //     triggers: [destA, destB]
+    // }, {
+    //     jobName2,
+    //     triggers: [destC, destD]
+    // }]
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config           | Object | Config object |
+| config.pipelineId | Number | The unique ID for the pipeline |
+
 ### Token Factory
 #### Search
 ```js

--- a/README.md
+++ b/README.md
@@ -1049,7 +1049,7 @@ factory.list({
 #### Get Triggers
 Get triggers based on pipeline ID.
 ```js
-factory.getTriggers({pipelineId}).then(result => {
+factory.getTriggers({ pipelineId, type }).then(result => {
     console.log(result);
     // [{
     //     jobName1,
@@ -1065,6 +1065,7 @@ factory.getTriggers({pipelineId}).then(result => {
 | :-------------   | :---- | :-------------|
 | config           | Object | Config object |
 | config.pipelineId | Number | The unique ID for the pipeline |
+| config.type | String | Type of jobs to get (`pr` or `pipeline`; default `pipeline`) |
 
 ### Token Factory
 #### Search

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -44,20 +44,21 @@ class TriggerFactory extends BaseFactory {
             .then((pipeline) => {
                 if (pipeline) {
                     // Get pipeline job names
-                    return pipeline.jobs.then(jobs => Promise.all(
-                        jobs.map(j =>
-                            // Get dest triggers for each src job
-                            this.list({
-                                params: {
-                                    src: `~sd@${pipelineId}:${j.name}`
-                                }
-                            // Push jobName and dest triggers to result
-                            }).then((triggersArr) => {
-                                const triggers = triggersArr.map(t => t.dest);
+                    return pipeline.getJobs()
+                        .then(jobs => Promise.all(
+                            jobs.map(j =>
+                                // Get dest triggers for each src job
+                                this.list({
+                                    params: {
+                                        src: `~sd@${pipelineId}:${j.name}`
+                                    }
+                                // Push jobName and dest triggers to result
+                                }).then((triggersArr) => {
+                                    const triggers = triggersArr.map(t => t.dest);
 
-                                result.push({ jobName: j.name, triggers });
-                            })
-                        ))).then(() => result);
+                                    result.push({ jobName: j.name, triggers });
+                                })
+                            ))).then(() => result);
                 }
 
                 return result;

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -32,9 +32,10 @@ class TriggerFactory extends BaseFactory {
      * Get all triggers related to a pipeline
      * @param  {Object} config
      * @param  {String} config.pipelineId   pipelineId
+     * @param  {String} [config.type]       Type of job to get ('pr' or 'pipeline'; default 'pipeline')
      * @return {Object}                     Returns object with dest triggers split by src jobs
      */
-    getTriggers({ pipelineId }) {
+    getTriggers({ pipelineId, type }) {
         // eslint-disable-next-line global-require
         const PipelineFactory = require('./pipelineFactory');
         const pipelineFactory = PipelineFactory.getInstance();
@@ -44,7 +45,7 @@ class TriggerFactory extends BaseFactory {
             .then((pipeline) => {
                 if (pipeline) {
                     // Get pipeline job names
-                    return pipeline.getJobs({ type: 'pipeline' })
+                    return pipeline.getJobs({ type: type || 'pipeline' })
                         .then(jobs => Promise.all(
                             jobs.map(j =>
                                 // Get dest triggers for each src job

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -44,7 +44,7 @@ class TriggerFactory extends BaseFactory {
             .then((pipeline) => {
                 if (pipeline) {
                     // Get pipeline job names
-                    return pipeline.getJobs()
+                    return pipeline.getJobs({ type: 'pipeline' })
                         .then(jobs => Promise.all(
                             jobs.map(j =>
                                 // Get dest triggers for each src job

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -29,6 +29,42 @@ class TriggerFactory extends BaseFactory {
     }
 
     /**
+     * Get all triggers related to a pipeline
+     * @param  {Object} config
+     * @param  {String} config.pipelineId   pipelineId
+     * @return {Object}                     Returns object with dest triggers split by src jobs
+     */
+    getTriggers({ pipelineId }) {
+        // eslint-disable-next-line global-require
+        const PipelineFactory = require('./pipelineFactory');
+        const pipelineFactory = PipelineFactory.getInstance();
+        const result = [];
+
+        return pipelineFactory.get(pipelineId)
+            .then((pipeline) => {
+                if (pipeline) {
+                    // Get pipeline job names
+                    return pipeline.jobs.then(jobs => Promise.all(
+                        jobs.map(j =>
+                            // Get dest triggers for each src job
+                            this.list({
+                                params: {
+                                    src: `~sd@${pipelineId}:${j.name}`
+                                }
+                            // Push jobName and dest triggers to result
+                            }).then((triggersArr) => {
+                                const triggers = triggersArr.map(t => t.dest);
+
+                                result.push({ jobName: j.name, triggers });
+                            })
+                        ))).then(() => result);
+                }
+
+                return result;
+            });
+    }
+
+    /**
      * Get an instance of the TriggerFactory
      * @method getInstance
      * @param  {Object}     config

--- a/test/lib/triggerFactory.test.js
+++ b/test/lib/triggerFactory.test.js
@@ -93,7 +93,7 @@ describe('Trigger Factory', () => {
                         { src: '~pr:/^.*$/', dest: 'pr-wild' }
                     ]
                 },
-                jobs: Promise.resolve(jobsMock)
+                getJobs: sinon.stub().resolves(jobsMock)
             }),
             scm: {
                 getCommitSha: sinon.stub().resolves('configpipelinesha')

--- a/test/lib/triggerFactory.test.js
+++ b/test/lib/triggerFactory.test.js
@@ -173,7 +173,7 @@ describe('Trigger Factory', () => {
             }];
         });
 
-        it('gets all Triggers given a pipelineId', () => {
+        it('gets all pipeline Triggers given a pipelineId', () => {
             datastore.scan.resolves(expected);
 
             return factory.getTriggers({
@@ -182,6 +182,29 @@ describe('Trigger Factory', () => {
                 model.forEach((m) => {
                     assert.instanceOf(m.triggers, Array);
                     assert.calledWith(pipelineMock.getJobs, { type: 'pipeline' });
+                });
+            });
+        });
+
+        it('gets all PR Triggers given a pipelineId and type', () => {
+            datastore.scan.resolves(expected);
+            pipelineMock.getJobs.withArgs({ type: 'pr' }).resolves([{
+                id: 1,
+                pipelineId,
+                name: 'PR-1:main',
+                permutations: [{
+                    requires: ['~commit', '~pr', '~sd@123:main', '~commit:branch', '~pr:branch']
+                }],
+                state: 'ENABLED'
+            }]);
+
+            return factory.getTriggers({
+                pipelineId,
+                type: 'pr'
+            }).then((model) => {
+                model.forEach((m) => {
+                    assert.instanceOf(m.triggers, Array);
+                    assert.calledWith(pipelineMock.getJobs, { type: 'pr' });
                 });
             });
         });

--- a/test/lib/triggerFactory.test.js
+++ b/test/lib/triggerFactory.test.js
@@ -13,10 +13,38 @@ describe('Trigger Factory', () => {
         src,
         dest
     };
+    const pipelineId = 8765;
+    const generatedId = 1234135;
     let TriggerFactory;
     let datastore;
     let factory;
     let Trigger;
+    let pipelineFactoryMock;
+    const jobsMock = [{
+        id: 1,
+        pipelineId,
+        name: 'main',
+        permutations: [{
+            requires: ['~commit', '~pr', '~sd@123:main', '~commit:branch', '~pr:branch']
+        }],
+        state: 'ENABLED'
+    }, {
+        id: 2,
+        pipelineId,
+        name: 'disabledjob',
+        permutations: [{
+            requires: ['main']
+        }],
+        state: 'DISABLED'
+    }, {
+        id: 4,
+        pipelineId,
+        name: 'publish',
+        permutations: [{
+            requires: ['~pr']
+        }],
+        state: 'ENABLED'
+    }];
 
     before(() => {
         mockery.enable({
@@ -31,6 +59,50 @@ describe('Trigger Factory', () => {
             get: sinon.stub(),
             scan: sinon.stub()
         };
+        pipelineFactoryMock = {
+            get: sinon.stub().resolves({
+                id: pipelineId,
+                scmUri: 'github.com:1234:branch',
+                scmContext: 'github:github.com',
+                token: Promise.resolve('foo'),
+                workflowGraph: {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'main' },
+                        { name: 'disabledJob' },
+                        { name: 'publish' },
+                        { name: '~sd@123:main' },
+                        { name: '~commit:branch' },
+                        { name: '~commit:/^.*$/' },
+                        { name: '~pr:branch' },
+                        { name: '~pr:/^.*$/' }
+                    ],
+                    edges: [
+                        { src: '~sd@123:main', dest: 'main' },
+                        { src: '~pr', dest: 'main' },
+                        { src: '~commit', dest: 'main' },
+                        { src: 'main', dest: 'disabledJob' },
+                        { src: '~pr', dest: 'publish' },
+                        { src: '~commit', dest: 'only-commit' },
+                        { src: '~commit:branch', dest: 'main' },
+                        { src: '~commit:branch', dest: 'commit-branch' },
+                        { src: '~commit:/^.*$/', dest: 'commit-wild' },
+                        { src: '~pr:branch', dest: 'main' },
+                        { src: '~pr:branch', dest: 'pr-branch' },
+                        { src: '~pr:/^.*$/', dest: 'pr-wild' }
+                    ]
+                },
+                jobs: Promise.resolve(jobsMock)
+            }),
+            scm: {
+                getCommitSha: sinon.stub().resolves('configpipelinesha')
+            }
+        };
+
+        mockery.registerMock('./pipelineFactory', {
+            getInstance: sinon.stub().returns(pipelineFactoryMock)
+        });
 
         // eslint-disable-next-line global-require
         Trigger = require('../../lib/trigger');
@@ -59,7 +131,6 @@ describe('Trigger Factory', () => {
     });
 
     describe('create', () => {
-        const generatedId = 1234135;
         let expected;
 
         beforeEach(() => {
@@ -81,6 +152,44 @@ describe('Trigger Factory', () => {
                 Object.keys(expected).forEach((key) => {
                     assert.strictEqual(model[key], expected[key]);
                 });
+            });
+        });
+    });
+
+    describe('getTriggers', () => {
+        let expected;
+
+        beforeEach(() => {
+            expected = [{
+                id: generatedId,
+                src,
+                dest
+            }, {
+                id: 1234567,
+                src,
+                dest: '~sd@12345:main'
+            }];
+        });
+
+        it('gets all Triggers given a pipelineId', () => {
+            datastore.scan.resolves(expected);
+
+            return factory.getTriggers({
+                pipelineId
+            }).then((model) => {
+                model.forEach((m) => {
+                    assert.instanceOf(m.triggers, Array);
+                });
+            });
+        });
+
+        it('returns empty array if pipeline does not exist', () => {
+            pipelineFactoryMock.get.resolves(null);
+
+            return factory.getTriggers({
+                pipelineId
+            }).then((model) => {
+                assert.instanceOf(model, Array);
             });
         });
     });


### PR DESCRIPTION
## Context
It would be nice if users could see what pipelines/jobs run after jobs in their pipeline are done.

## Objective
This PR adds a method `getTriggers` that returns an object with jobName and destination trigger data.

Example output:
```
[{
  jobName: 'main',
  triggers: ['~sd@12345:main']
}, {
  jobName: 'beta',
  triggers: ['~sd@12345:test', '~sd@223344:test']
}, {
  jobName: 'prod',
  triggers: ['~sd@556677:deploy']
}]
```

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1333