### PR TITLE
fix: enable overriding metrics information sort order

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1326,10 +1326,11 @@ class PipelineModel extends BaseModel {
                     page: config.page,
                     count: config.count
                 };
+                options.sort = 'descending';
             }
 
             const events = await this.getEvents(options);
-            const metrics = await Promise.all(events.map(async (e) => {
+            const metrics = await Promise.all(events.reverse().map(async (e) => {
                 const { id, createTime, causeMessage, sha, commit } = e;
                 const m = await eventMetrics(e);
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1310,7 +1310,7 @@ class PipelineModel extends BaseModel {
         const options = {
             startTime: config.startTime,
             endTime: config.endTime,
-            sort: 'ascending',
+            sort: config.sort || 'ascending',
             sortBy: 'id',
             paginate: {
                 page: DEFAULT_PAGE,
@@ -1326,11 +1326,10 @@ class PipelineModel extends BaseModel {
                     page: config.page,
                     count: config.count
                 };
-                options.sort = 'descending';
             }
 
             const events = await this.getEvents(options);
-            const metrics = await Promise.all(events.reverse().map(async (e) => {
+            const metrics = await Promise.all(events.map(async (e) => {
                 const { id, createTime, causeMessage, sha, commit } = e;
                 const m = await eventMetrics(e);
 


### PR DESCRIPTION
## Context

Allow caller to specific sort order

## Objective

With collections card view, the data it's currently showing is from the beginning of the pipeline. UI should call it with descending sort order and then change the order to display time series of events.



## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
