### PR TITLE
fix(1801): update collection when removing pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1184,7 +1184,8 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Remove all jobs & builds associated with this pipeline and the pipeline itself
+     * Remove all jobs & builds associated with this pipeline,
+     * remove id from all associated collection and the pipeline itself
      * @return {Promise}        Resolves to null if remove successfully
      */
     remove() {
@@ -1253,6 +1254,32 @@ class PipelineModel extends BaseModel {
                 });
         });
 
+        const removeFromCollections = (() => {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const CollectionFactory = require('./collectionFactory');
+            /* eslint-enable global-require */
+
+            const collectionFactory = CollectionFactory.getInstance();
+            const search = {
+                field: 'pipelineIds',
+                keyword: `%${this.id}%`
+            };
+
+            return collectionFactory.list({ search })
+                .then((collections) => {
+                    const filteredCollections = collections.filter(collection =>
+                        collection.pipelineIds.includes(this.id));
+
+                    return Promise.all(filteredCollections.map((collection) => {
+                        collection.pipelineIds.splice(collection.pipelineIds.indexOf(this.id), 1);
+
+                        return collection.update();
+                    }));
+                });
+        });
+
         return this.secrets
             .then((secrets) => { // remove secrets
                 const filteredSecrets = secrets.filter(secret => secret.pipelineId === this.id);
@@ -1266,6 +1293,7 @@ class PipelineModel extends BaseModel {
             .then(() => removeEvents('pipeline')) // remove pipeline events
             .then(() => removeEvents('pr')) // remove pr events
             .then(() => removeChildPipelines()) // remove pr events
+            .then(() => removeFromCollections())
             .then(() => super.remove()); // remove pipeline
     }
 


### PR DESCRIPTION
## Context

currently we do not update associated collections when we remove a pipeline, resulting error in some of our api

## Objective

add collection clean up in pipeline remove() method

## References

https://github.com/screwdriver-cd/screwdriver/issues/1801

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
