### PR TITLE
fix: unpin workflow-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash": "^4.17.11",
     "screwdriver-config-parser": "^4.11.1",
     "screwdriver-data-schema": "^18.46.2",
-    "screwdriver-workflow-parser": "1.8.4",
+    "screwdriver-workflow-parser": "^1.8.6",
     "winston": "^2.4.4"
   }
 }


### PR DESCRIPTION
Pin this version previously because of https://github.com/screwdriver-cd/workflow-parser/pull/23
However, cannot pin because the API checks for duplicate. 