### PR TITLE
feat(1717): get latest build

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -192,12 +192,14 @@ class Job extends BaseModel {
     }
 
     /**
-     * Return the last successful build that belong to this job
-     * @return {Promise}        Resolves to the last successful build of this job
+     * Return latest build that belong to this job
+     * @param  {Object}   [config]                  Configuration object
+     * @param  {String}   [config.status]           Return latest build with this status
+     * @return {Promise}                            Lastest build
      */
-    getLastSuccessfulBuild() {
-        return this.getBuilds({ status: 'SUCCESS' })
-            .then(successfulBuilds => successfulBuilds[0]);
+    getLatestBuild(config = {}) {
+        return this.getBuilds({ status: config.status })
+            .then(latestBuilds => latestBuilds[0]);
     }
 
     /**

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -358,7 +358,7 @@ describe('Job Model', () => {
     });
 
     describe('getLatestBuild', () => {
-        it('gets lastest build', () => {
+        it('gets latest build', () => {
             buildFactoryMock.list.resolves([build3]);
 
             const expected = {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -357,8 +357,28 @@ describe('Job Model', () => {
         });
     });
 
-    describe('getLastSuccessfulBuild', () => {
-        it('gets last successful build', () => {
+    describe('getLatestBuild', () => {
+        it('gets lastest build', () => {
+            buildFactoryMock.list.resolves([build3]);
+
+            const expected = {
+                paginate: {
+                    count: 10
+                },
+                params: {
+                    jobId: 1234
+                },
+                sort: 'descending'
+            };
+
+            return job.getLatestBuild()
+                .then((latestBuild) => {
+                    assert.calledWith(buildFactoryMock.list, expected);
+                    assert.equal(latestBuild, build3);
+                });
+        });
+
+        it('gets last queued build', () => {
             buildFactoryMock.list.resolves([build3]);
 
             const expected = {
@@ -367,15 +387,16 @@ describe('Job Model', () => {
                 },
                 params: {
                     jobId: 1234,
-                    status: 'SUCCESS'
+                    status: 'QUEUED'
                 },
                 sort: 'descending'
             };
 
-            return job.getLastSuccessfulBuild().then((successfulBuild) => {
-                assert.calledWith(buildFactoryMock.list, expected);
-                assert.equal(successfulBuild, build3);
-            });
+            return job.getLatestBuild({ status: 'QUEUED' })
+                .then((queueBuild) => {
+                    assert.calledWith(buildFactoryMock.list, expected);
+                    assert.equal(queueBuild, build3);
+                });
         });
     });
 


### PR DESCRIPTION
## Context

This is initial work for adding an endpoint that return latest build

## Objective

Modify getLastSuccessfulBuild to accept other status

## References

https://github.com/screwdriver-cd/screwdriver/issues/1717

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
