### PR TITLE
fix: inject cluster environment into builds

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -115,6 +115,7 @@ function getJobsFromPR(config) {
  * @param  {Boolean}  [config.webhooks]         If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]             Is it PR?
  * @param  {Object}   [config.decoratedCommit]  Decorated commit object
+ * @param  {Object}   [config.clusterEnv]       Environment variables set by cluster
  * @return {Promise}
  */
 function startBuild(config) {
@@ -122,10 +123,11 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit } = config;
+    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit, clusterEnv }
+        = config;
     let hasChangeInSourcePaths = true;
 
-    buildConfig.environment = {};
+    buildConfig.environment = clusterEnv || {};
 
     // Only check if sourcePaths exists
     if ((webhooks || isPR) && sourcePaths) {
@@ -185,6 +187,7 @@ function startBuild(config) {
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]                          Is it PR?
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
+ * @param  {Object}   [config.clusterEnv]                    Environment variables set by cluster
  */
 function createBuilds(config) {
     const {
@@ -195,7 +198,8 @@ function createBuilds(config) {
         pipelineConfig,
         changedFiles,
         webhooks,
-        isPR
+        isPR,
+        clusterEnv
     } = config;
     const startFrom = eventConfig.startFrom;
 
@@ -254,7 +258,8 @@ function createBuilds(config) {
                     changedFiles,
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks,
-                    isPR
+                    isPR,
+                    clusterEnv
                 });
             })).then((buildsCreated) => {
                 const builds = buildsCreated.filter(b => b !== null);
@@ -411,6 +416,7 @@ class EventFactory extends BaseFactory {
      * @param  {Object}  [config.prInfo]            PR info
      * @param  {String}  [config.skipMessage]       Message to skip starting builds
      * @param  {Boolean} [config.chainPR]           Chain PR flag
+     * @param  {Object}  [config.clusterEnv]        Environment variables set by cluster
      * @return {Promise}
      */
     create(config) {
@@ -421,7 +427,7 @@ class EventFactory extends BaseFactory {
         const pipelineFactory = PipelineFactory.getInstance();
         const { pipelineId, configPipelineSha, username, scmContext,
             parentEventId, sha, startFrom, changedFiles, webhooks,
-            prInfo, prTitle, prRef, prNum, skipMessage, chainPR } = config;
+            prInfo, prTitle, prRef, prNum, skipMessage, chainPR, clusterEnv } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
         const modelConfig = {
@@ -552,7 +558,8 @@ class EventFactory extends BaseFactory {
                             pipelineConfig: modelConfig,
                             isPR: !!prInfo,
                             changedFiles,
-                            webhooks
+                            webhooks,
+                            clusterEnv
                         });
                     }).then((builds) => {
                         event.builds = builds;

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -12,7 +12,6 @@ const {
 } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const winston = require('winston');
-const clusterEnv = Symbol('clusterEnv');
 
 let instance;
 
@@ -116,6 +115,7 @@ function getJobsFromPR(config) {
  * @param  {Boolean}  [config.webhooks]         If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]             Is it PR?
  * @param  {Object}   [config.decoratedCommit]  Decorated commit object
+ * @param  {Object}   [config.clusterEnv]       Default cluster environment variables
  * @return {Promise}
  */
 function startBuild(config) {
@@ -123,11 +123,11 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit }
+    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit, clusterEnv }
         = config;
     let hasChangeInSourcePaths = true;
 
-    buildConfig.environment = this[clusterEnv];
+    buildConfig.environment = clusterEnv || {};
 
     // Only check if sourcePaths exists
     if ((webhooks || isPR) && sourcePaths) {
@@ -187,6 +187,7 @@ function startBuild(config) {
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]                          Is it PR?
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
+ * @param  {Object}   [config.clusterEnv]                    Default cluster environment variables
  */
 function createBuilds(config) {
     const {
@@ -197,7 +198,8 @@ function createBuilds(config) {
         pipelineConfig,
         changedFiles,
         webhooks,
-        isPR
+        isPR,
+        clusterEnv
     } = config;
     const startFrom = eventConfig.startFrom;
 
@@ -250,13 +252,14 @@ function createBuilds(config) {
 
                 buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;
 
-                return startBuild.call(this, {
+                return startBuild({
                     decoratedCommit,
                     buildConfig,
                     changedFiles,
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks,
-                    isPR
+                    isPR,
+                    clusterEnv
                 });
             })).then((buildsCreated) => {
                 const builds = buildsCreated.filter(b => b !== null);
@@ -355,7 +358,7 @@ class EventFactory extends BaseFactory {
      */
     constructor(config) {
         super('event', config);
-        this[clusterEnv] = config.clusterEnv || {};
+        this.clusterEnv = config.clusterEnv || {};
     }
 
     /**
@@ -548,7 +551,7 @@ class EventFactory extends BaseFactory {
                         }
 
                         // Start builds
-                        return createBuilds.call(this, {
+                        return createBuilds({
                             decoratedCommit,
                             eventConfig: config,
                             eventId: event.id,
@@ -556,7 +559,8 @@ class EventFactory extends BaseFactory {
                             pipelineConfig: modelConfig,
                             isPR: !!prInfo,
                             changedFiles,
-                            webhooks
+                            webhooks,
+                            clusterEnv: this.clusterEnv
                         });
                     }).then((builds) => {
                         event.builds = builds;

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -12,6 +12,7 @@ const {
 } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const winston = require('winston');
+const clusterEnv = Symbol('clusterEnv');
 
 let instance;
 
@@ -115,7 +116,6 @@ function getJobsFromPR(config) {
  * @param  {Boolean}  [config.webhooks]         If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]             Is it PR?
  * @param  {Object}   [config.decoratedCommit]  Decorated commit object
- * @param  {Object}   [config.clusterEnv]       Environment variables set by cluster
  * @return {Promise}
  */
 function startBuild(config) {
@@ -123,11 +123,11 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit, clusterEnv }
+    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit }
         = config;
     let hasChangeInSourcePaths = true;
 
-    buildConfig.environment = clusterEnv || {};
+    buildConfig.environment = this[clusterEnv];
 
     // Only check if sourcePaths exists
     if ((webhooks || isPR) && sourcePaths) {
@@ -187,7 +187,6 @@ function startBuild(config) {
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]                          Is it PR?
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
- * @param  {Object}   [config.clusterEnv]                    Environment variables set by cluster
  */
 function createBuilds(config) {
     const {
@@ -198,8 +197,7 @@ function createBuilds(config) {
         pipelineConfig,
         changedFiles,
         webhooks,
-        isPR,
-        clusterEnv
+        isPR
     } = config;
     const startFrom = eventConfig.startFrom;
 
@@ -252,14 +250,13 @@ function createBuilds(config) {
 
                 buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;
 
-                return startBuild({
+                return startBuild.call(this, {
                     decoratedCommit,
                     buildConfig,
                     changedFiles,
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks,
-                    isPR,
-                    clusterEnv
+                    isPR
                 });
             })).then((buildsCreated) => {
                 const builds = buildsCreated.filter(b => b !== null);
@@ -354,9 +351,11 @@ class EventFactory extends BaseFactory {
      * @method constructor
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {Object}    config.clusterEnv    Default cluster environment variables
      */
     constructor(config) {
         super('event', config);
+        this[clusterEnv] = config.clusterEnv || {};
     }
 
     /**
@@ -416,7 +415,6 @@ class EventFactory extends BaseFactory {
      * @param  {Object}  [config.prInfo]            PR info
      * @param  {String}  [config.skipMessage]       Message to skip starting builds
      * @param  {Boolean} [config.chainPR]           Chain PR flag
-     * @param  {Object}  [config.clusterEnv]        Environment variables set by cluster
      * @return {Promise}
      */
     create(config) {
@@ -427,7 +425,7 @@ class EventFactory extends BaseFactory {
         const pipelineFactory = PipelineFactory.getInstance();
         const { pipelineId, configPipelineSha, username, scmContext,
             parentEventId, sha, startFrom, changedFiles, webhooks,
-            prInfo, prTitle, prRef, prNum, skipMessage, chainPR, clusterEnv } = config;
+            prInfo, prTitle, prRef, prNum, skipMessage, chainPR } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
         const modelConfig = {
@@ -550,7 +548,7 @@ class EventFactory extends BaseFactory {
                         }
 
                         // Start builds
-                        return createBuilds({
+                        return createBuilds.call(this, {
                             decoratedCommit,
                             eventConfig: config,
                             eventId: event.id,
@@ -558,8 +556,7 @@ class EventFactory extends BaseFactory {
                             pipelineConfig: modelConfig,
                             isPR: !!prInfo,
                             changedFiles,
-                            webhooks,
-                            clusterEnv
+                            webhooks
                         });
                     }).then((builds) => {
                         event.builds = builds;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.1",
-    "screwdriver-data-schema": "^18.46.1",
+    "screwdriver-data-schema": "^18.46.2",
     "screwdriver-workflow-parser": "^1.8.4",
     "winston": "^2.4.4"
   }

--- a/package.json
+++ b/package.json
@@ -42,20 +42,20 @@
     "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
     "rewire": "^4.0.1",
-    "sinon": "^7.3.1"
+    "sinon": "^7.3.2"
   },
   "dependencies": {
     "async": "^2.6.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
-    "dayjs": "^1.8.12",
+    "dayjs": "^1.8.13",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.1",
-    "screwdriver-data-schema": "^18.45.1",
-    "screwdriver-workflow-parser": "^1.8.3",
+    "screwdriver-data-schema": "^18.46.1",
+    "screwdriver-workflow-parser": "^1.8.4",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -8,7 +8,7 @@ const PARSED_YAML = require('../data/parserWithWorkflowGraph');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('Event Factory', () => {
+describe.only('Event Factory', () => {
     const dateNow = 1234567;
     const nowTime = (new Date(dateNow)).toISOString();
     let EventFactory;
@@ -1170,20 +1170,17 @@ describe('Event Factory', () => {
             config.prNum = 1;
             config.prTitle = 'Update the README with new information';
             config.changedFiles = ['src/test/README.md', 'NOTINSOURCEPATH.md'];
-            config.clusterEnv = { FOO: 'bar' };
 
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledTwice(buildFactoryMock.create);
                 assert.deepEqual(
                     buildFactoryMock.create.args[0][0].environment, {
-                        SD_SOURCE_PATH: 'src/test/',
-                        FOO: 'bar'
+                        SD_SOURCE_PATH: 'src/test/'
                     });
                 assert.deepEqual(
                     buildFactoryMock.create.args[1][0].environment, {
-                        SD_SOURCE_PATH: 'src/test/',
-                        FOO: 'bar'
+                        SD_SOURCE_PATH: 'src/test/'
                     });
             });
         });

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -937,7 +937,7 @@ describe('Event Factory', () => {
             config.meta = meta;
             expected.meta = meta;
 
-            eventFactory.create(config).then((model) => {
+            return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledWith(scm.decorateAuthor, {
                     username: 'stjohn',
@@ -1139,7 +1139,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should start builds if changed file is in sourcePaths', () => {
+        it('should start builds if changedFiles in sourcePaths and pass in clusterenv', () => {
             jobsMock = [{
                 id: 1,
                 pipelineId: 8765,
@@ -1170,18 +1170,21 @@ describe('Event Factory', () => {
             config.prNum = 1;
             config.prTitle = 'Update the README with new information';
             config.changedFiles = ['src/test/README.md', 'NOTINSOURCEPATH.md'];
+            config.clusterEnv = { FOO: 'bar' };
 
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.calledTwice(buildFactoryMock.create);
                 assert.deepEqual(
-                    buildFactoryMock.create.args[0][0].environment,
-                    { SD_SOURCE_PATH: 'src/test/' }
-                );
+                    buildFactoryMock.create.args[0][0].environment, {
+                        SD_SOURCE_PATH: 'src/test/',
+                        FOO: 'bar'
+                    });
                 assert.deepEqual(
-                    buildFactoryMock.create.args[1][0].environment,
-                    { SD_SOURCE_PATH: 'src/test/' }
-                );
+                    buildFactoryMock.create.args[1][0].environment, {
+                        SD_SOURCE_PATH: 'src/test/',
+                        FOO: 'bar'
+                    });
             });
         });
 


### PR DESCRIPTION
Related: accept optional `clusterEnv` and inject into build. This field will be passed in by API

https://github.com/screwdriver-cd/screwdriver/issues/1070