### PR TITLE
fix: improve DB query efficiency

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -205,7 +205,7 @@ function createBuilds(config) {
 
     return Promise.all([
         pipeline.branch,
-        pipeline.jobs
+        pipeline.getJobs()
     ]).then(([branch, jobs]) => {
         // When startFrom is ~commit, ~release, ~tag, ~sd@
         const jobsFromTrigger = getJobsFromTrigger({

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -76,14 +76,21 @@ class TemplateFactory extends BaseFactory {
         const parsedTemplate = {
             name: nameWithNamespace
         };
+        const paginate = {
+            page: 1,
+            count: 1
+        };
 
         // If fullTemplateName has no '/', don't need to bother to grep for namespace
         if (fullTemplateName.indexOf('/') <= -1) {
             // Check if template with default namespace and name exist, default to using that template
-            return super.list({ params: {
-                namespace: 'default',
-                name: parsedTemplate.name
-            } }).then((namespaceExists) => {
+            return super.list({
+                params: {
+                    namespace: 'default',
+                    name: parsedTemplate.name
+                },
+                paginate
+            }).then((namespaceExists) => {
                 if (namespaceExists.length > 0) {
                     parsedTemplate.namespace = 'default';
                 }
@@ -96,10 +103,13 @@ class TemplateFactory extends BaseFactory {
             = TEMPLATE_NAME_REGEX_WITH_NAMESPACE.exec(fullTemplateName);
 
         // Check if template with namespace and name exist, default to using that template
-        return super.list({ params: {
-            namespace,
-            name
-        } }).then((namespaceExists) => {
+        return super.list({
+            params: {
+                namespace,
+                name
+            },
+            paginate
+        }).then((namespaceExists) => {
             if (namespaceExists.length > 0) {
                 parsedTemplate.namespace = namespace;
                 parsedTemplate.name = name;
@@ -247,14 +257,19 @@ class TemplateFactory extends BaseFactory {
                 });
         }
 
+        // If no version provided, return the most recently published template
+        if (!versionOrTag) {
+            const listConfig = {
+                params: { name: templateName },
+                paginate: { page: 1, count: 1 }
+            };
+
+            return this.list(listConfig).then(templates => templates[0] || null);
+        }
+
         // Get all templates with the same name
         return this.list({ params: { name: templateName } })
             .then((templates) => {
-                // If no version provided, return the most recently published template
-                if (!versionOrTag) {
-                    return templates[0];
-                }
-
                 // Get templates that have versions beginning with the version given
                 const filtered = templates.filter(template =>
                     template.version.startsWith(versionOrTag));

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -223,7 +223,7 @@ describe('Event Factory', () => {
                 },
                 getConfiguration: sinon.stub().resolves(PARSED_YAML),
                 update: sinon.stub().resolves(syncedPipelineMock),
-                jobs: Promise.resolve([]),
+                getJobs: sinon.stub().resolves([]),
                 branch: Promise.resolve('branch')
             };
 
@@ -319,7 +319,7 @@ describe('Event Factory', () => {
                     state: 'ENABLED'
                 }];
 
-                syncedPipelineMock.jobs = Promise.resolve(jobsMock);
+                syncedPipelineMock.getJobs = sinon.stub().resolves(jobsMock);
                 buildFactoryMock.create.resolves('a build object');
             });
 
@@ -376,8 +376,9 @@ describe('Event Factory', () => {
                     state: 'DISABLED'
                 }];
 
-                afterSyncedPRPipelineMock.jobs = Promise.resolve(jobsMock);
+                afterSyncedPRPipelineMock.getJobs.resolves(jobsMock);
                 afterSyncedPRPipelineMock.update = sinon.stub().resolves(afterSyncedPRPipelineMock);
+                syncedPipelineMock.update = sinon.stub().resolves(syncedPipelineMock);
 
                 config.startFrom = '~pr';
                 config.prRef = 'branch';
@@ -425,6 +426,7 @@ describe('Event Factory', () => {
             it('should create commit builds', () => {
                 config.startFrom = '~commit';
                 config.webhooks = true;
+                syncedPipelineMock.id = 123566;
 
                 return eventFactory.create(config).then((model) => {
                     assert.instanceOf(model, Event);
@@ -582,9 +584,9 @@ describe('Event Factory', () => {
                 }];
 
                 syncedPipelineMock.workflowGraph = releaseWorkflow;
-                syncedPipelineMock.jobs = Promise.resolve(jobsMock);
+                syncedPipelineMock.getJobs = sinon.stub().resolves(jobsMock);
                 syncedPipelineMock.update = sinon.stub().resolves({
-                    jobs: Promise.resolve(jobsMock),
+                    getJobs: sinon.stub().resolves(jobsMock),
                     branch: Promise.resolve('branch')
                 });
                 config.startFrom = '~release';
@@ -627,9 +629,9 @@ describe('Event Factory', () => {
                 }];
 
                 syncedPipelineMock.workflowGraph = tagWorkflow;
-                syncedPipelineMock.jobs = Promise.resolve(jobsMock);
+                syncedPipelineMock.getJobs = sinon.stub().resolves(jobsMock);
                 syncedPipelineMock.update = sinon.stub().resolves({
-                    jobs: Promise.resolve(jobsMock),
+                    getJobs: sinon.stub().resolves(jobsMock),
                     branch: Promise.resolve('branch')
                 });
                 config.startFrom = '~tag';
@@ -879,7 +881,7 @@ describe('Event Factory', () => {
                 config.prTitle = 'Update the README with new information';
                 config.webhooks = true;
 
-                afterSyncedPRPipelineMock.jobs = Promise.resolve(jobsMock);
+                afterSyncedPRPipelineMock.getJobs = sinon.stub().resolves(jobsMock);
                 afterSyncedPRPipelineMock.chainPR = true;
                 afterSyncedPRPipelineMock.update = sinon.stub().resolves(afterSyncedPRPipelineMock);
                 // This function is called in updateWorkflowGraph() which is tested in another unit test.
@@ -1055,7 +1057,7 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock),
+                getJobs: sinon.stub().resolves(jobsMock),
                 branch: Promise.resolve('branch')
             });
 
@@ -1083,7 +1085,7 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock),
+                getJobs: sinon.stub().resolves(jobsMock),
                 branch: Promise.resolve('branch')
             });
 
@@ -1110,7 +1112,7 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             syncedPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock),
+                getJobs: sinon.stub().resolves(jobsMock),
                 branch: Promise.resolve('branch')
             });
 
@@ -1158,7 +1160,7 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock),
+                getJobs: sinon.stub().resolves(jobsMock),
                 branch: Promise.resolve('branch')
             });
 
@@ -1195,7 +1197,7 @@ describe('Event Factory', () => {
                 state: 'ENABLED'
             }];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
-                jobs: Promise.resolve(jobsMock),
+                getJobs: sinon.stub().resolves(jobsMock),
                 branch: Promise.resolve('branch')
             });
 


### PR DESCRIPTION
- in event create, call `pipeline.getJobs()` instead of `pipeline.jobs` to get only unarchived jobs.
- in template factory, only fetch the latest template instead of fetching them all and pick the first one when user has no tag and version in template config. 

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1603