### PR TITLE
fix: switch to pipeline.getJobs instead of pipeline.jobs

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -64,7 +64,7 @@ function getBlockedByIds(pipeline, job) {
     // Remove ~ prefix for job names
     blockedByNames = blockedByNames.map(name => name.replace('~', ''));
 
-    return pipeline.jobs.then((pipelineJobs) => {
+    return pipeline.getJobs().then((pipelineJobs) => {
         // Get internal blocked by first
         blockedByIds = blockedByIds.concat(
             findIdsOfMatchedJobs(pipelineJobs, blockedByNames));
@@ -90,7 +90,7 @@ function getBlockedByIds(pipeline, job) {
                             return [];
                         }
 
-                        return p.jobs;
+                        return p.getJobs();
                     })
                     .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));
             }))

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "async": "^2.6.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
-    "dayjs": "^1.8.12",
+    "dayjs": "^1.8.13",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.1",
-    "screwdriver-data-schema": "^18.45.1",
-    "screwdriver-workflow-parser": "^1.8.3",
+    "screwdriver-data-schema": "^18.46.0",
+    "screwdriver-workflow-parser": "^1.8.4",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -976,7 +976,7 @@ describe('Build Model', () => {
                 scmContext,
                 admin: Promise.resolve(adminUser),
                 token: Promise.resolve('foo'),
-                jobs: Promise.resolve([
+                getJobs: sinon.stub().resolves([
                     { id: jobId, name: 'main', isPR: () => false },
                     blocking1,
                     { id: 123, name: 'somejob', isPR: () => false },
@@ -1036,14 +1036,14 @@ describe('Build Model', () => {
             };
             const pipeline1 = {
                 id: externalPid1,
-                jobs: Promise.resolve([
+                getJobs: sinon.stub().resolves([
                     { id: 999, name: 'somejob', isPR: () => false },
                     externalJob1
                 ])
             };
             const pipeline2 = {
                 id: externalPid2,
-                jobs: Promise.resolve([
+                getJobs: sinon.stub().resolves([
                     { id: 888, name: 'somerandomjob', isPR: () => false },
                     externalJob2
                 ])
@@ -1063,7 +1063,7 @@ describe('Build Model', () => {
                 scmContext,
                 admin: Promise.resolve(adminUser),
                 token: Promise.resolve('foo'),
-                jobs: Promise.resolve([
+                getJobs: sinon.stub().resolves([
                     { id: jobId, name: 'main', isPR: () => false },
                     { id: 123, name: 'somejob', isPR: () => false },
                     { id: internalJob.id, name: internalJob.name, isPR: () => false }])
@@ -1119,7 +1119,7 @@ describe('Build Model', () => {
             };
             const pipeline1 = {
                 id: externalPid1,
-                jobs: Promise.resolve([
+                getJobs: sinon.stub().resolves([
                     { id: 999, name: 'somejob', isPR: () => false },
                     externalJob1
                 ])
@@ -1139,7 +1139,7 @@ describe('Build Model', () => {
                 scmContext,
                 admin: Promise.resolve(adminUser),
                 token: Promise.resolve('foo'),
-                jobs: Promise.resolve([
+                getJobs: sinon.stub().resolves([
                     { id: jobId, name: 'main', isPR: () => false },
                     { id: 123, name: 'somejob', isPR: () => false },
                     { id: internalJob.id, name: internalJob.name, isPR: () => false }])


### PR DESCRIPTION
in `getBlockedByIds`, we are calling `pipeline.jobs`, switch to `getJobs` to get only active jobs instead.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1603