### PR TITLE
fix: allow the pipeline model's getMetrics method to fetch metrics by pagination

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -17,6 +17,9 @@ const REGEX_CAPTURING_GROUP = {
     job: 2 // main or undefined if using legacy
 };
 const MAX_COUNT = 1000;
+// The default page for fetching not by aggregatedInteval
+// And the start page for fetching by aggregatedInteval
+const DEFAULT_PAGE = 1;
 
 winston.level = process.env.LOG_LEVEL || 'info';
 const logger = new (winston.Logger)({
@@ -1274,19 +1277,28 @@ class PipelineModel extends BaseModel {
      * @param  {String}   [config.aggregateInterval]    Whether to aggregateInterval the data. For example, day/week/month/year
      * @return {Promise}  Resolves to array of metrics for events belong to this pipeline
      */
-    async getMetrics(config = { startTime: null, endTime: null }) {
+    async getMetrics(config = { startTime: null, endTime: null, page: null, count: null }) {
         const options = {
             startTime: config.startTime,
             endTime: config.endTime,
             sort: 'ascending',
             sortBy: 'id',
             paginate: {
+                page: DEFAULT_PAGE,
                 count: MAX_COUNT
             },
             readOnly: true
         };
 
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
+            // If fetching events by page and count, update them according to config
+            if (page && count) {
+                options.paginate = {
+                    page: config.page,
+                    count: config.count
+                }
+            }
+
             const events = await this.getEvents(options);
             const metrics = await Promise.all(events.map(async (e) => {
                 const { id, createTime, causeMessage, sha, commit } = e;
@@ -1302,8 +1314,6 @@ class PipelineModel extends BaseModel {
             // filter for empty event
             return metrics.filter(m => m);
         }
-
-        options.paginate.page = 1;
 
         const allEvents = await getAllRecords.call(this,
             'getEvents', config.aggregateInterval, options, [[]]);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1292,11 +1292,11 @@ class PipelineModel extends BaseModel {
 
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
             // If fetching events by page and count, update them according to config
-            if (page && count) {
+            if (config.page && config.count) {
                 options.paginate = {
                     page: config.page,
                     count: config.count
-                }
+                };
             }
 
             const events = await this.getEvents(options);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1289,14 +1289,14 @@ class PipelineModel extends BaseModel {
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
             const events = await this.getEvents(options);
             const metrics = await Promise.all(events.map(async (e) => {
-                const { id, createTime, causeMessage, sha, commit } = e;
+                const { id, createTime, causeMessage, sha } = e;
                 const m = await eventMetrics(e);
 
                 if (!m) {
                     return null;
                 }
 
-                return Object.assign({}, { id, createTime, causeMessage, sha, commit }, m);
+                return Object.assign({}, { id, createTime, causeMessage, sha }, m);
             }));
 
             // filter for empty event

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1289,14 +1289,14 @@ class PipelineModel extends BaseModel {
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
             const events = await this.getEvents(options);
             const metrics = await Promise.all(events.map(async (e) => {
-                const { id, createTime, causeMessage, sha } = e;
+                const { id, createTime, causeMessage, sha, commit } = e;
                 const m = await eventMetrics(e);
 
                 if (!m) {
                     return null;
                 }
 
-                return Object.assign({}, { id, createTime, causeMessage, sha }, m);
+                return Object.assign({}, { id, createTime, causeMessage, sha, commit }, m);
             }));
 
             // filter for empty event

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2157,9 +2157,7 @@ describe('Pipeline Model', () => {
                         name: 'BatMan',
                         username: 'batman'
                     },
-                    message: 'Update screwdriver.yaml',
-                    // eslint-disable-next-line max-len
-                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
+                    message: 'Update screwdriver.yaml'
                 },
                 createTime: '2019-01-22T21:00:00.000Z',
                 creator: {
@@ -2190,15 +2188,6 @@ describe('Pipeline Model', () => {
             };
             event2 = Object.assign({}, {
                 id: 1234,
-                commit: {
-                    author: {
-                        name: 'BatMan',
-                        username: 'batman'
-                    },
-                    message: 'Update package.json',
-                    // eslint-disable-next-line max-len
-                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
-                },
                 createTime: '2019-01-24T11:25:00.610Z',
                 sha: '14b920bef306eb1bde8ec0b6a32372eebecc6d0e',
                 getMetrics: sinon.stub().resolves([build21, build22])
@@ -2213,7 +2202,6 @@ describe('Pipeline Model', () => {
                 id: event1.id,
                 createTime: event1.createTime,
                 sha: event1.sha,
-                commit: event1.commit,
                 causeMessage: event1.causeMessage,
                 duration: duration1,
                 status: build12.status,
@@ -2224,7 +2212,6 @@ describe('Pipeline Model', () => {
                 id: event2.id,
                 createTime: event2.createTime,
                 sha: event2.sha,
-                commit: event2.commit,
                 causeMessage: event2.causeMessage,
                 duration: duration2,
                 status: build22.status,

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2157,7 +2157,9 @@ describe('Pipeline Model', () => {
                         name: 'BatMan',
                         username: 'batman'
                     },
-                    message: 'Update screwdriver.yaml'
+                    message: 'Update screwdriver.yaml',
+                    // eslint-disable-next-line max-len
+                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
                 },
                 createTime: '2019-01-22T21:00:00.000Z',
                 creator: {
@@ -2188,6 +2190,15 @@ describe('Pipeline Model', () => {
             };
             event2 = Object.assign({}, {
                 id: 1234,
+                commit: {
+                    author: {
+                        name: 'BatMan',
+                        username: 'batman'
+                    },
+                    message: 'Update package.json',
+                    // eslint-disable-next-line max-len
+                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
+                },
                 createTime: '2019-01-24T11:25:00.610Z',
                 sha: '14b920bef306eb1bde8ec0b6a32372eebecc6d0e',
                 getMetrics: sinon.stub().resolves([build21, build22])
@@ -2202,6 +2213,7 @@ describe('Pipeline Model', () => {
                 id: event1.id,
                 createTime: event1.createTime,
                 sha: event1.sha,
+                commit: event1.commit,
                 causeMessage: event1.causeMessage,
                 duration: duration1,
                 status: build12.status,
@@ -2212,6 +2224,7 @@ describe('Pipeline Model', () => {
                 id: event2.id,
                 createTime: event2.createTime,
                 sha: event2.sha,
+                commit: event2.commit,
                 causeMessage: event2.causeMessage,
                 duration: duration2,
                 status: build22.status,

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -25,6 +25,7 @@ const EXTERNAL_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML, {
 const NON_CHAINPR_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML_PR, {
     annotations: { 'screwdriver.cd/chainPR': false }
 });
+const DEFAULT_PAGE = 1;
 const MAX_COUNT = 1000;
 const FAKE_MAX_COUNT = 5;
 
@@ -2105,6 +2106,8 @@ describe('Pipeline Model', () => {
     describe('get metrics', () => {
         const startTime = '2019-01-20T12:00:00.000Z';
         const endTime = '2019-01-30T12:00:00.000Z';
+        const page = 1;
+        const count = 2;
         const build11 = {
             id: 11,
             eventId: 1,
@@ -2234,7 +2237,7 @@ describe('Pipeline Model', () => {
             }];
         });
 
-        it('generates metrics', () => {
+        it('generates metrics by time', () => {
             const eventListConfig = {
                 params: {
                     pipelineId: 123,
@@ -2243,6 +2246,7 @@ describe('Pipeline Model', () => {
                 sort: 'ascending',
                 sortBy: 'id',
                 paginate: {
+                    page: DEFAULT_PAGE,
                     count: MAX_COUNT
                 },
                 startTime,
@@ -2256,6 +2260,32 @@ describe('Pipeline Model', () => {
                 assert.calledWith(eventFactoryMock.list, eventListConfig);
                 assert.calledOnce(event1.getMetrics);
                 assert.calledOnce(event2.getMetrics);
+                assert.deepEqual(result, metrics);
+            });
+        });
+
+        it('generates metrics by pagination', () => {
+            const eventListConfig = {
+                params: {
+                    pipelineId: 123,
+                    type: 'pipeline'
+                },
+                sort: 'ascending',
+                sortBy: 'id',
+                paginate: {
+                    page,
+                    count
+                },
+                readOnly: true
+            };
+
+            eventFactoryMock.list.resolves([event1, event0, event2]);
+
+            return pipeline.getMetrics({ page, count }).then((result) => {
+                assert.calledWith(eventFactoryMock.list, eventListConfig);
+                assert.calledOnce(event0.getMetrics);
+                assert.calledOnce(event2.getMetrics);
+                assert.calledOnce(event1.getMetrics);
                 assert.deepEqual(result, metrics);
             });
         });
@@ -2279,7 +2309,7 @@ describe('Pipeline Model', () => {
                     sort: 'ascending',
                     sortBy: 'id',
                     paginate: {
-                        page: 1,
+                        page: DEFAULT_PAGE,
                         count: FAKE_MAX_COUNT
                     },
                     readOnly: true
@@ -2458,6 +2488,7 @@ describe('Pipeline Model', () => {
                 sort: 'ascending',
                 sortBy: 'id',
                 paginate: {
+                    page: DEFAULT_PAGE,
                     count: MAX_COUNT
                 },
                 readOnly: true


### PR DESCRIPTION
## Context
Currently on the frontend the dashboard/show page fetches metrics of last month, which may retrieve nothing for some pipeline that hasn't been triggered for a while and cause pipeline-card component or collection-table-row component to show nothing (because lastEventInfo will be empty too). If we allow pipeline metrics to be fetched by pagination, we can always get the latest metrics info as long as the pipeline has been triggered before.

## Objective
Pipeline model's getMetrics method can fetch metrics by pagination

## References
[Screwdriver-1784](https://github.com/screwdriver-cd/screwdriver/pull/1784)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
