### PR TITLE
fix: job.getBuilds should use default pagination

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -9,6 +9,7 @@ const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
 const START_INDEX = 3;
 const MAX_COUNT = 1000;
+const DEFAULT_COUNT = 10;
 
 /**
  * Find metrics and step metrics related to the build
@@ -145,6 +146,9 @@ class Job extends BaseModel {
             params: {
                 jobId: this.id
             },
+            paginate: {
+                count: DEFAULT_COUNT
+            },
             sort: sort ? sort.toLowerCase() : 'descending' // Sort by primary sort key
         };
 
@@ -227,8 +231,8 @@ class Job extends BaseModel {
      */
     remove() {
         const removeBuilds = (() =>
-            // Iterate through the builds and remove them
-            this.getBuilds().then((builds) => {
+            // Iterate through the builds and remove MAX_COUNT at a time
+            this.getBuilds({ paginate: { count: MAX_COUNT } }).then((builds) => {
                 if (builds.length === 0) {
                     // Done removing builds
                     return null;

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -289,6 +289,9 @@ describe('Job Model', () => {
     describe('getBuilds', () => {
         it('use the default config when not passed in', () => {
             const expected = {
+                paginate: {
+                    count: 10
+                },
                 params: {
                     jobId: 1234
                 },
@@ -331,6 +334,9 @@ describe('Job Model', () => {
     describe('getRunningBuilds', () => {
         it('gets all running builds', () => {
             const expectedFirstCall = {
+                paginate: {
+                    count: 10
+                },
                 params: {
                     jobId: 1234,
                     status: 'RUNNING'
@@ -356,6 +362,9 @@ describe('Job Model', () => {
             buildFactoryMock.list.resolves([build3]);
 
             const expected = {
+                paginate: {
+                    count: 10
+                },
                 params: {
                     jobId: 1234,
                     status: 'SUCCESS'


### PR DESCRIPTION
## Context

`job.getBuilds()` is expensive for jobs with large number of builds and should always be using with pagination. 

## Objective

Reduce number of data records fetched from DB for `job.getBuilds()`

## References

https://github.com/screwdriver-cd/screwdriver/issues/1737

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
