### PR TITLE
fix: add commit info to default build meta

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -108,12 +108,13 @@ function getJobsFromPR(config) {
 /**
  * Starts the build if the changed file is part of the sourcePaths, or if there is no sourcePaths
  * @method startBuild
- * @param  {Object}   config                configuration object
- * @param  {Object}   config.buildConfig    Build Config to create the build with
- * @param  {Array}    config.changedFiles   List of files that were changed
- * @param  {Array}    config.sourcePaths    List of soure paths
- * @param  {Boolean}  [config.webhooks]     If the create came from a webhook (pr or push) or not
- * @param  {Boolean}  [config.isPR]         Is it PR?
+ * @param  {Object}   config                    configuration object
+ * @param  {Object}   config.buildConfig        Build Config to create the build with
+ * @param  {Array}    config.changedFiles       List of files that were changed
+ * @param  {Array}    config.sourcePaths        List of soure paths
+ * @param  {Boolean}  [config.webhooks]         If the create came from a webhook (pr or push) or not
+ * @param  {Boolean}  [config.isPR]             Is it PR?
+ * @param  {Object}   [config.decoratedCommit]  Decorated commit object
  * @return {Promise}
  */
 function startBuild(config) {
@@ -121,7 +122,7 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR } = config;
+    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit } = config;
     let hasChangeInSourcePaths = true;
 
     buildConfig.environment = {};
@@ -151,6 +152,13 @@ function startBuild(config) {
             }));
     }
 
+    buildConfig.meta = Object.assign({
+        commit: {
+            ...decoratedCommit,
+            changedFiles: changedFiles ? changedFiles.join(',') : ''
+        }
+    }, buildConfig.meta);
+
     return hasChangeInSourcePaths ? buildFactory.create(buildConfig) : null;
 }
 
@@ -176,9 +184,11 @@ function startBuild(config) {
  * @param  {Array}    [config.changedFiles]                  Array of files that were changed
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]                          Is it PR?
+ * @param  {Object}   [config.decoratedCommit]               Decorated commit object
  */
 function createBuilds(config) {
     const {
+        decoratedCommit,
         eventConfig,
         eventId,
         pipeline,
@@ -239,6 +249,7 @@ function createBuilds(config) {
                 buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;
 
                 return startBuild({
+                    decoratedCommit,
                     buildConfig,
                     changedFiles,
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
@@ -425,6 +436,7 @@ class EventFactory extends BaseFactory {
             pr: {},
             prNum
         };
+        let decoratedCommit;
 
         return pipelineFactory.get(pipelineId)
             // Sync pipeline to make sure workflowGraph is generated
@@ -500,6 +512,7 @@ class EventFactory extends BaseFactory {
                     });
                 })
                 .then((commit) => {
+                    decoratedCommit = commit;
                     modelConfig.commit = commit;
                     modelConfig.createTime = (new Date()).toISOString();
 
@@ -532,6 +545,7 @@ class EventFactory extends BaseFactory {
 
                         // Start builds
                         return createBuilds({
+                            decoratedCommit,
                             eventConfig: config,
                             eventId: event.id,
                             pipeline: p,

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -121,6 +121,12 @@ describe('Event Factory', () => {
                 url: 'https://internal-ghe.mycompany.com/imbatman',
                 username: 'imbatman'
             },
+            committer: {
+                avatar: 'https://avatars.githubusercontent.com/u/1234567?v=3',
+                name: 'Batman',
+                url: 'https://internal-ghe.mycompany.com/imbatman',
+                username: 'imbatman'
+            },
             message: 'some commit message that is here',
             url: 'https://link.to/commitDiff'
         };
@@ -388,7 +394,13 @@ describe('Event Factory', () => {
                         eventId: model.id,
                         jobId: 5,
                         prRef: 'branch',
-                        prTitle: 'Update the README with new information'
+                        prTitle: 'Update the README with new information',
+                        meta: {
+                            commit: {
+                                ...commit,
+                                changedFiles: ''
+                            }
+                        }
                     }));
                     assert.calledOnce(syncedPipelineMock.syncPR);
                     assert.calledWith(syncedPipelineMock.syncPR.firstCall, 1);
@@ -1110,6 +1122,14 @@ describe('Event Factory', () => {
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledOnce(buildFactoryMock.create);
+                assert.calledWith(buildFactoryMock.create.firstCall, sinon.match({
+                    meta: {
+                        commit: {
+                            ...commit,
+                            changedFiles: 'README.md,root/src/test/file'
+                        }
+                    }
+                }));
                 assert.deepEqual(
                     buildFactoryMock.create.args[0][0].environment,
                     {}


### PR DESCRIPTION
add commit info to default build meta when we create a new event. Downstream builds will inherit this meta. 

Blocked by: https://github.com/screwdriver-cd/scm-github/pull/128
Related to: https://github.com/screwdriver-cd/screwdriver/issues/1437