### PR TITLE
fix: Remove upstream triggers when deleting a pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1226,6 +1226,29 @@ class PipelineModel extends BaseModel {
         const removeTokens = (() =>
             this.tokens.then(tokens => Promise.all(tokens.map(t => t.remove()))));
 
+        const removeTriggers = (() => {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const TriggerFactory = require('./triggerFactory');
+            /* eslint-enable global-require */
+
+            const triggerFactory = TriggerFactory.getInstance();
+
+            // list records that would trigger this job
+            return this.getJobs({ type: 'pipeline' })
+                .then((jobs) => {
+                    const srcArray = jobs.map(j => `~sd@${this.id}:${j.name}`);
+
+                    // Get dest triggers for each src job
+                    return triggerFactory.list({
+                        params: {
+                            src: srcArray
+                        }
+                    }).then(triggersArr => Promise.all(triggersArr.map(t => t.remove())));
+                });
+        });
+
         return this.secrets
             .then((secrets) => { // remove secrets
                 const filteredSecrets = secrets.filter(secret => secret.pipelineId === this.id);
@@ -1233,6 +1256,7 @@ class PipelineModel extends BaseModel {
                 return Promise.all(filteredSecrets.map(secret => secret.remove()));
             })
             .then(() => removeTokens()) // remove tokens
+            .then(() => removeTriggers()) // remove triggers
             .then(() => removeJobs(true)) // remove archived jobs
             .then(() => removeJobs(false)) // remove non-archived jobs
             .then(() => removeEvents('pipeline')) // remove pipeline events

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1853,6 +1853,11 @@ describe('Pipeline Model', () => {
             pipelineId: testId,
             remove: sinon.stub().resolves(null)
         };
+        const trigger = {
+            src: '~sd@123:main',
+            dest: '~sd@345:main',
+            remove: sinon.stub().resolves(null)
+        };
 
         beforeEach(() => {
             archived = {
@@ -1874,6 +1879,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.list.resolves([]);
             secretFactoryMock.list.resolves([secret]);
             tokenFactoryMock.list.resolves([token]);
+            triggerFactoryMock.list.resolves([trigger]);
         });
 
         afterEach(() => {
@@ -1881,11 +1887,13 @@ describe('Pipeline Model', () => {
             jobFactoryMock.list.reset();
             secretFactoryMock.list.reset();
             tokenFactoryMock.list.reset();
+            triggerFactoryMock.list.reset();
             publishJob.remove.reset();
             mainJob.remove.reset();
             blahJob.remove.reset();
             secret.remove.reset();
             token.remove.reset();
+            trigger.remove.reset();
         });
 
         it('remove secrets', () =>
@@ -1899,6 +1907,13 @@ describe('Pipeline Model', () => {
             pipeline.remove().then(() => {
                 assert.calledOnce(tokenFactoryMock.list);
                 assert.calledOnce(token.remove);
+            })
+        );
+
+        it('remove triggers', () =>
+            pipeline.remove().then(() => {
+                assert.calledOnce(triggerFactoryMock.list);
+                assert.calledOnce(trigger.remove);
             })
         );
 
@@ -1922,8 +1937,8 @@ describe('Pipeline Model', () => {
                 assert.callCount(jobFactoryMock.list, 8);
 
                 // Delete all the jobs
-                assert.callCount(publishJob.remove, 4);
-                assert.callCount(mainJob.remove, 4);
+                assert.callCount(publishJob.remove, 3);
+                assert.callCount(mainJob.remove, 3);
                 assert.callCount(blahJob.remove, 2);
 
                 // Delete the pipeline


### PR DESCRIPTION
## Context

When a pipeline is removed, triggers are not cleaned up. This is confusing in the UI. For example, if there is pipeline A and pipeline B (A -> B). Pipeline B requires pipeline A. If pipeline B is deleted, pipeline A should not still show pipeline B as a downstream trigger.

## Objective

This PR removes all triggers where pipeline B is a destination when pipeline B is deleted.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1333

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
