### PR TITLE
fix: Sort metrics descendingly before returning

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1322,10 +1322,13 @@ class PipelineModel extends BaseModel {
         if (!config.aggregateInterval || config.aggregateInterval === 'none') {
             // If fetching events by page and count, update them according to config
             if (config.page || config.count) {
-                options.paginate = {
-                    page: config.page,
-                    count: config.count
-                };
+                Object.assign(options, {
+                    sort: 'descending',
+                    paginate: {
+                        page: config.page,
+                        count: config.count
+                    }
+                });
             }
 
             const events = await this.getEvents(options);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2308,7 +2308,7 @@ describe('Pipeline Model', () => {
                     pipelineId: 123,
                     type: 'pipeline'
                 },
-                sort: 'ascending',
+                sort: 'descending',
                 sortBy: 'id',
                 paginate: {
                     page,
@@ -2334,7 +2334,7 @@ describe('Pipeline Model', () => {
                     pipelineId: 123,
                     type: 'pipeline'
                 },
-                sort: 'ascending',
+                sort: 'descending',
                 sortBy: 'id',
                 paginate: {
                     page,
@@ -2360,7 +2360,7 @@ describe('Pipeline Model', () => {
                     pipelineId: 123,
                     type: 'pipeline'
                 },
-                sort: 'ascending',
+                sort: 'descending',
                 sortBy: 'id',
                 paginate: {
                     page: undefined,


### PR DESCRIPTION
## Context
Events-thumbnail components show outdated events info because of pipeline model sorts metrics ascendingly before returning them.

## Objective
Make pipeline model sort metrics descendingly when metrics are fetched by pagination so that it returns latest events info.

## References
[screwdriver feat(947)](https://github.com/screwdriver-cd/ui/pull/480)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
