### PR TITLE
feat(1610): Add cleanup method in job factory

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -211,6 +211,13 @@ class BaseFactory {
     }
 
     /**
+     * Cleanup
+     */
+    cleanUp() {
+        // no-op when not implemted by extender
+    }
+
+    /**
      * Get an instance of a Factory
      * @method getInstance
      * @param  {Object}     ClassDef            Class definition of a factory

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -81,6 +81,13 @@ class JobFactory extends BaseFactory {
     }
 
     /**
+     * Cleanup any processing
+     */
+    async cleanUp() {
+        await this.executor.cleanUp();
+    }
+
+    /**
      * Get an instance of the JobFactory
      * @method getInstance
      * @param  {Object}     config

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -41,7 +41,8 @@ describe('Job Factory', () => {
             get: sinon.stub().resolves({ id: 9999 })
         };
         executor = {
-            startPeriodic: sinon.stub().resolves()
+            startPeriodic: sinon.stub().resolves(),
+            cleanUp: sinon.stub().resolves()
         };
         apiUri = 'https://notify.com/some/endpoint';
 
@@ -226,6 +227,14 @@ describe('Job Factory', () => {
 
         it('should throw when config not supplied', () => {
             assert.throw(JobFactory.getInstance, Error, 'No datastore provided to JobFactory');
+        });
+    });
+
+    describe('cleanUp', () => {
+        it('should call cleanUp', () => {
+            factory.cleanUp().then(() => {
+                assert.calledWith(executor.cleanUp);
+            });
         });
     });
 });


### PR DESCRIPTION
## Context

Currently when the node process terminates it happens abruptly and the in process messages are lost

## Objective

This PR adds a cleanup function

## References

https://github.com/screwdriver-cd/screwdriver/issues/1610

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
