### PR TITLE
fix(1364): fix to consider ~pr:pipelineBranch trigger

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -82,21 +82,30 @@ function getJobsFromJobName(config) {
  * @param  {Object}    config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
  * @param  {String}    config.startFrom                      Startfrom (e.g. ~commit, ~pr, etc)
  * @param  {Boolean}   config.chainPR                        Flag of triggering subsequent job after pull request job
+ * @param  {String}    config.branch                         triggered branch name
  * @resolves {Array}                                         Array of PR jobs to start
  */
 function getJobsFromPR(config) {
-    const { jobs, prNum, pipelineConfig, startFrom, chainPR } = config;
+    const { jobs, prNum, pipelineConfig, startFrom, chainPR, branch } = config;
     const isPRTrigger = PR_TRIGGER.test(startFrom);
 
     if (!isPRTrigger) {
         return [];
     }
 
-    const nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+    let nextJobs = workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
         trigger: startFrom,
         prNum,
         chainPR
     });
+
+    if (startFrom === '~pr') {
+        nextJobs = nextJobs.concat(workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+            trigger: `~pr:${branch}`,
+            prNum,
+            chainPR
+        }));
+    }
 
     const jobsToStart = jobs.filter(
         j => nextJobs.includes(j.name)
@@ -247,7 +256,8 @@ function createBuilds(config) {
             prNum: eventConfig.prNum,
             pipelineConfig,
             startFrom,
-            chainPR: pipeline.chainPR
+            chainPR: pipeline.chainPR,
+            branch
         });
 
         return Promise.all([jobsFromTrigger, jobsFromJobName, jobsFromPR])


### PR DESCRIPTION
## Context
Branch filtering doesn't work with `~pr` trigger when use pipeline's branch for the filter.


## Objective
Fix triggers like `~pr:pipelineBranch` to work properly.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1364

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
