### PR TITLE
fix: add events' commit information to returned metrics

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1289,14 +1289,14 @@ class PipelineModel extends BaseModel {
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
             const events = await this.getEvents(options);
             const metrics = await Promise.all(events.map(async (e) => {
-                const { id, createTime, causeMessage, sha, commit } = e;
+                const { id, createTime, causeMessage, sha } = e;
                 const m = await eventMetrics(e);
 
                 if (!m) {
                     return null;
                 }
 
-                return Object.assign({}, { id, createTime, causeMessage, sha, commit }, m);
+                return Object.assign({}, { id, createTime, causeMessage, sha }, m);
             }));
 
             // filter for empty event

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1289,14 +1289,14 @@ class PipelineModel extends BaseModel {
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
             const events = await this.getEvents(options);
             const metrics = await Promise.all(events.map(async (e) => {
-                const { id, createTime, causeMessage, sha } = e;
+                const { id, createTime, causeMessage, sha, commit } = e;
                 const m = await eventMetrics(e);
 
                 if (!m) {
                     return null;
                 }
 
-                return Object.assign({}, { id, createTime, causeMessage, sha }, m);
+                return Object.assign({}, { id, createTime, causeMessage, sha, commit }, m);
             }));
 
             // filter for empty event

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2157,9 +2157,7 @@ describe('Pipeline Model', () => {
                         name: 'BatMan',
                         username: 'batman'
                     },
-                    message: 'Update screwdriver.yaml',
-                    // eslint-disable-next-line max-len
-                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
+                    message: 'Update screwdriver.yaml'
                 },
                 createTime: '2019-01-22T21:00:00.000Z',
                 creator: {
@@ -2190,15 +2188,6 @@ describe('Pipeline Model', () => {
             };
             event2 = Object.assign({}, {
                 id: 1234,
-                commit: {
-                    author: {
-                        name: 'BatMan',
-                        username: 'batman'
-                    },
-                    message: 'Update package.json',
-                    // eslint-disable-next-line max-len
-                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
-                },
                 createTime: '2019-01-24T11:25:00.610Z',
                 sha: '14b920bef306eb1bde8ec0b6a32372eebecc6d0e',
                 getMetrics: sinon.stub().resolves([build21, build22])
@@ -2213,7 +2202,6 @@ describe('Pipeline Model', () => {
                 id: event1.id,
                 createTime: event1.createTime,
                 sha: event1.sha,
-                commit: event1.commit,
                 causeMessage: event1.causeMessage,
                 duration: duration1,
                 status: build12.status,
@@ -2224,7 +2212,6 @@ describe('Pipeline Model', () => {
                 id: event2.id,
                 createTime: event2.createTime,
                 sha: event2.sha,
-                commit: event2.commit,
                 causeMessage: event2.causeMessage,
                 duration: duration2,
                 status: build22.status,

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2157,7 +2157,9 @@ describe('Pipeline Model', () => {
                         name: 'BatMan',
                         username: 'batman'
                     },
-                    message: 'Update screwdriver.yaml'
+                    message: 'Update screwdriver.yaml',
+                    // eslint-disable-next-line max-len
+                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
                 },
                 createTime: '2019-01-22T21:00:00.000Z',
                 creator: {
@@ -2188,6 +2190,15 @@ describe('Pipeline Model', () => {
             };
             event2 = Object.assign({}, {
                 id: 1234,
+                commit: {
+                    author: {
+                        name: 'BatMan',
+                        username: 'batman'
+                    },
+                    message: 'Update package.json',
+                    // eslint-disable-next-line max-len
+                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
+                },
                 createTime: '2019-01-24T11:25:00.610Z',
                 sha: '14b920bef306eb1bde8ec0b6a32372eebecc6d0e',
                 getMetrics: sinon.stub().resolves([build21, build22])
@@ -2202,6 +2213,7 @@ describe('Pipeline Model', () => {
                 id: event1.id,
                 createTime: event1.createTime,
                 sha: event1.sha,
+                commit: event1.commit,
                 causeMessage: event1.causeMessage,
                 duration: duration1,
                 status: build12.status,
@@ -2212,6 +2224,7 @@ describe('Pipeline Model', () => {
                 id: event2.id,
                 createTime: event2.createTime,
                 sha: event2.sha,
+                commit: event2.commit,
                 causeMessage: event2.causeMessage,
                 duration: duration2,
                 status: build22.status,


### PR DESCRIPTION
## Context
Currently, in `dashboard/show` page, in order to enable `events-thumbnail` component to generate events graph, `route.js` has to fetch events as well as their builds (for generating duration information) which is very inefficient and can be improved by using pipeline metrics which contains event duration info that is computed in the backend. But in order to allow metrics to provide all information we need for `pipeline-card` component and `collection-table-row` component, we need to change what is returned from the corresponding API call.

## Objective
Add events' commit information to return metrics including commit url and commit message.

## References
[484](https://github.com/screwdriver-cd/ui/pull/484)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
