### PR TITLE
fix(1682): Clean up deleted triggers

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1243,7 +1243,7 @@ class PipelineModel extends BaseModel {
                     // Get dest triggers for each src job
                     return triggerFactory.list({
                         params: {
-                            src: srcArray
+                            dest: srcArray
                         }
                     }).then(triggersArr => Promise.all(triggersArr.map(t => t.remove())));
                 });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1912,6 +1912,8 @@ describe('Pipeline Model', () => {
 
         it('remove triggers', () =>
             pipeline.remove().then(() => {
+                assert.calledWith(triggerFactoryMock.list, { params: { dest: [] } });
+                assert.calledThrice(jobFactoryMock.list);
                 assert.calledOnce(triggerFactoryMock.list);
                 assert.calledOnce(trigger.remove);
             })


### PR DESCRIPTION
## Context

When a downstream trigger pipeline is deleted, the triggers still appear on the UI.

## Objective

This PR fixes it so the downstream triggers are deleted from the trigger table when a pipeline is deleted.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1682

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
