### PR TITLE
feat(1455): Add rootDir to sourcePaths (4)

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -10,7 +10,6 @@ const {
     RELEASE_TRIGGER,
     TAG_TRIGGER
 } = require('screwdriver-data-schema').config.regex;
-const path = require('path');
 const workflowParser = require('screwdriver-workflow-parser');
 const winston = require('winston');
 
@@ -146,16 +145,11 @@ function startBuild(config) {
             throw new Error('Your SCM does not support Source Paths');
         }
 
-        let paths = sourcePaths || [];
+        const paths = sourcePaths || [];
 
         // Add rootDir as a sourcePath if no sourcePaths
-        // Or prefix all sourcePaths with rootDir
-        if (rootDir) {
-            if (paths.length === 0) {
-                paths.push(`${rootDir}/`);
-            } else {
-                paths = paths.map(p => path.join(rootDir, p));
-            }
+        if (rootDir && paths.length === 0) {
+            paths.push(`${rootDir}/`);
         }
 
         hasChangeInSourcePaths = changedFiles.some(file =>
@@ -287,7 +281,7 @@ function createBuilds(config) {
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks,
                     isPR,
-                    rootDir
+                    rootDir,
                     clusterEnv
                 });
             })).then((buildsCreated) => {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -10,6 +10,7 @@ const {
     RELEASE_TRIGGER,
     TAG_TRIGGER
 } = require('screwdriver-data-schema').config.regex;
+const path = require('path');
 const workflowParser = require('screwdriver-workflow-parser');
 const winston = require('winston');
 
@@ -115,6 +116,7 @@ function getJobsFromPR(config) {
  * @param  {Boolean}  [config.webhooks]         If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]             Is it PR?
  * @param  {Object}   [config.decoratedCommit]  Decorated commit object
+ * @param  {String}   [config.rootDir]          Root directory
  * @return {Promise}
  */
 function startBuild(config) {
@@ -122,28 +124,51 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit } = config;
+    const {
+        buildConfig,
+        changedFiles,
+        sourcePaths,
+        webhooks,
+        isPR,
+        decoratedCommit,
+        rootDir
+    } = config;
     let hasChangeInSourcePaths = true;
 
     buildConfig.environment = {};
 
-    // Only check if sourcePaths exists
-    if ((webhooks || isPR) && sourcePaths) {
+    // Only check if sourcePaths or rootDir is set
+    // and webhooks or is a PR
+    if ((webhooks || isPR) && (sourcePaths || rootDir)) {
         if (!changedFiles) {
             throw new Error('Your SCM does not support Source Paths');
         }
+
+        let paths = sourcePaths || [];
+
+        // Add rootDir as a sourcePath if no sourcePaths
+        // Or prefix all sourcePaths with rootDir
+        if (rootDir) {
+            if (paths.length === 0) {
+                paths.push(`${rootDir}/`);
+            } else {
+                paths = paths.map(p => path.join(rootDir, p));
+            }
+        }
+
         hasChangeInSourcePaths = changedFiles.some(file =>
-            sourcePaths.some((source) => {
+            paths.some((source) => {
                 let isMatch = false;
 
+                // source path is a file
                 if (source.slice(-1) !== '/') {
-                    // source path is a file
                     isMatch = file === source;
+                // source path is a directory
                 } else {
-                    // source path is directory
                     isMatch = file.startsWith(source);
                 }
 
+                // Set env var
                 if (isMatch) {
                     buildConfig.environment.SD_SOURCE_PATH = source;
                 }
@@ -198,6 +223,7 @@ function createBuilds(config) {
         isPR
     } = config;
     const startFrom = eventConfig.startFrom;
+    let rootDir = '';
 
     if (!startFrom) {
         return null;
@@ -205,8 +231,10 @@ function createBuilds(config) {
 
     return Promise.all([
         pipeline.branch,
-        pipeline.jobs
-    ]).then(([branch, jobs]) => {
+        pipeline.jobs,
+        pipeline.rootDir
+    ]).then(([branch, jobs, root]) => {
+        rootDir = root;
         // When startFrom is ~commit, ~release, ~tag, ~sd@
         const jobsFromTrigger = getJobsFromTrigger({
             jobs,
@@ -254,7 +282,8 @@ function createBuilds(config) {
                     changedFiles,
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks,
-                    isPR
+                    isPR,
+                    rootDir
                 });
             })).then((buildsCreated) => {
                 const builds = buildsCreated.filter(b => b !== null);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -140,6 +140,33 @@ const sumAggregatedEventMetrics = async (events) => {
 };
 
 /**
+ * Parse scmUri and return desired field
+ * @param  {String} scmUri   Scm uri (e.g.: github.com:12345:master)
+ * @param  {String} field    Desired field (host, id, branch, or rootDir)
+ * @return {String}          Desired field
+ */
+function parseScmUri({ scmUri, field }) {
+    const fieldMap = {
+        host: 0,
+        id: 1,
+        branch: 2,
+        rootDir: 3
+    };
+
+    if (!scmUri) {
+        return '';
+    }
+    const uriInfos = scmUri.split(':');
+    const position = fieldMap[field];
+
+    if (uriInfos.length < position + 1) {
+        return '';
+    }
+
+    return uriInfos[position];
+}
+
+/**
  * Sync external triggers
  * Remove the trigger if the job is no longer in yaml, or if the src is no longer in 'requires'
  * Add the trigger src is in 'requires' and was not in the database yet
@@ -960,16 +987,22 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     get branch() {
-        if (!this.scmUri || this.scmUri === '') {
-            return Promise.resolve('');
-        }
-        const uriInfos = this.scmUri.split(':');
+        return Promise.resolve(parseScmUri({
+            scmUri: this.scmUri,
+            field: 'branch'
+        }));
+    }
 
-        if (uriInfos.length < 3) {
-            return Promise.resolve('');
-        }
-
-        return Promise.resolve(uriInfos[2]);
+    /**
+     * Get the rootDir of the pipeline
+     * @property rootDir
+     * @return {Promise}
+     */
+    get rootDir() {
+        return Promise.resolve(parseScmUri({
+            scmUri: this.scmUri,
+            field: 'rootDir'
+        }));
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -159,7 +159,7 @@ function parseScmUri({ scmUri, field }) {
     const uriInfos = scmUri.split(':');
     const position = fieldMap[field];
 
-    if (uriInfos.length < position + 1) {
+    if (position >= uriInfos.length) {
         return '';
     }
 

--- a/package.json
+++ b/package.json
@@ -42,20 +42,20 @@
     "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
     "rewire": "^4.0.1",
-    "sinon": "^7.3.1"
+    "sinon": "^7.3.2"
   },
   "dependencies": {
     "async": "^2.6.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
-    "dayjs": "^1.8.12",
+    "dayjs": "^1.8.13",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.1",
-    "screwdriver-data-schema": "^18.45.1",
-    "screwdriver-workflow-parser": "^1.8.3",
+    "screwdriver-data-schema": "^18.45.5",
+    "screwdriver-workflow-parser": "^1.8.4",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1110,7 +1110,7 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock),
+                getJobs: sinon.stub().resolves(jobsMock),
                 branch: Promise.resolve('branch'),
                 rootDir: Promise.resolve('root/src/test')
             });
@@ -1149,7 +1149,7 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock),
+                getJobs: sinon.stub().resolves(jobsMock),
                 branch: Promise.resolve('branch'),
                 rootDir: Promise.resolve('root/src/test')
             });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1190,6 +1190,29 @@ describe('Pipeline Model', () => {
         });
     });
 
+    describe('get rootDir', () => {
+        it('has an rootDir getter', () => {
+            pipeline.scmUri = 'github.com:1234:branch:src/app/component';
+            pipeline.rootDir.then((rootDir) => {
+                assert.equal(rootDir, 'src/app/component');
+            });
+        });
+
+        it('return blank if scmUri is blank', () => {
+            pipeline.scmUri = '';
+            pipeline.rootDir.then((rootDir) => {
+                assert.equal(rootDir, '');
+            });
+        });
+
+        it('return blank if scmUri is invalid', () => {
+            pipeline.scmUri = 'github.com:1234:branch';
+            pipeline.rootDir.then((rootDir) => {
+                assert.equal(rootDir, '');
+            });
+        });
+    });
+
     describe('get jobs', () => {
         it('has a jobs getter', () => {
             const listConfig = {


### PR DESCRIPTION
## Context
Would be nice if users could put screwdriver.yaml not at root.

## Objective
This PR adjusts startBuild params so that if rootDir is set:
- when no sourcePaths: start build if changedFile matches `rootDir`
- when sourcePaths: start build if changedFile matches `<rootDir>/<sourcePath>`

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1455