### PR TITLE
fix: use name.value instead of name for parameters

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -244,17 +244,19 @@ function createBuilds(config) {
             if (typeof val === 'object') {
                 defaultParameterValue = val.value;
             }
-            allowedParameters[name] = defaultParameterValue;
 
+            allowedParameters[name] = { value: defaultParameterValue };
             if (pipelineConfig.meta.parameters) {
-                const actualParameterValue = pipelineConfig.meta.parameters[name];
+                let actualParameterValue = pipelineConfig.meta.parameters[name];
 
-                // handle input as 0, false and other intented falsy value as user input
+                if (typeof actualParameterValue === 'object') {
+                    actualParameterValue = actualParameterValue.value;
+                }
+
                 if (actualParameterValue !== undefined) {
-                    allowedParameters[name] = actualParameterValue;
+                    allowedParameters[name] = { value: actualParameterValue };
                 }
             }
-
         });
 
         if (pipelineConfig.meta) {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -12,8 +12,6 @@ const {
 } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const winston = require('winston');
-const _ = require('lodash');
-
 let instance;
 
 /**
@@ -236,15 +234,34 @@ function createBuilds(config) {
         return null;
     }
 
-    // enable pipeline parameters feature
-    if (pipeline.parameters && pipelineConfig.meta && pipelineConfig.meta.parameters) {
-        const allowedPipelineParameters = _.keys(pipeline.parameters);
-        const currentPipelineParameters = _.assign({},
-            pipeline.parameters,
-            pipelineConfig.meta.parameters);
+    // enable pipeline parameters feature, if parameters exist in screwdriver.yaml
+    if (pipeline.parameters) {
+        const allowedParameters = Object.create(null);
 
-        pipelineConfig.meta.parameters = _.pick(currentPipelineParameters,
-            allowedPipelineParameters);
+        Object.entries(pipeline.parameters).forEach(([name, val]) => {
+            let defaultParameterValue = val;
+
+            if (typeof val === 'object') {
+                defaultParameterValue = val.value;
+            }
+            allowedParameters[name] = defaultParameterValue;
+
+            if (pipelineConfig.meta.parameters) {
+                const actualParameterValue = pipelineConfig.meta.parameters[name];
+
+                // handle input as 0, false and other intented falsy value as user input
+                if (actualParameterValue !== undefined) {
+                    allowedParameters[name] = actualParameterValue;
+                }
+            }
+
+        });
+
+        if (pipelineConfig.meta) {
+            Object.assign(pipelineConfig.meta, { parameters: allowedParameters });
+        } else {
+            pipelineConfig.meta = { parameters: allowedParameters };
+        }
     }
 
     return Promise.all([

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1525,7 +1525,7 @@ describe('Event Factory', () => {
             syncedPipelineMock.update = sinon.stub().resolves(fixedPipelineConfig);
 
             return eventFactory.create(config).then((model) => {
-                assert.equal(model.meta.parameters.user, 'actualValue');
+                assert.equal(model.meta.parameters.user.value, 'actualValue');
             });
         });
 
@@ -1547,7 +1547,7 @@ describe('Event Factory', () => {
             syncedPipelineMock.update = sinon.stub().resolves(fixedPipelineConfig);
 
             return eventFactory.create(config).then((model) => {
-                assert.equal(model.meta.parameters.user, 'originalValue');
+                assert.equal(model.meta.parameters.user.value, 'originalValue');
             });
         });
     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

For this PR, unify the way of parameters defined in the screwdriver and used in the backend. For example:

Before

```
parameters: 
  p1: 'a'
  p2: 
    value: 'b'
    description: 'b description'
```

You can get value 

```
echo $(meta get parameters.p1) # a
echo $(meta get parameters.p2) # object 
```

After

```
echo $(meta get parameters.p1.value) # a
echo $(meta get parameters.p2.value) # b
```

`p1` 
```
parameters: 
  p1: 'a'
```

is now a shorthand of 

```
parameters: 
  p1: 
    value: 'a'
    description: ''
```

and users must use `parameter.name.value` to get its `value`

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR implements above behavior

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
