### PR TITLE
fix: make pipeline model fetch metrics by pagination when either page or count is available in the config

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1302,14 +1302,14 @@ class PipelineModel extends BaseModel {
 
             const events = await this.getEvents(options);
             const metrics = await Promise.all(events.map(async (e) => {
-                const { id, createTime, causeMessage, sha, commit } = e;
+                const { id, createTime, causeMessage, sha } = e;
                 const m = await eventMetrics(e);
 
                 if (!m) {
                     return null;
                 }
 
-                return Object.assign({}, { id, createTime, causeMessage, sha, commit }, m);
+                return Object.assign({}, { id, createTime, causeMessage, sha }, m);
             }));
 
             // filter for empty event

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1293,7 +1293,7 @@ class PipelineModel extends BaseModel {
 
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
             // If fetching events by page and count, update them according to config
-            if (config.page && config.count) {
+            if (config.page || config.count) {
                 options.paginate = {
                     page: config.page,
                     count: config.count

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1302,14 +1302,14 @@ class PipelineModel extends BaseModel {
 
             const events = await this.getEvents(options);
             const metrics = await Promise.all(events.map(async (e) => {
-                const { id, createTime, causeMessage, sha } = e;
+                const { id, createTime, causeMessage, sha, commit } = e;
                 const m = await eventMetrics(e);
 
                 if (!m) {
                     return null;
                 }
 
-                return Object.assign({}, { id, createTime, causeMessage, sha }, m);
+                return Object.assign({}, { id, createTime, causeMessage, sha, commit }, m);
             }));
 
             // filter for empty event

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2160,7 +2160,9 @@ describe('Pipeline Model', () => {
                         name: 'BatMan',
                         username: 'batman'
                     },
-                    message: 'Update screwdriver.yaml'
+                    message: 'Update screwdriver.yaml',
+                    // eslint-disable-next-line max-len
+                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
                 },
                 createTime: '2019-01-22T21:00:00.000Z',
                 creator: {
@@ -2191,6 +2193,15 @@ describe('Pipeline Model', () => {
             };
             event2 = Object.assign({}, {
                 id: 1234,
+                commit: {
+                    author: {
+                        name: 'BatMan',
+                        username: 'batman'
+                    },
+                    message: 'Update package.json',
+                    // eslint-disable-next-line max-len
+                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
+                },
                 createTime: '2019-01-24T11:25:00.610Z',
                 sha: '14b920bef306eb1bde8ec0b6a32372eebecc6d0e',
                 getMetrics: sinon.stub().resolves([build21, build22])
@@ -2205,6 +2216,7 @@ describe('Pipeline Model', () => {
                 id: event1.id,
                 createTime: event1.createTime,
                 sha: event1.sha,
+                commit: event1.commit,
                 causeMessage: event1.causeMessage,
                 duration: duration1,
                 status: build12.status,
@@ -2215,6 +2227,7 @@ describe('Pipeline Model', () => {
                 id: event2.id,
                 createTime: event2.createTime,
                 sha: event2.sha,
+                commit: event2.commit,
                 causeMessage: event2.causeMessage,
                 duration: duration2,
                 status: build22.status,

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2290,6 +2290,58 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it.only('generates metrics by pagination if page is available but count', () => {
+            const eventListConfig = {
+                params: {
+                    pipelineId: 123,
+                    type: 'pipeline'
+                },
+                sort: 'ascending',
+                sortBy: 'id',
+                paginate: {
+                    page,
+                    count: undefined
+                },
+                readOnly: true
+            };
+
+            eventFactoryMock.list.resolves([event1, event0, event2]);
+
+            return pipeline.getMetrics({ page }).then((result) => {
+                assert.calledWith(eventFactoryMock.list, eventListConfig);
+                assert.calledOnce(event0.getMetrics);
+                assert.calledOnce(event2.getMetrics);
+                assert.calledOnce(event1.getMetrics);
+                assert.deepEqual(result, metrics);
+            });
+        });
+
+        it.only('generates metrics by pagination if count is available but page', () => {
+            const eventListConfig = {
+                params: {
+                    pipelineId: 123,
+                    type: 'pipeline'
+                },
+                sort: 'ascending',
+                sortBy: 'id',
+                paginate: {
+                    page: undefined,
+                    count
+                },
+                readOnly: true
+            };
+
+            eventFactoryMock.list.resolves([event1, event0, event2]);
+
+            return pipeline.getMetrics({ count }).then((result) => {
+                assert.calledWith(eventFactoryMock.list, eventListConfig);
+                assert.calledOnce(event0.getMetrics);
+                assert.calledOnce(event2.getMetrics);
+                assert.calledOnce(event1.getMetrics);
+                assert.deepEqual(result, metrics);
+            });
+        });
+
         describe('aggregate metrics', () => {
             const RewirePipelineModel = rewire('../../lib/pipeline');
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2160,9 +2160,7 @@ describe('Pipeline Model', () => {
                         name: 'BatMan',
                         username: 'batman'
                     },
-                    message: 'Update screwdriver.yaml',
-                    // eslint-disable-next-line max-len
-                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
+                    message: 'Update screwdriver.yaml'
                 },
                 createTime: '2019-01-22T21:00:00.000Z',
                 creator: {
@@ -2193,15 +2191,6 @@ describe('Pipeline Model', () => {
             };
             event2 = Object.assign({}, {
                 id: 1234,
-                commit: {
-                    author: {
-                        name: 'BatMan',
-                        username: 'batman'
-                    },
-                    message: 'Update package.json',
-                    // eslint-disable-next-line max-len
-                    url: 'https://github.com/Code-Beast/models/commit/14b920bef306eb1bde8ec0b6a32372eebecc6d0e'
-                },
                 createTime: '2019-01-24T11:25:00.610Z',
                 sha: '14b920bef306eb1bde8ec0b6a32372eebecc6d0e',
                 getMetrics: sinon.stub().resolves([build21, build22])
@@ -2216,7 +2205,6 @@ describe('Pipeline Model', () => {
                 id: event1.id,
                 createTime: event1.createTime,
                 sha: event1.sha,
-                commit: event1.commit,
                 causeMessage: event1.causeMessage,
                 duration: duration1,
                 status: build12.status,
@@ -2227,7 +2215,6 @@ describe('Pipeline Model', () => {
                 id: event2.id,
                 createTime: event2.createTime,
                 sha: event2.sha,
-                commit: event2.commit,
                 causeMessage: event2.causeMessage,
                 duration: duration2,
                 status: build22.status,

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2290,7 +2290,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it.only('generates metrics by pagination if page is available but count', () => {
+        it('generates metrics by pagination if page is available but count', () => {
             const eventListConfig = {
                 params: {
                     pipelineId: 123,
@@ -2316,7 +2316,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it.only('generates metrics by pagination if count is available but page', () => {
+        it('generates metrics by pagination if count is available but page', () => {
             const eventListConfig = {
                 params: {
                     pipelineId: 123,


### PR DESCRIPTION
## Context
The way pagination works need to be more consistent throughout the code base.

## Objective
Make pipeline model fetch metrics by pagination when either page or count is available in the config.

## References
[399](https://github.com/screwdriver-cd/models/pull/399)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
