### PR TITLE
fix: getLatestBuild return default if no build found

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -199,7 +199,7 @@ class Job extends BaseModel {
      */
     getLatestBuild(config = {}) {
         return this.getBuilds({ status: config.status })
-            .then(latestBuilds => latestBuilds[0]);
+            .then(latestBuilds => latestBuilds[0] || {});
     }
 
     /**

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -379,7 +379,7 @@ describe('Job Model', () => {
         });
 
         it('gets last queued build', () => {
-            buildFactoryMock.list.resolves([build3]);
+            buildFactoryMock.list.resolves([build2]);
 
             const expected = {
                 paginate: {
@@ -395,7 +395,28 @@ describe('Job Model', () => {
             return job.getLatestBuild({ status: 'QUEUED' })
                 .then((queueBuild) => {
                     assert.calledWith(buildFactoryMock.list, expected);
-                    assert.equal(queueBuild, build3);
+                    assert.equal(queueBuild, build2);
+                });
+        });
+
+        it('gets last failure build that does not exists', () => {
+            buildFactoryMock.list.resolves([]);
+
+            const expected = {
+                paginate: {
+                    count: 10
+                },
+                params: {
+                    jobId: 1234,
+                    status: 'FAILURE'
+                },
+                sort: 'descending'
+            };
+
+            return job.getLatestBuild({ status: 'FAILURE' })
+                .then((failureBuild) => {
+                    assert.calledWith(buildFactoryMock.list, expected);
+                    assert.isEmpty(failureBuild);
                 });
         });
     });


### PR DESCRIPTION
## Context

in my previous PR I overlooked case for builds that doesn't exist

## Objective

making change so that getLatestBuild return an empty object when request build doesn't exist

## References

https://github.com/screwdriver-cd/models/pull/393

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
