### PR TITLE
fix(1646): [5] fix to create job for pr specific job

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -424,26 +424,35 @@ class PipelineModel extends BaseModel {
                     ref: prInfo.ref,
                     isPR: true
                 }),
-                this.jobs
+                this.jobs,
+                Promise.resolve(prInfo.baseBranch)
             ]))
-            .then(([parsedConfig, jobs]) => {
+            .then(([parsedConfig, jobs, branch]) => {
                 logger.info(`pipelineId:${this.id}: chainPR flag is ${this.chainPR}.`);
 
                 const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
+                const workflowGraph = parsedConfig.workflowGraph;
 
                 // Get next jobs for when startFrom is ~pr
-                let nextJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
+                let nextJobs = workflowParser.getNextJobs(workflowGraph, {
                     trigger: '~pr',
                     prNum,
                     chainPR: this.chainPR
                 });
+
+                // Get next jobs for when startFrom is ~pr:branchName
+                nextJobs = nextJobs.concat(workflowParser.getNextJobs(workflowGraph, {
+                    trigger: `~pr:${branch}`,
+                    prNum,
+                    chainPR: this.chainPR
+                }));
 
                 // Get all chained jobs if chainPR is true
                 if (this.chainPR) {
                     let triggerJobs = nextJobs.concat();
 
                     while (triggerJobs.length > 0) {
-                        const chainedJobs = workflowParser.getNextJobs(parsedConfig.workflowGraph, {
+                        const chainedJobs = workflowParser.getNextJobs(workflowGraph, {
                             trigger: triggerJobs[0],
                             chainPR: this.chainPR
                         });
@@ -453,6 +462,10 @@ class PipelineModel extends BaseModel {
                         nextJobs = nextJobs.concat(chainedJobs);
                     }
                 }
+
+                // PR jobs which requires ~pr or ~pr:branch are both same job name (like PR-1:test),
+                // so it needs to remove a duplicated PR job.
+                nextJobs = _.uniq(nextJobs);
 
                 // Get all the missing PR- job names
                 const existingPRJobNames = prJobs.map(prJob => prJob.name);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -434,14 +434,14 @@ class PipelineModel extends BaseModel {
                 const workflowGraph = parsedConfig.workflowGraph;
 
                 // Get next jobs for when startFrom is ~pr
-                let nextJobs = workflowParser.getNextJobs(workflowGraph, {
+                let nextJobNames = workflowParser.getNextJobs(workflowGraph, {
                     trigger: '~pr',
                     prNum,
                     chainPR: this.chainPR
                 });
 
                 // Get next jobs for when startFrom is ~pr:branchName
-                nextJobs = nextJobs.concat(workflowParser.getNextJobs(workflowGraph, {
+                nextJobNames = nextJobNames.concat(workflowParser.getNextJobs(workflowGraph, {
                     trigger: `~pr:${branch}`,
                     prNum,
                     chainPR: this.chainPR
@@ -449,7 +449,7 @@ class PipelineModel extends BaseModel {
 
                 // Get all chained jobs if chainPR is true
                 if (this.chainPR) {
-                    let triggerJobs = nextJobs.concat();
+                    let triggerJobs = nextJobNames.concat();
 
                     while (triggerJobs.length > 0) {
                         const chainedJobs = workflowParser.getNextJobs(workflowGraph, {
@@ -459,23 +459,23 @@ class PipelineModel extends BaseModel {
 
                         triggerJobs.splice(0, 1);
                         triggerJobs = triggerJobs.concat(chainedJobs);
-                        nextJobs = nextJobs.concat(chainedJobs);
+                        nextJobNames = nextJobNames.concat(chainedJobs);
                     }
                 }
 
                 // PR jobs which requires ~pr or ~pr:branch are both same job name (like PR-1:test),
                 // so it needs to remove a duplicated PR job.
-                nextJobs = _.uniq(nextJobs);
+                nextJobNames = _.uniq(nextJobNames);
 
                 // Get all the missing PR- job names
                 const existingPRJobNames = prJobs.map(prJob => prJob.name);
                 const missingPRJobNames =
-                    nextJobs.filter(nextJob => !existingPRJobNames.includes(nextJob));
+                    nextJobNames.filter(nextJob => !existingPRJobNames.includes(nextJob));
 
                 // Get the job name part, e.g. main from PR-1:main to create job
                 const jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
-                const jobsToArchive = prJobs.filter(prJob => !nextJobs.includes(prJob.name));
-                const jobsToUnarchive = prJobs.filter(prJob => nextJobs.includes(prJob.name));
+                const jobsToArchive = prJobs.filter(prJob => !nextJobNames.includes(prJob.name));
+                const jobsToUnarchive = prJobs.filter(prJob => nextJobNames.includes(prJob.name));
 
                 // Lazy load factory dependency to prevent circular dependency issues
                 // https://nodejs.org/api/modules.html#modules_cycles

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -425,7 +425,7 @@ class PipelineModel extends BaseModel {
                     isPR: true
                 }),
                 this.jobs,
-                Promise.resolve(prInfo.baseBranch)
+                prInfo.baseBranch
             ]))
             .then(([parsedConfig, jobs, branch]) => {
                 logger.info(`pipelineId:${this.id}: chainPR flag is ${this.chainPR}.`);

--- a/test/data/parserWithWorkflowGraphPR.json
+++ b/test/data/parserWithWorkflowGraphPR.json
@@ -107,6 +107,18 @@
                 ],
                 "requires": ["~commit"]
             }
+        ],
+        "pr_specific_branch": [
+            {
+                "image": "node:8",
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install test"
+                    }
+                ],
+                "requires": ["~pr:testBranch"]
+            }
         ]
     },
     "workflowGraph": {
@@ -125,7 +137,8 @@
             { "src": "~pr", "dest": "new_pr_job" },
             { "src": "~commit", "dest": "main" },
             { "src": "main", "dest": "publish" },
-            { "src": "~commit", "dest": "not_pr_job" }
+            { "src": "~commit", "dest": "not_pr_job" },
+            { "src": "~pr:testBranch", "dest": "pr_specific_branch" }
         ]
     },
     "annotations": {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1123,6 +1123,7 @@ describe('Pipeline Model', () => {
                 });
                 assert.calledOnce(prJobs[0].update);
                 assert.calledOnce(prJobs[1].update);
+                assert.calledOnce(prJobs[2].update);
                 // PR-1:test is triggered by ~pr and ~pr:testBranch, but it should be created just once
                 assert.calledOnce(jobFactoryMock.create);
                 assert.calledWith(jobFactoryMock.create, {


### PR DESCRIPTION
**Issue #, if available:** https://github.com/screwdriver-cd/screwdriver/issues/1646
As @yuichi10 mentioned in the issue, it's caused by that the PR job which requires `~pr:<branchName>` is not created, when `pipeline.prSync` is called.

**Description of changes:**
This fix `syncPR` to create PR job collectly which requires `~pr:<branchName>`.

This PR is requires below changes before merge.
https://github.com/screwdriver-cd/data-schema/pull/339
https://github.com/screwdriver-cd/scm-base/pull/70
https://github.com/screwdriver-cd/scm-github/pull/136
https://github.com/screwdriver-cd/scm-bitbucket/pull/60

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
