### PR TITLE
fix: sync PRs when chainPR was changed

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -425,12 +425,12 @@ class EventFactory extends BaseFactory {
             pr: {},
             prNum
         };
-        let beforeChainPR = '';
+        let prevChainPR = '';
 
         return pipelineFactory.get(pipelineId)
             // Sync pipeline to make sure workflowGraph is generated
             .then((p) => {
-                beforeChainPR = p.chainPR;
+                prevChainPR = p.chainPR;
                 // Sync pipeline with the parentEvent sha and create jobs based on that sha
                 if (parentEventId && !prRef) {
                     modelConfig.parentEventId = parentEventId;
@@ -459,7 +459,7 @@ class EventFactory extends BaseFactory {
                 return p.sync(null, chainPR);
             })
             .then((p) => {
-                if (beforeChainPR !== p.chainPR) {
+                if (prevChainPR !== p.chainPR) {
                     // when chainPR was changed, sync PRs.
                     return p.syncPRs();
                 }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -425,10 +425,12 @@ class EventFactory extends BaseFactory {
             pr: {},
             prNum
         };
+        let beforeChainPR = '';
 
         return pipelineFactory.get(pipelineId)
             // Sync pipeline to make sure workflowGraph is generated
             .then((p) => {
+                beforeChainPR = p.prChain;
                 // Sync pipeline with the parentEvent sha and create jobs based on that sha
                 if (parentEventId && !prRef) {
                     modelConfig.parentEventId = parentEventId;
@@ -455,6 +457,14 @@ class EventFactory extends BaseFactory {
                 }
 
                 return p.sync(null, chainPR);
+            })
+            .then((p) => {
+                if (beforeChainPR !== p.prChain) {
+                    // when chainPR was changed, sync PRs.
+                    return p.syncPRs();
+                }
+
+                return p;
             })
             .then((p) => {
                 if (prInfo && prInfo.url) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -263,6 +263,30 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * archive closed PR jobs
+     * @param {Array}   existingJobs List pipeline's existing jobs
+     * @param {Array}   openedPRs    List of opened PRs coming from SCM
+     * @param {Promise}
+     */
+    _archivePRs(existingJobs, openedPRs) {
+        const existingPRs = existingJobs.filter(j => j.isPR());
+        const openedPRsNames = openedPRs.map(j => j.name);
+        const toArchiveList = [];
+
+        existingPRs.forEach((job) => {
+            // getting PR and number e.g. PR-1
+            const prName = this._getPartialJobName(job.name, 'pr');
+
+            // if PR is closed, add it to archive list
+            if (!openedPRsNames.includes(prName) && !job.archived) {
+                toArchiveList.push(job);
+            }
+        });
+
+        return this._updateJobArchive(toArchiveList, true);
+    }
+
+    /**
      * Get a list of PR jobs to create or update
      * @method _checkPRState
      * @param  {Array}    existingJobs      List pipeline's existing jobs
@@ -424,13 +448,17 @@ class PipelineModel extends BaseModel {
                     token
                 })
             ]).then(([existingJobs, openedPRs]) => {
-                const jobList = this._checkPRState(existingJobs, openedPRs);
+                const synced = [];
 
-                return Promise.all([
-                    this._createPRJob(existingJobs, jobList.toCreate),
-                    this._updateJobArchive(jobList.toArchive, true),
-                    this._updateJobArchive(jobList.toUnarchive, false)
-                ]);
+                openedPRs.forEach((openedPR) => {
+                    const pathData = openedPR.name.split('-');
+                    const prNum = pathData[pathData.length - 1];
+
+                    synced.push(this.syncPR(prNum));
+                });
+
+                return Promise.all(synced).then(() => this._archivePRs(existingJobs, openedPRs));
+                // return Promise.all([this._archivePRs(existingJobs, openedPRs), synced]);
             }));
     }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -268,7 +268,7 @@ class PipelineModel extends BaseModel {
      * @param {Array}   openedPRs    List of opened PRs coming from SCM
      * @param {Promise}
      */
-    _archivePRs(existingJobs, openedPRs) {
+    _archiveClosePRs(existingJobs, openedPRs) {
         const existingPRs = existingJobs.filter(j => j.isPR());
         const openedPRsNames = openedPRs.map(j => j.name);
         const toArchiveList = [];
@@ -451,15 +451,14 @@ class PipelineModel extends BaseModel {
                 const synced = [];
 
                 openedPRs.forEach((openedPR) => {
-                    const pathData = openedPR.name.split('-');
-                    const prNum = pathData[pathData.length - 1];
+                    const prNum = openedPR.name.split('-')[1];
 
                     synced.push(this.syncPR(prNum));
                 });
 
-                return Promise.all(synced).then(() => this._archivePRs(existingJobs, openedPRs));
-                // return Promise.all([this._archivePRs(existingJobs, openedPRs), synced]);
-            }));
+                return Promise.all(synced)
+                    .then(() => this._archiveClosePRs(existingJobs, openedPRs));
+            })).then(() => this);
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -287,53 +287,6 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Get a list of PR jobs to create or update
-     * @method _checkPRState
-     * @param  {Array}    existingJobs      List pipeline's existing jobs
-     * @param  {Array}    openedPRs         List of opened PRs coming from SCM
-     * @return {Promise}                    Resolves to the list of jobs to archive, unarchive and create
-     * Note: toArchive and toUnarchive is an array of job objects; toCreate is an array of objects with name and ref.
-     */
-    _checkPRState(existingJobs, openedPRs) {
-        const jobList = {
-            toCreate: [],
-            toArchive: [],
-            toUnarchive: []
-        };
-        const existingPRs = existingJobs.filter(j => j.isPR()); // list of PRs according to SD
-        const openedPRsNames = openedPRs.map(j => j.name);
-        const openedPRsRef = openedPRs.map(j => j.ref);
-
-        existingPRs.forEach((job) => {
-            // getting PR and number e.g. PR-1
-            const prName = this._getPartialJobName(job.name, 'pr');
-
-            // if PR is closed, add it to archive list
-            if (!openedPRsNames.includes(prName) && !job.archived) {
-                jobList.toArchive.push(job);
-            }
-        });
-
-        openedPRsNames.forEach((name, i) => {
-            const matchedPRs = existingPRs.filter(job => job.name.startsWith(name));
-
-            // if opened PR was previously archived and prChain flag is false, unarchive it
-            matchedPRs.forEach((job) => {
-                if (job.archived && this.prChain === false) {
-                    jobList.toUnarchive.push(job);
-                }
-            });
-
-            // if opened PR is not in the list of existingPRs, create it
-            if (matchedPRs.length === 0) {
-                jobList.toCreate.push({ name, ref: openedPRsRef[i] });
-            }
-        });
-
-        return jobList;
-    }
-
-    /**
       * Go through the job list to archive/unarchive it and update job config if parsedConfig passed in
       * @method _updateJobArchive
       * @param  {Array}        jobList              List of job objects
@@ -356,63 +309,6 @@ class PipelineModel extends BaseModel {
         });
 
         return Promise.all(jobsToUpdate);
-    }
-
-    /**
-     * Go through the list of pr names and create pr jobs
-     * @method _createPRJob
-     * @param  {Array}      prList       Array of PR names and refs
-     * @return {Promise}
-     */
-    _createPRJob(allJobs, prList) {
-        // Lazy load factory dependency to prevent circular dependency issues
-        // https://nodejs.org/api/modules.html#modules_cycles
-        /* eslint-disable global-require */
-        const JobFactory = require('./jobFactory');
-        /* eslint-enable global-require */
-
-        const factory = JobFactory.getInstance();
-
-        const jobsToCreate = prList.map(pr =>
-            this.getConfiguration({
-                ref: pr.ref,
-                isPR: true
-            }).then((config) => {
-                const prNum = pr.name.split('-')[1];
-                const prJobNames = workflowParser.getNextJobs(config.workflowGraph, {
-                    trigger: '~pr',
-                    prNum
-                });
-
-                // filter to keep only the pipeline jobs that include in the jobsToCreate list
-                const prFromPipelineJobs = allJobs.filter(j =>
-                    !j.name.startsWith('PR-') && prJobNames.includes(`PR-${prNum}:${j.name}`));
-
-                // create a map for PR Parent Jobs like: {main: 1, publish: 2}
-                const prParentJobIdMap = {};
-
-                prFromPipelineJobs.forEach((j) => {
-                    prParentJobIdMap[j.name] = j.id;
-                });
-
-                return Promise.all[prJobNames.map((name) => {
-                    const jobName = this._getPartialJobName(name, 'job');
-
-                    const jobConfig = {
-                        pipelineId: this.id,
-                        name,
-                        permutations: config.jobs[jobName]
-                    };
-
-                    if (prParentJobIdMap[jobName]) {
-                        jobConfig.prParentJobId = prParentJobIdMap[jobName];
-                    }
-
-                    return factory.create(jobConfig);
-                })];
-            }));
-
-        return Promise.all(jobsToCreate);
     }
 
     /**

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1032,6 +1032,7 @@ describe('Pipeline Model', () => {
             datastore.update.resolves(null);
             scmMock.getFile.resolves('superyamlcontent');
             parserMock.withArgs('superyamlcontent', templateFactoryMock).resolves(PARSED_YAML);
+            scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge' });
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
             pipeline.admins = { batman: true, robin: true };
@@ -1051,7 +1052,6 @@ describe('Pipeline Model', () => {
 
             return pipeline.syncPRs()
                 .then(() => {
-                    assert.calledOnce(prJob.update);
                     assert.equal(prJob.archived, true);
                 });
         });
@@ -1069,10 +1069,11 @@ describe('Pipeline Model', () => {
 
             return pipeline.syncPRs()
                 .then(() => {
+                    // assert.calledOnce(jobFactoryMock.create);
                     assert.calledWith(jobFactoryMock.create, {
+                        permutations: PARSED_YAML.jobs.main,
                         pipelineId: testId,
                         name: 'PR-2:main',
-                        permutations: PARSED_YAML.jobs.main,
                         prParentJobId: 99998
                     });
                 });
@@ -1095,7 +1096,6 @@ describe('Pipeline Model', () => {
 
             return pipeline.syncPRs()
                 .then(() => {
-                    assert.notCalled(prJob.update);
                     assert.notCalled(jobFactoryMock.create);
                 });
         });


### PR DESCRIPTION
## Context
When change chainPR of pipeline, UI does not change automatically.
This PR sync PRs and change UI automatically when chainPR was changed.

## Objective
- syncPRs function call syncPR functions. 
   To sync chainPR's status, we need to get pipeline configuration to check next job of workflowParser. Now syncPRs function does not see pipeline configuration. If syncPRs get pipeline configuration, there are almost no difference to call syncPR function.

- syncPRs when chainPR was changed
  Maybe it took many time to sync PRs, because it get pipeline configuration and check next job. Thus I call syncPRs function only chainPR was changed.

