### PR TITLE
fix: pass clusterEnv to buildFactory

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -267,15 +267,11 @@ class BuildFactory extends BaseFactory {
      */
     create(config) {
         const number = Date.now();
-        const { jobId, configPipelineSha, start, meta, username, environment } = config;
+        const { jobId, configPipelineSha, start, meta, username } = config;
         const modelConfig = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
 
-        // if did not go through eventFactory create to set clusterEnv
-        if (!environment) {
-            modelConfig.environment = this.clusterEnv;
-        }
         modelConfig.cause = `Started by user ${displayName}`;
         modelConfig.number = number;
         modelConfig.status = start === false ? 'CREATED' : 'QUEUED';
@@ -330,6 +326,7 @@ class BuildFactory extends BaseFactory {
 
                     // merge preset environment with build environment
                     modelConfig.environment = Object.assign({},
+                        this.clusterEnv,
                         modelConfig.environment,
                         permutation.environment
                     );

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -207,7 +207,8 @@ class BuildFactory extends BaseFactory {
      * @param  {Executor}  config.executor                  Object that will perform compute operations
      * @param  {Bookend}   config.bookend                   Object that will calculate the setup and teardown commands
      * @param  {String}    config.uiUri                     Partial Uri including hostname and namespace for ui for git notifications
-     * @param  {Boolean}    config.multiBuildClusterEnabled Enable multiple build cluster feature or not
+     * @param  {Boolean}   config.multiBuildClusterEnabled  Enable multiple build cluster feature or not
+     * @param  {Object}    config.clusterEnv                Default cluster environment variables
      */
     constructor(config) {
         super('build', config);
@@ -218,6 +219,7 @@ class BuildFactory extends BaseFactory {
         this.apiUri = null;
         this.tokenGen = null;
         this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
+        this.clusterEnv = config.clusterEnv || {};
     }
 
     /**
@@ -260,18 +262,24 @@ class BuildFactory extends BaseFactory {
      * @param  {Boolean}   [config.start]              Whether to start the build after creating
      * @param  {Object}    [config.environment]        Dynamically injected environment variables
      * @param  {Object}    [config.meta]               Metadata tied to this build
+     * @param  {Object}    [config.environment]        Preset environment variables
      * @return {Promise}
      */
     create(config) {
         const number = Date.now();
+        const { jobId, configPipelineSha, start, meta, username, environment } = config;
         const modelConfig = config;
         const displayLabel = this.scm.getDisplayName(config);
-        const displayName = displayLabel ? `${displayLabel}:${config.username}` : config.username;
+        const displayName = displayLabel ? `${displayLabel}:${username}` : username;
 
+        // if did not go through eventFactory create to set clusterEnv
+        if (!environment) {
+            modelConfig.environment = this.clusterEnv;
+        }
         modelConfig.cause = `Started by user ${displayName}`;
         modelConfig.number = number;
-        modelConfig.status = config.start === false ? 'CREATED' : 'QUEUED';
-        modelConfig.meta = config.meta || {};
+        modelConfig.status = start === false ? 'CREATED' : 'QUEUED';
+        modelConfig.meta = meta || {};
 
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
@@ -282,7 +290,7 @@ class BuildFactory extends BaseFactory {
         const factory = JobFactory.getInstance();
         const stepFactory = StepFactory.getInstance();
 
-        return factory.get(config.jobId)
+        return factory.get(jobId)
             .then((job) => {
                 if (!job) {
                     throw new Error('Job does not exist');
@@ -320,6 +328,7 @@ class BuildFactory extends BaseFactory {
                         dockerRegistry: this.dockerRegistry
                     });
 
+                    // merge preset environment with build environment
                     modelConfig.environment = Object.assign({},
                         modelConfig.environment,
                         permutation.environment
@@ -334,7 +343,7 @@ class BuildFactory extends BaseFactory {
 
                     if (pipeline.configPipelineId) {
                         bookendConfig.configPipeline = await pipeline.configPipeline;
-                        bookendConfig.configPipelineSha = config.configPipelineSha;
+                        bookendConfig.configPipelineSha = configPipelineSha;
                     }
 
                     return Promise.all([
@@ -361,7 +370,7 @@ class BuildFactory extends BaseFactory {
                         )))).then(() => build)
                     )
                     .then((build) => {
-                        if (config.start === false) {
+                        if (start === false) {
                             return build;
                         }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -116,7 +116,6 @@ function getJobsFromPR(config) {
  * @param  {Boolean}  [config.isPR]             Is it PR?
  * @param  {Object}   [config.decoratedCommit]  Decorated commit object
  * @param  {String}   [config.rootDir]          Root directory
- * @param  {Object}   [config.clusterEnv]       Default cluster environment variables
  * @return {Promise}
  */
 function startBuild(config) {
@@ -131,12 +130,11 @@ function startBuild(config) {
         webhooks,
         isPR,
         decoratedCommit,
-        rootDir,
-        clusterEnv
+        rootDir
     } = config;
     let hasChangeInSourcePaths = true;
 
-    buildConfig.environment = clusterEnv || {};
+    buildConfig.environment = {};
 
     // Only check if sourcePaths or rootDir is set
     // and webhooks or is a PR
@@ -206,7 +204,6 @@ function startBuild(config) {
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]                          Is it PR?
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
- * @param  {Object}   [config.clusterEnv]                    Default cluster environment variables
  */
 function createBuilds(config) {
     const {
@@ -217,8 +214,7 @@ function createBuilds(config) {
         pipelineConfig,
         changedFiles,
         webhooks,
-        isPR,
-        clusterEnv
+        isPR
     } = config;
     const startFrom = eventConfig.startFrom;
     let rootDir = '';
@@ -281,8 +277,7 @@ function createBuilds(config) {
                     sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                     webhooks,
                     isPR,
-                    rootDir,
-                    clusterEnv
+                    rootDir
                 });
             })).then((buildsCreated) => {
                 const builds = buildsCreated.filter(b => b !== null);
@@ -377,11 +372,9 @@ class EventFactory extends BaseFactory {
      * @method constructor
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
-     * @param  {Object}    config.clusterEnv    Default cluster environment variables
      */
     constructor(config) {
         super('event', config);
-        this.clusterEnv = config.clusterEnv || {};
     }
 
     /**
@@ -592,8 +585,7 @@ class EventFactory extends BaseFactory {
                             pipelineConfig: modelConfig,
                             isPR: !!prInfo,
                             changedFiles,
-                            webhooks,
-                            clusterEnv: this.clusterEnv
+                            webhooks
                         });
                     }).then((builds) => {
                         event.builds = builds;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.1",
     "screwdriver-data-schema": "^18.46.2",
-    "screwdriver-workflow-parser": "^1.8.4",
+    "screwdriver-workflow-parser": "1.8.4",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -205,21 +205,21 @@ describe('Build Factory', () => {
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '4' },
+            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
             image: 'node:4'
         }, {
             commands: [
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '5' },
+            environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
             image: 'node:5'
         }, {
             commands: [
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '6' },
+            environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
             image: 'node:6'
         }];
         const permutationsWithAnnotations = [{
@@ -230,7 +230,7 @@ describe('Build Factory', () => {
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '4' },
+            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
             image: 'node:4'
         }];
 
@@ -623,7 +623,9 @@ describe('Build Factory', () => {
                 meta
             }).then(() => {
                 assert.notCalled(startStub);
-                saveConfig.params.environment.EXTRA = true;
+                saveConfig.params.environment = {
+                    CLUSTER_FOO: 'bar', EXTRA: true, NODE_ENV: 'test', NODE_VERSION: '4'
+                };
                 assert.calledWith(datastore.save, saveConfig);
                 delete saveConfig.params.environment.EXTRA;
             });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -20,6 +20,7 @@ class Build {
         this.tokenGen = config.tokenGen;
         this.uiUri = config.uiUri;
         this.steps = config.steps;
+        this.clusterEnv = config.clusterEnv || {};
         this.start = startStub.resolves(this);
         this.getSteps = getStepsStub;
     }
@@ -42,6 +43,7 @@ describe('Build Factory', () => {
     const apiUri = 'https://notify.com/some/endpoint';
     const tokenGen = sinon.stub();
     const uiUri = 'http://display.com/some/endpoint';
+    const clusterEnv = { CLUSTER_FOO: 'bar' };
     const steps = [
         { name: 'sd-setup-launcher' },
         { name: 'sd-setup-scm', command: 'git clone' },
@@ -137,6 +139,7 @@ describe('Build Factory', () => {
             scm: scmMock,
             uiUri,
             bookend: bookendMock,
+            clusterEnv,
             multiBuildClusterEnabled: true
         });
         factory.apiUri = apiUri;
@@ -196,27 +199,27 @@ describe('Build Factory', () => {
         const dateNow = Date.now();
         const isoTime = (new Date(dateNow)).toISOString();
         const container = 'node:4';
-        const environment = { NODE_ENV: 'test', NODE_VERSION: '4' };
+        const environment = { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '4' };
         const permutations = [{
             commands: [
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
+            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '4' },
             image: 'node:4'
         }, {
             commands: [
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
+            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '5' },
             image: 'node:5'
         }, {
             commands: [
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
+            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '6' },
             image: 'node:6'
         }];
         const permutationsWithAnnotations = [{
@@ -227,7 +230,7 @@ describe('Build Factory', () => {
                 { command: 'npm install', name: 'init' },
                 { command: 'npm test', name: 'test' }
             ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
+            environment: { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '4' },
             image: 'node:4'
         }];
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1282,45 +1282,6 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should start builds with clusterEnv', () => {
-            const mockEventFactory = new EventFactory({
-                datastore, scm, clusterEnv: { FOO: 'BAR', TEST: 'BAZ' }
-            });
-
-            jobsMock = [{
-                id: 1,
-                pipelineId: 8765,
-                name: 'PR-1:main',
-                permutations: [{
-                    requires: ['~pr'],
-                    sourcePaths: ['src/test/']
-                }],
-                state: 'ENABLED'
-            }];
-            afterSyncedPRPipelineMock.update = sinon.stub().resolves({
-                getJobs: sinon.stub().resolves(jobsMock),
-                branch: Promise.resolve('branch')
-            });
-
-            config.webhooks = true;
-            config.startFrom = '~pr';
-            config.prRef = 'branch';
-            config.prNum = 1;
-            config.prTitle = 'Update the README with new information';
-            config.changedFiles = ['src/test/README.md', 'NOTINSOURCEPATH.md'];
-
-            return mockEventFactory.create(config).then((model) => {
-                assert.instanceOf(model, Event);
-                assert.calledOnce(buildFactoryMock.create);
-                assert.deepEqual(
-                    buildFactoryMock.create.args[0][0].environment, {
-                        SD_SOURCE_PATH: 'src/test/',
-                        FOO: 'BAR',
-                        TEST: 'BAZ'
-                    });
-            });
-        });
-
         it('should start build when sourcePath is a file, and is the same as changedFile', () => {
             jobsMock = [{
                 id: 1,


### PR DESCRIPTION
Not all builds go through the eventFactory create route
Added a check here, if clusterEnv was not set by `eventFactory`, it will be set here. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1070