### PR TITLE
fix(1801): update collection when removing pipeline take 2

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1273,7 +1273,11 @@ class PipelineModel extends BaseModel {
                         collection.pipelineIds.includes(this.id));
 
                     return Promise.all(filteredCollections.map((collection) => {
-                        collection.pipelineIds.splice(collection.pipelineIds.indexOf(this.id), 1);
+                        const newPipelineIds = collection.pipelineIds.filter(pipelineId =>
+                            pipelineId !== this.id);
+
+                        // Using a new array to mark pipelineIds dirty, otherwsie db won't update
+                        collection.pipelineIds = newPipelineIds;
 
                         return collection.update();
                     }));


### PR DESCRIPTION
## Context

in previous pull request, collection.pipelineIds was not mark dirty thus db is not actually updated

## Objective

assign new array to collection so collection.pipelineIds would be marked as dirty

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
