### PR TITLE
fix: builds list should use createTime as default sortBy

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -394,11 +394,14 @@ class BuildFactory extends BaseFactory {
      * @param  {Object}   config.paginate         Pagination parameters
      * @param  {Number}   config.paginate.count   Number of items per page
      * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @param  {String}   config.sortBy           Key to sort builds table
      * @param  {Boolean}  [config.fetchSteps]     Fetch steps for all the builds, default is true
      * @return {Promise}                          Resolve builds after merging with step models
      */
     list(config) {
         const fetchSteps = config.fetchSteps || false;
+
+        config.sortBy = config.sortBy || 'createTime';
 
         return super.list(config)
             .then((builds) => {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -726,7 +726,10 @@ describe('Build Factory', () => {
             datastore.scan.resolves([buildData, buildData]);
 
             return factory.list({})
-                .then(builds => builds.map(build => assert.deepEqual(build.steps, steps)));
+                .then((builds) => {
+                    builds.map(build => assert.deepEqual(build.steps, steps));
+                    assert.calledWithMatch(datastore.scan, { sortBy: 'createTime' });
+                });
         });
 
         it('should list builds with merged step data if config.fetchSteps is true', () => {

--- a/test/lib/collectionFactory.test.js
+++ b/test/lib/collectionFactory.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe.only('Collection Factory', () => {
+describe('Collection Factory', () => {
     const name = 'Favorites';
     const description = 'Collection of favorite pipelines';
     const userId = 1;
@@ -113,7 +113,8 @@ describe.only('Collection Factory', () => {
                         userId,
                         name,
                         description,
-                        pipelineIds: [] // The collectionFactory should add this field
+                        pipelineIds: [], // The collectionFactory should add this field
+                        type
                     },
                     table: 'collections'
                 });

--- a/test/lib/collectionFactory.test.js
+++ b/test/lib/collectionFactory.test.js
@@ -6,25 +6,27 @@ const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('Collection Factory', () => {
+describe.only('Collection Factory', () => {
     const name = 'Favorites';
     const description = 'Collection of favorite pipelines';
     const userId = 1;
     const collectionId = 123;
     const pipelineIds = [12, 34, 56];
+    const type = 'normal';
     const collectionData = {
         id: collectionId,
         userId,
         name,
         description,
         pipelineIds,
-        type: undefined
+        type
     };
     const expected = {
         userId,
         name,
         description,
-        pipelineIds
+        pipelineIds,
+        type
     };
 
     let CollectionFactory;
@@ -78,7 +80,8 @@ describe('Collection Factory', () => {
                 userId,
                 name,
                 description,
-                pipelineIds
+                pipelineIds,
+                type
             }).then((model) => {
                 assert.isTrue(datastore.save.calledOnce);
                 assert.calledWith(datastore.save, {
@@ -101,7 +104,8 @@ describe('Collection Factory', () => {
             return factory.create({
                 userId,
                 name,
-                description
+                description,
+                type
             }).then((model) => {
                 assert.isTrue(datastore.save.calledOnce);
                 assert.calledWith(datastore.save, {

--- a/test/lib/collectionFactory.test.js
+++ b/test/lib/collectionFactory.test.js
@@ -17,7 +17,8 @@ describe('Collection Factory', () => {
         userId,
         name,
         description,
-        pipelineIds
+        pipelineIds,
+        type: undefined
     };
     const expected = {
         userId,


### PR DESCRIPTION
## Context

Use `createTime` as default sortBy for builds list, so that it uses index.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Address performance issue with `job.builds` list
## References

https://github.com/screwdriver-cd/screwdriver/issues/1737
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
