### PR TITLE
fix(1675): Pass causeMessage into build executor start [2]

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -414,9 +414,13 @@ class BuildModel extends BaseModel {
     /**
      * Start this build and update commit status as pending
      * @method start
+     * @param startConfig
+     * @param startConfig.causeMessage  Message that describes why the event was created
      * @return {Promise}
      */
-    start() {
+    start(startConfig = {}) {
+        const { causeMessage } = startConfig;
+
         // Make sure that a pipeline and job is associated with the build
         return this.job.then(job =>
             job.pipeline.then(pipeline => getBlockedByIds(pipeline, job)
@@ -445,6 +449,7 @@ class BuildModel extends BaseModel {
                             id: pipeline.id,
                             scmContext: pipeline.scmContext
                         },
+                        causeMessage: causeMessage || '',
                         freezeWindows: hoek.reach(job.permutations[0],
                             'freezeWindows', { default: [] }),
                         apiUri: this[apiUri],

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -251,6 +251,7 @@ class BuildFactory extends BaseFactory {
      * Create a new Build
      * @method create
      * @param  {Object}    config                      Config object
+     * @param  {String}    config.causeMessage         Message that describes why the event was created
      * @param  {String}    config.eventId              The eventId that this build belongs to
      * @param  {String}    config.jobId                The job associated with this build
      * @param  {String}    config.username             The user that created this build
@@ -267,7 +268,7 @@ class BuildFactory extends BaseFactory {
      */
     create(config) {
         const number = Date.now();
-        const { jobId, configPipelineSha, start, meta, username } = config;
+        const { jobId, configPipelineSha, start, meta, username, causeMessage } = config;
         const modelConfig = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
@@ -371,7 +372,7 @@ class BuildFactory extends BaseFactory {
                             return build;
                         }
 
-                        return build.start();
+                        return build.start({ causeMessage });
                     });
             });
     }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -208,6 +208,7 @@ function startBuild(config) {
  * @param  {Number}   config.eventId                         Event id
  * @param  {Pipeline} config.pipeline                        Pipeline to create builds
  * @param  {Object}   config.pipelineConfig
+ * @param  {String}   config.pipelineConfig.causeMessage     Message that describes why the event was created
  * @param  {Object}   [config.pipelineConfig.workflowGraph]  Object with nodes and edges that represent the order of jobs
  * @param  {Array}    [config.changedFiles]                  Array of files that were changed
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
@@ -275,7 +276,8 @@ function createBuilds(config) {
             return Promise.all(jobsToStart.map((j) => {
                 const buildConfig = Object.assign({
                     jobId: j.id,
-                    eventId
+                    eventId,
+                    causeMessage: pipelineConfig.causeMessage
                 }, eventConfig);
 
                 buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;

--- a/package.json
+++ b/package.json
@@ -39,23 +39,23 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^7.0.0",
+    "jenkins-mocha": "^8.0.0",
     "mockery": "^2.0.0",
     "rewire": "^4.0.1",
-    "sinon": "^7.3.2"
+    "sinon": "^7.5.0"
   },
   "dependencies": {
-    "async": "^2.6.2",
+    "async": "^2.6.3",
     "base64url": "^3.0.1",
-    "compare-versions": "^3.4.0",
-    "dayjs": "^1.8.14",
+    "compare-versions": "^3.5.1",
+    "dayjs": "^1.8.16",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
-    "lodash": "^4.17.11",
-    "screwdriver-config-parser": "^4.11.1",
-    "screwdriver-data-schema": "^18.46.2",
-    "screwdriver-workflow-parser": "^1.8.6",
+    "lodash": "^4.17.15",
+    "screwdriver-config-parser": "^4.11.5",
+    "screwdriver-data-schema": "^18.47.6",
+    "screwdriver-workflow-parser": "^1.8.8",
     "winston": "^2.4.4"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -17,6 +17,7 @@ describe('Build Model', () => {
     const jobState = 'ENABLED';
     const jobArchived = false;
     const eventId = 555;
+    const causeMessage = '';
     const now = 112233445566;
     const buildId = 9876;
     const sha = 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f';
@@ -873,6 +874,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.start, {
                         build,
+                        causeMessage,
                         eventId,
                         jobId,
                         jobName,
@@ -921,6 +923,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.start, {
                         build,
+                        causeMessage,
                         jobId,
                         jobName,
                         jobState,
@@ -962,6 +965,54 @@ describe('Build Model', () => {
                     });
                 });
         });
+
+        it('passes causeMessage to executor if it exists', () => build.start({
+            causeMessage: '[force start] Push out hotfix'
+        })
+            .then(() => {
+                assert.calledWith(executorMock.start, {
+                    build,
+                    causeMessage: '[force start] Push out hotfix',
+                    jobId,
+                    jobName,
+                    jobState,
+                    jobArchived,
+                    eventId,
+                    annotations,
+                    freezeWindows,
+                    blockedBy: [jobId],
+                    apiUri,
+                    buildId,
+                    container,
+                    token,
+                    tokenGen,
+                    pipeline: {
+                        id: pipelineMockB.id,
+                        scmContext: pipelineMockB.scmContext
+                    }
+                });
+
+                assert.calledWith(tokenGen, buildId, {
+                    isPR: false,
+                    jobId,
+                    pipelineId,
+                    configPipelineId,
+                    eventId,
+                    prParentJobId
+                }, scmContext, TEMPORAL_JWT_TIMEOUT);
+
+                assert.calledWith(scmMock.updateCommitStatus, {
+                    token: 'foo',
+                    scmUri,
+                    scmContext,
+                    sha,
+                    jobName: 'main',
+                    buildStatus: 'QUEUED',
+                    url,
+                    pipelineId
+                });
+            })
+        );
 
         it('get internal blockedby job Ids and pass to executor start', () => {
             const blocking1 = {
@@ -1014,6 +1065,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.start, {
                         build,
+                        causeMessage,
                         jobId,
                         jobName,
                         jobState,
@@ -1105,6 +1157,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.start, {
                         build,
+                        causeMessage,
                         jobId,
                         jobName,
                         jobState,
@@ -1185,6 +1238,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.start, {
                         build,
+                        causeMessage,
                         jobId,
                         jobName,
                         jobState,
@@ -1230,6 +1284,7 @@ describe('Build Model', () => {
                 .then(() => {
                     assert.calledWith(executorMock.start, {
                         build,
+                        causeMessage,
                         jobId,
                         jobName,
                         jobState,


### PR DESCRIPTION
## Context

Sometimes users want to bypass freeze windows to start a build.

## Objective

This PR passes causeMessage to build executor start.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1675
Blocked by https://github.com/screwdriver-cd/data-schema/pull/360

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
