### PR TITLE
[2] fix(1755): Add baseBranch to event if exists

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -467,7 +467,8 @@ class EventFactory extends BaseFactory {
             creator: config.creator || null,
             meta: config.meta || {},
             pr: {},
-            prNum
+            prNum,
+            baseBranch: config.baseBranch || null
         };
         let prevChainPR = '';
         let decoratedCommit;

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1157,6 +1157,33 @@ describe('Event Factory', () => {
             });
         });
 
+        it('should create an Event with baseBranch', () => {
+            const baseBranchTest = 'branch';
+
+            config.baseBranch = baseBranchTest;
+            expected.baseBranch = baseBranchTest;
+
+            eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.notCalled(scm.decorateAuthor);
+                assert.calledWith(scm.decorateCommit, {
+                    scmUri: 'github.com:1234:branch',
+                    scmContext,
+                    sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
+                    token: 'foo'
+                });
+                assert.strictEqual(syncedPipelineMock.lastEventId, model.id);
+                assert.strictEqual(config.prInfo.url, model.pr.url);
+                Object.keys(expected).forEach((key) => {
+                    if (key === 'workflowGraph' || key === 'meta' || key === 'creator') {
+                        assert.deepEqual(model[key], expected[key]);
+                    } else {
+                        assert.strictEqual(model[key], expected[key]);
+                    }
+                });
+            });
+        });
+
         it('should call pipeline sync with configPipelineSha if passed in', () => {
             config.parentEventId = 222;
             config.configPipelineSha = 'configpipelinesha';


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To use branch info in the restarted build and triggered build, I added branch info to event when it is created.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add branch info to event when create.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1755
https://github.com/screwdriver-cd/screwdriver/issues/1760

Related PRs:
https://github.com/screwdriver-cd/data-schema/pull/357
https://github.com/screwdriver-cd/scm-base/pull/72
https://github.com/screwdriver-cd/screwdriver/pull/1770


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
