### PR TITLE
fix(1333): Make getTriggers db call more efficient

### DIFF
--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -46,20 +46,28 @@ class TriggerFactory extends BaseFactory {
                 if (pipeline) {
                     // Get pipeline job names
                     return pipeline.getJobs({ type: type || 'pipeline' })
-                        .then(jobs => Promise.all(
-                            jobs.map(j =>
-                                // Get dest triggers for each src job
-                                this.list({
-                                    params: {
-                                        src: `~sd@${pipelineId}:${j.name}`
-                                    }
-                                // Push jobName and dest triggers to result
-                                }).then((triggersArr) => {
-                                    const triggers = triggersArr.map(t => t.dest);
+                        .then((jobs) => {
+                            const srcArray = jobs.map(j => `~sd@${pipelineId}:${j.name}`);
 
-                                    result.push({ jobName: j.name, triggers });
-                                })
-                            ))).then(() => result);
+                            // Get dest triggers for each src job
+                            return this.list({
+                                params: {
+                                    src: srcArray
+                                }
+                            }).then((triggersArr) => {
+                                // Push jobName and dest triggers to result
+                                jobs.forEach((j) => {
+                                    let matchArr = triggersArr.filter(t =>
+                                        t.src === `~sd@${pipelineId}:${j.name}`);
+
+                                    matchArr = matchArr.map(m => m.dest);
+
+                                    result.push({ jobName: j.name, triggers: matchArr });
+                                });
+
+                                return result;
+                            });
+                        });
                 }
 
                 return result;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "async": "^2.6.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.4.0",
-    "dayjs": "^1.8.13",
+    "dayjs": "^1.8.14",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",

--- a/test/lib/triggerFactory.test.js
+++ b/test/lib/triggerFactory.test.js
@@ -7,7 +7,7 @@ const sinon = require('sinon');
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('Trigger Factory', () => {
-    const src = '~sd@12345:component';
+    const src = '~sd@8765:main';
     const dest = '~sd@5678:main';
     const metaData = {
         src,
@@ -170,6 +170,14 @@ describe('Trigger Factory', () => {
                 id: 1234567,
                 src,
                 dest: '~sd@12345:main'
+            }, {
+                id: 1234568,
+                src: '~sd@8765:disabledjob',
+                dest: '~sd@58967:main'
+            }, {
+                id: 1234569,
+                src: '~sd@8765:publish',
+                dest: '~sd@58967:publish'
             }];
         });
 


### PR DESCRIPTION
## Context
Need to make getTriggers call more efficient. 
Before, we were making a call to the DB per pipeline job, which would potentially be a lot of calls depending on number of jobs. Now, we make one call total to the DB to get triggers for all pipeline jobs.

## Objective
This PR changes DB logic to make the call more efficient.

This is probably what the translated query becomes:
_Before:_
1.
```
SELECT
 trigger
FROM
 triggers
WHERE src='~sd@123:main';
```
2.
```
SELECT
 trigger
FROM
 triggers
WHERE src='~sd@999:test';
```
3.
```
SELECT
 trigger
FROM
 triggers
WHERE src='~sd@555:publish';
```

_After:_
```
SELECT
 trigger
FROM
 triggers
WHERE
 src IN ('~sd@123:main', '~sd@999:test', '~sd@555:publish');
```

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1333