### PR TITLE
fix: add parameters to top level

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -215,6 +215,8 @@ function startBuild(config) {
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]                          Is it PR?
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
+ * @param  {Object}   [config.pipeline]                      Default pipeline config from databse
+ * @param  {Object}   [config.pipelineConfig]                Current Pipeline config
  */
 function createBuilds(config) {
     const {
@@ -237,10 +239,12 @@ function createBuilds(config) {
     // enable pipeline parameters feature
     if (pipeline.parameters && pipelineConfig.meta && pipelineConfig.meta.parameters) {
         const allowedPipelineParameters = _.keys(pipeline.parameters);
-        const currentPipelineParamters = _.assign({}, pipeline.parameters,
+        const currentPipelineParameters = _.assign({},
+            pipeline.parameters,
             pipelineConfig.meta.parameters);
 
-        pipelineConfig.meta.paramters = _.pick(currentPipelineParamters, allowedPipelineParameters);
+        pipelineConfig.meta.parameters = _.pick(currentPipelineParameters,
+            allowedPipelineParameters);
     }
 
     return Promise.all([

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -12,6 +12,7 @@ const {
 } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const winston = require('winston');
+const _ = require('lodash');
 
 let instance;
 
@@ -231,6 +232,13 @@ function createBuilds(config) {
 
     if (!startFrom) {
         return null;
+    }
+
+    // enable pipeline parameters feature
+    if (pipeline.parameters && pipelineConfig.meta && pipelineConfig.meta.parameters) {
+        const allowedPipelineParameters = _.keys(pipeline.parameters);
+        const currentPipelineParamters = _.assign({}, pipeline.parameters, pipelineConfig.meta.parameters);
+        pipelineConfig.meta.paramters = _.pick(currentPipelineParamters, allowedPipelineParameters);
     }
 
     return Promise.all([

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -237,7 +237,9 @@ function createBuilds(config) {
     // enable pipeline parameters feature
     if (pipeline.parameters && pipelineConfig.meta && pipelineConfig.meta.parameters) {
         const allowedPipelineParameters = _.keys(pipeline.parameters);
-        const currentPipelineParamters = _.assign({}, pipeline.parameters, pipelineConfig.meta.parameters);
+        const currentPipelineParamters = _.assign({}, pipeline.parameters,
+            pipelineConfig.meta.parameters);
+
         pipelineConfig.meta.paramters = _.pick(currentPipelineParamters, allowedPipelineParameters);
     }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -720,6 +720,7 @@ class PipelineModel extends BaseModel {
                 this.chainPR = typeof annotChainPR === 'undefined' ? chainPR : annotChainPR;
                 this.workflowGraph = parsedConfig.workflowGraph;
                 this.annotations = parsedConfig.annotations;
+                this.parameters = parsedConfig.parameters;
 
                 return this.jobs
                     .then((existingJobs) => {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1507,7 +1507,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it.only('should have parameters if create with parameters', () => {
+        it('should have parameters if create with parameters', () => {
             const currentPipelineConfig = Object.assign({
                 parameters: {
                     user: 'actualValue'
@@ -1529,7 +1529,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it.only('should not have parameters if create without parameters', () => {
+        it('should not have parameters if create without parameters', () => {
             const currentPipelineConfig = Object.assign({
                 parameters: {
                     thisIsNotFromPipeline: 'nonExistingValue'

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1506,6 +1506,50 @@ describe('Event Factory', () => {
                 });
             });
         });
+
+        it.only('should have parameters if create with parameters', () => {
+            const currentPipelineConfig = Object.assign({
+                parameters: {
+                    user: 'actualValue'
+                }
+            }, syncedPipelineMock);
+
+            const fixedPipelineConfig = Object.assign({
+                parameters: {
+                    user: 'originalValue'
+                }
+            }, syncedPipelineMock);
+
+            config.startFrom = 'main';
+            config.meta = currentPipelineConfig;
+            syncedPipelineMock.update = sinon.stub().resolves(fixedPipelineConfig);
+
+            return eventFactory.create(config).then((model) => {
+                assert.equal(model.meta.parameters.user, 'actualValue');
+            });
+        });
+
+        it.only('should not have parameters if create without parameters', () => {
+            const currentPipelineConfig = Object.assign({
+                parameters: {
+                    thisIsNotFromPipeline: 'nonExistingValue'
+                }
+            }, syncedPipelineMock);
+
+            const fixedPipelineConfig = Object.assign({
+                parameters: {
+                    user: 'originalValue'
+                }
+            }, syncedPipelineMock);
+
+            config.startFrom = 'main';
+            config.meta = currentPipelineConfig;
+            syncedPipelineMock.update = sinon.stub().resolves(fixedPipelineConfig);
+
+            return eventFactory.create(config).then((model) => {
+                assert.equal(model.meta.parameters.user, 'originalValue');
+            });
+        });
     });
 
     describe('getInstance', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Allow users to send `{ meta: parameters: {} }` via API, uisng `meta get` to react in their pipelines later. We need to be able to only allow parameters defined in `screwdriver.yaml` to pass thru.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR does exactly that, pass thru the user defined parameters in `screwdriver.yaml` file down to the `lib/eventFactory.js` to trigger build.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
