### PR TITLE
feat(1830): build cache to disk

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -3,7 +3,7 @@
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const imageParser = require('docker-parse-image');
-const getBuildClusterName = require('./helper').getBuildClusterName;
+const helper = require('./helper');
 const hoek = require('hoek');
 let instance;
 
@@ -229,7 +229,7 @@ class BuildFactory extends BaseFactory {
                     let buildClusterName;
 
                     if (String(this.multiBuildClusterEnabled) === 'true') {
-                        buildClusterName = await getBuildClusterName({
+                        buildClusterName = await helper.getBuildClusterName({
                             annotations,
                             pipeline
                         });

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -3,85 +3,9 @@
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const imageParser = require('docker-parse-image');
-const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+const getBuildClusterName = require('./helper').getBuildClusterName;
 const hoek = require('hoek');
 let instance;
-
-/**
- * Pick a random cluster from the array based on their weightage
- * @method getRandomCluster
- * @param  {Array}          clusters    An array of build clusters
- * @return {String}                     Name of the picked cluster
- */
-function getRandomCluster(clusters) {
-    // Add up all the weightage, and generate a random number between (0, totalWeight - 1)
-    const totalWeight = clusters.reduce((prev, cur) => prev + cur.weightage, 0);
-    const number = Math.floor(Math.random() * totalWeight);
-    let sum = 0;
-
-    for (let i = 0; i < clusters.length; i += 1) {
-        sum += clusters[i].weightage;
-
-        if (number < sum) return clusters[i].name;
-    }
-
-    return clusters[0].name;
-}
-
-/**
- * Get build cluster name based on annotations
- * @method getBuildClusterName
- * @param  {Object}         config
- * @param  {Object}         config.annotations              Annotations for the job
- * @param  {PipelineModel}  config.pipeline                 Pipeline model
- * @return {String}        Build cluster name
- */
-async function getBuildClusterName({ annotations, pipeline }) {
-    const buildClusterName = annotations[buildClusterAnnotation] || '';
-    // Lazy load factory dependency to prevent circular dependency issues
-    // https://nodejs.org/api/modules.html#modules_cycles
-    // eslint-disable-next-line global-require
-    const BuildClusterFactory = require('./buildClusterFactory');
-    const buildClusterFactory = BuildClusterFactory.getInstance();
-
-    if (!buildClusterName) {
-        return buildClusterFactory.list({
-            params: {
-                managedByScrewdriver: true,
-                isActive: true
-            }
-        }).then((buildClusters) => {
-            if (buildClusters.length === 0) {
-                return '';
-            }
-
-            return getRandomCluster(buildClusters);
-        });
-    }
-
-    return buildClusterFactory.get({
-        name: buildClusterName
-    }).then((buildCluster) => {
-        if (!buildCluster) {
-            // eslint-disable-next-line max-len
-            throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} does not exist.`);
-        }
-
-        // Check if this pipeline's org is authorized to use the build cluster
-        // pipeline name example: screwdriver-cd/ui
-        const regex = /^([^/]+)\/.*/;
-        const matched = pipeline.name.match(regex);
-        const org = matched ? matched[1] : '';
-
-        if (buildCluster.scmContext !== pipeline.scmContext
-            || (buildCluster.managedByScrewdriver === false
-                && !buildCluster.scmOrganizations.includes(org))) {
-            throw new Error('This pipeline is not authorized to use this build cluster.');
-        }
-
-        return buildCluster.name;
-    });
-}
 
 /**
  * Gathers a sha for the build

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -136,7 +136,9 @@ async function getBuildClusterName({ annotations, pipeline }) {
 
     if (!buildClusterName) {
         // get pipeline build cluster
-        buildClusterName = pipeline.annotations[buildClusterAnnotation] || '';
+        if (pipeline.annotations) {
+            buildClusterName = pipeline.annotations[buildClusterAnnotation] || '';
+        }
         if (!buildClusterName) {
             return buildClusterFactory.list({
                 params: {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const schema = require('screwdriver-data-schema');
+const hoek = require('hoek');
 const dayjs = require('dayjs');
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
-const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 
 /**
  * Get the value of the annotation that matches name
@@ -128,16 +128,23 @@ function getRandomCluster(clusters) {
  * @return {String}        Build cluster name
  */
 async function getBuildClusterName({ annotations, pipeline }) {
-    let buildClusterName = annotations[buildClusterAnnotation] || '';
+    const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+    const pipelineAnnotations = hoek.reach(pipeline, 'annotations', { default: {} });
+    let buildClusterName;
+
+    if (annotations) {
+        buildClusterName = annotations[buildClusterAnnotation] || '';
+    }
+
+    if (!buildClusterName && pipelineAnnotations) {
+        buildClusterName = pipelineAnnotations[buildClusterAnnotation] || '';
+    }
+
     // Lazy load factory dependency to prevent circular dependency issues
     // https://nodejs.org/api/modules.html#modules_cycles
     // eslint-disable-next-line global-require
     const BuildClusterFactory = require('./buildClusterFactory');
     const buildClusterFactory = BuildClusterFactory.getInstance();
-
-    if (!buildClusterName && pipeline.annotations && pipeline.annotations[buildClusterAnnotation]) {
-        buildClusterName = pipeline.annotations[buildClusterAnnotation] || '';
-    }
 
     if (!buildClusterName) {
         return buildClusterFactory.list({

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const schema = require('screwdriver-data-schema');
+const BuildClusterFactory = require('./buildClusterFactory');
+const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 const dayjs = require('dayjs');
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
@@ -97,8 +99,89 @@ async function getAllRecords(funcName, aggregateInterval, opts, resultArray, dat
         funcName, aggregateInterval, opts, resultArray, currentDate, currentIndex);
 }
 
+/**
+ * Pick a random cluster from the array based on their weightage
+ * @method getRandomCluster
+ * @param  {Array}          clusters    An array of build clusters
+ * @return {String}                     Name of the picked cluster
+ */
+function getRandomCluster(clusters) {
+    // Add up all the weightage, and generate a random number between (0, totalWeight - 1)
+    const totalWeight = clusters.reduce((prev, cur) => prev + cur.weightage, 0);
+    const number = Math.floor(Math.random() * totalWeight);
+    let sum = 0;
+
+    for (let i = 0; i < clusters.length; i += 1) {
+        sum += clusters[i].weightage;
+
+        if (number < sum) return clusters[i].name;
+    }
+
+    return clusters[0].name;
+}
+
+/**
+ * Get build cluster name based on annotations
+ * @method getBuildClusterName
+ * @param  {Object}         config
+ * @param  {Object}         config.annotations              Annotations for the job
+ * @param  {PipelineModel}  config.pipeline                 Pipeline model
+ * @return {String}        Build cluster name
+ */
+async function getBuildClusterName({ annotations, pipeline }) {
+    let buildClusterName = annotations[buildClusterAnnotation] || '';
+    // Lazy load factory dependency to prevent circular dependency issues
+    // https://nodejs.org/api/modules.html#modules_cycles
+    const buildClusterFactory = BuildClusterFactory.getInstance();
+
+    if (!buildClusterName) {
+        // get pipeline build cluster
+        buildClusterName = pipeline.annotations[buildClusterAnnotation] || '';
+        if (!buildClusterName) {
+            return buildClusterFactory.list({
+                params: {
+                    managedByScrewdriver: true,
+                    isActive: true
+                }
+            }).then((buildClusters) => {
+                if (buildClusters.length === 0) {
+                    return '';
+                }
+
+                return getRandomCluster(buildClusters);
+            });
+        }
+
+        return buildClusterName;
+    }
+
+    return buildClusterFactory.get({
+        name: buildClusterName
+    }).then((buildCluster) => {
+        if (!buildCluster) {
+            // eslint-disable-next-line max-len
+            throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} does not exist.`);
+        }
+
+        // Check if this pipeline's org is authorized to use the build cluster
+        // pipeline name example: screwdriver-cd/ui
+        const regex = /^([^/]+)\/.*/;
+        const matched = pipeline.name.match(regex);
+        const org = matched ? matched[1] : '';
+
+        if (buildCluster.scmContext !== pipeline.scmContext
+            || (buildCluster.managedByScrewdriver === false
+                && !buildCluster.scmOrganizations.includes(org))) {
+            throw new Error('This pipeline is not authorized to use this build cluster.');
+        }
+
+        return buildCluster.name;
+    });
+}
+
 module.exports = {
     getAnnotations,
     parseTemplateConfigName,
-    getAllRecords
+    getAllRecords,
+    getBuildClusterName
 };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const schema = require('screwdriver-data-schema');
-const BuildClusterFactory = require('./buildClusterFactory');
-const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 const dayjs = require('dayjs');
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
+const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 
 /**
  * Get the value of the annotation that matches name
@@ -132,29 +131,27 @@ async function getBuildClusterName({ annotations, pipeline }) {
     let buildClusterName = annotations[buildClusterAnnotation] || '';
     // Lazy load factory dependency to prevent circular dependency issues
     // https://nodejs.org/api/modules.html#modules_cycles
+    // eslint-disable-next-line global-require
+    const BuildClusterFactory = require('./buildClusterFactory');
     const buildClusterFactory = BuildClusterFactory.getInstance();
 
+    if (!buildClusterName && pipeline.annotations && pipeline.annotations[buildClusterAnnotation]) {
+        buildClusterName = pipeline.annotations[buildClusterAnnotation] || '';
+    }
+
     if (!buildClusterName) {
-        // get pipeline build cluster
-        if (pipeline.annotations) {
-            buildClusterName = pipeline.annotations[buildClusterAnnotation] || '';
-        }
-        if (!buildClusterName) {
-            return buildClusterFactory.list({
-                params: {
-                    managedByScrewdriver: true,
-                    isActive: true
-                }
-            }).then((buildClusters) => {
-                if (buildClusters.length === 0) {
-                    return '';
-                }
+        return buildClusterFactory.list({
+            params: {
+                managedByScrewdriver: true,
+                isActive: true
+            }
+        }).then((buildClusters) => {
+            if (buildClusters.length === 0) {
+                return '';
+            }
 
-                return getRandomCluster(buildClusters);
-            });
-        }
-
-        return buildClusterName;
+            return getRandomCluster(buildClusters);
+        });
     }
 
     return buildClusterFactory.get({

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1176,7 +1176,7 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Update the repository and branch
+     * Update the repository and branch and validate buildCluster annotation
      * @method update
      * @return {Promise}
      */
@@ -1192,19 +1192,14 @@ class PipelineModel extends BaseModel {
                 this.scmRepo = scmRepo;
                 this.name = scmRepo.name;
 
-                let buildClusterName;
                 const annotations = this.annotations;
                 const config = this;
 
                 if (String(this.multiBuildClusterEnabled) === 'true') {
-                    buildClusterName = await getBuildClusterName({
+                    await getBuildClusterName({
                         annotations,
                         config
                     });
-                }
-
-                if (buildClusterName) {
-                    this.buildClusterName = buildClusterName;
                 }
 
                 return super.update();

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1209,13 +1209,7 @@ class PipelineModel extends BaseModel {
                         }
                         this.annotations[buildClusterAnnotation] = buildClusterName;
                     }
-                } /* else {
-                    /* eslint no-lonely-if:
-                    if (this.annotations && this.annotations[buildClusterAnnotation]) {
-                        // eslint-disable-next-line max-len
-                        throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${this.annotations[buildClusterAnnotation]} does not exist.`);
-                    }
-                } */
+                }
 
                 return super.update();
             });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -11,6 +11,7 @@ const winston = require('winston');
 const dayjs = require('dayjs');
 const _ = require('lodash');
 const { getAllRecords } = require('./helper.js');
+const getBuildClusterName = require('./helper').getBuildClusterName;
 const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
@@ -1187,9 +1188,24 @@ class PipelineModel extends BaseModel {
                 scmContext: this.scmContext,
                 token
             }))
-            .then((scmRepo) => {
+            .then(async (scmRepo) => {
                 this.scmRepo = scmRepo;
                 this.name = scmRepo.name;
+
+                let buildClusterName;
+                const annotations = this.annotations;
+                const config = this;
+
+                if (String(this.multiBuildClusterEnabled) === 'true') {
+                    buildClusterName = await getBuildClusterName({
+                        annotations,
+                        config
+                    });
+                }
+
+                if (buildClusterName) {
+                    this.buildClusterName = buildClusterName;
+                }
 
                 return super.update();
             });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1209,13 +1209,13 @@ class PipelineModel extends BaseModel {
                         }
                         this.annotations[buildClusterAnnotation] = buildClusterName;
                     }
-                } else {
-                    /* eslint no-lonely-if: */
+                } /* else {
+                    /* eslint no-lonely-if:
                     if (this.annotations && this.annotations[buildClusterAnnotation]) {
                         // eslint-disable-next-line max-len
                         throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${this.annotations[buildClusterAnnotation]} does not exist.`);
                     }
-                }
+                } */
 
                 return super.update();
             });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -11,7 +11,6 @@ const winston = require('winston');
 const dayjs = require('dayjs');
 const _ = require('lodash');
 const { getAllRecords } = require('./helper.js');
-const getBuildClusterName = require('./helper').getBuildClusterName;
 const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
@@ -28,6 +27,8 @@ const logger = new (winston.Logger)({
         new (winston.transports.Console)({ timestamp: true })
     ]
 });
+const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+const helper = require('./helper');
 
 // Calculate event duration by using max endTime - min startTime of builds
 // that belong this event
@@ -225,6 +226,7 @@ class PipelineModel extends BaseModel {
     constructor(config) {
         super('pipeline', config);
         this.scmContext = config.scmContext;
+        this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
     }
 
     /**
@@ -278,7 +280,7 @@ class PipelineModel extends BaseModel {
         }
 
         return this.admin.then(user => user.unsealToken())
-            // fetch the screwdriver.yaml file
+        // fetch the screwdriver.yaml file
             .then((token) => {
                 const config = {
                     scmUri: this.scmUri,
@@ -347,13 +349,13 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-      * Go through the job list to archive/unarchive it and update job config if parsedConfig passed in
-      * @method _updateJobArchive
-      * @param  {Array}        jobList              List of job objects
-      * @param  {boolean}      archived             Archived value to update to
-      * @param  {Object}       [parsedConfig]       Parsed job configuration
-      * @return {Promise}
-      */
+     * Go through the job list to archive/unarchive it and update job config if parsedConfig passed in
+     * @method _updateJobArchive
+     * @param  {Array}        jobList              List of job objects
+     * @param  {boolean}      archived             Archived value to update to
+     * @param  {Object}       [parsedConfig]       Parsed job configuration
+     * @return {Promise}
+     */
     _updateJobArchive(jobList, archived, parsedConfig) {
         const jobsToUpdate = [];
 
@@ -634,7 +636,7 @@ class PipelineModel extends BaseModel {
             configPipelineId: this.id
         }).then((p) => {
             logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} ` +
-              `with pipelineId:${p.id}.`);
+                `with pipelineId:${p.id}.`);
         });
     }
 
@@ -756,7 +758,7 @@ class PipelineModel extends BaseModel {
                                 job.permutations = permutations;
                                 job.archived = false;
                                 jobsToSync.push(job.update());
-                            // if it's not in the yaml then archive it
+                                // if it's not in the yaml then archive it
                             } else if (!job.isPR()) {
                                 job.archived = true;
                                 jobsToSync.push(job.update());
@@ -826,7 +828,7 @@ class PipelineModel extends BaseModel {
      * Fetch the build admin
      * @property admin
      * @return {Promise}
-    */
+     */
     get admin() {
         delete this.admin;
 
@@ -844,9 +846,9 @@ class PipelineModel extends BaseModel {
     }
 
     /** Fetch a pipeline's tokens
-    /* @property tokens
-    /* @return {Promise}
-    */
+     /* @property tokens
+     /* @return {Promise}
+     */
     get tokens() {
         const listConfig = {
             params: {
@@ -962,7 +964,7 @@ class PipelineModel extends BaseModel {
      * Fetch all jobs that belong to this pipeline
      * @property jobs
      * @return {Promise}
-    */
+     */
     get jobs() {
         const listConfig = {
             params: {
@@ -995,7 +997,7 @@ class PipelineModel extends BaseModel {
      * Fetch all secrets that belong to this pipeline
      * @property secrets
      * @return Promise
-    */
+     */
     get secrets() {
         const listConfig = {
             params: {
@@ -1176,7 +1178,7 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Update the repository and branch and validate buildCluster annotation
+     * Update the repository and branch
      * @method update
      * @return {Promise}
      */
@@ -1192,14 +1194,29 @@ class PipelineModel extends BaseModel {
                 this.scmRepo = scmRepo;
                 this.name = scmRepo.name;
 
-                const annotations = this.annotations;
-                const config = this;
+                let annotations = {};
+                let buildClusterName;
+
+                if (this.annotations && this.annotations[buildClusterAnnotation]) {
+                    annotations = this.annotations;
+                }
 
                 if (String(this.multiBuildClusterEnabled) === 'true') {
-                    await getBuildClusterName({
+                    buildClusterName = await helper.getBuildClusterName({
                         annotations,
-                        config
+                        pipeline: this
                     });
+                }
+
+                if (buildClusterName) {
+                    if (this.annotations &&
+                        (this.annotations[buildClusterAnnotation] === '' ||
+                            this.annotations[buildClusterAnnotation])) {
+                        this.annotations[buildClusterAnnotation] = buildClusterName;
+                    } else {
+                        this.annotations =
+                            { 'screwdriver.cd/buildCluster': buildClusterName };
+                    }
                 }
 
                 return super.update();
@@ -1401,7 +1418,7 @@ class PipelineModel extends BaseModel {
      * Fetch the value of prChain via chainPR property.
      * @property chainPR
      * @return {boolean}
-    */
+     */
     get chainPR() {
         return this.prChain;
     }
@@ -1409,7 +1426,7 @@ class PipelineModel extends BaseModel {
     /**
      * Set the value of prChain via chainPR property.
      * @property chainPR
-    */
+     */
     set chainPR(chainPR) {
         this.prChain = chainPR;
     }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -27,7 +27,6 @@ const logger = new (winston.Logger)({
         new (winston.transports.Console)({ timestamp: true })
     ]
 });
-const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 const helper = require('./helper');
 
 // Calculate event duration by using max endTime - min startTime of builds
@@ -1194,28 +1193,27 @@ class PipelineModel extends BaseModel {
                 this.scmRepo = scmRepo;
                 this.name = scmRepo.name;
 
-                let annotations = {};
                 let buildClusterName;
-
-                if (this.annotations && this.annotations[buildClusterAnnotation]) {
-                    annotations = this.annotations;
-                }
+                const annotations = hoek.reach(this, 'annotations', { default: {} });
+                const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 
                 if (String(this.multiBuildClusterEnabled) === 'true') {
                     buildClusterName = await helper.getBuildClusterName({
                         annotations,
                         pipeline: this
                     });
-                }
 
-                if (buildClusterName) {
-                    if (this.annotations &&
-                        (this.annotations[buildClusterAnnotation] === '' ||
-                            this.annotations[buildClusterAnnotation])) {
+                    if (buildClusterName) {
+                        if (!this.annotations) {
+                            this.annotations = {};
+                        }
                         this.annotations[buildClusterAnnotation] = buildClusterName;
-                    } else {
-                        this.annotations =
-                            { 'screwdriver.cd/buildCluster': buildClusterName };
+                    }
+                } else {
+                    /* eslint no-lonely-if: */
+                    if (this.annotations && this.annotations[buildClusterAnnotation]) {
+                        // eslint-disable-next-line max-len
+                        throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${this.annotations[buildClusterAnnotation]} does not exist.`);
                     }
                 }
 

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const hoek = require('hoek');
 const BaseFactory = require('./baseFactory');
 const Pipeline = require('./pipeline');
-const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 const helper = require('./helper');
 let instance;
 
@@ -71,28 +71,28 @@ class PipelineFactory extends BaseFactory {
                 modelConfig.scmRepo = scmRepo;
                 modelConfig.name = scmRepo.name;
 
-                let annotations = {};
                 let buildClusterName;
-
-                if (modelConfig.annotations && modelConfig.annotations[buildClusterAnnotation]) {
-                    annotations = modelConfig.annotations;
-                }
+                const annotations = hoek.reach(modelConfig, 'annotations', { default: {} });
+                const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 
                 if (String(this.multiBuildClusterEnabled) === 'true') {
                     buildClusterName = await helper.getBuildClusterName({
                         annotations,
                         pipeline: modelConfig
                     });
-                }
 
-                if (buildClusterName) {
-                    if (modelConfig.annotations &&
-                        (modelConfig.annotations[buildClusterAnnotation] === '' ||
-                            modelConfig.annotations[buildClusterAnnotation])) {
+                    if (buildClusterName) {
+                        if (!modelConfig.annotations) {
+                            modelConfig.annotations = {};
+                        }
                         modelConfig.annotations[buildClusterAnnotation] = buildClusterName;
-                    } else {
-                        modelConfig.annotations =
-                            { 'screwdriver.cd/buildCluster': buildClusterName };
+                    }
+                } else {
+                    /* eslint no-lonely-if: */
+                    if (modelConfig.annotations &&
+                        modelConfig.annotations[buildClusterAnnotation]) {
+                        // eslint-disable-next-line max-len
+                        throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${modelConfig.annotations[buildClusterAnnotation]} does not exist.`);
                     }
                 }
 

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -80,10 +80,6 @@ class PipelineFactory extends BaseFactory {
                     });
                 }
 
-                if (buildClusterName) {
-                    modelConfig.buildClusterName = buildClusterName;
-                }
-
                 return super.create(modelConfig);
             });
     }

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -2,7 +2,8 @@
 
 const BaseFactory = require('./baseFactory');
 const Pipeline = require('./pipeline');
-const getBuildClusterName = require('./helper').getBuildClusterName;
+const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+const helper = require('./helper');
 let instance;
 
 class PipelineFactory extends BaseFactory {
@@ -11,13 +12,13 @@ class PipelineFactory extends BaseFactory {
      * @method constructor
      * @param  {Object}    config
      * @param  {Object}    config.datastore         Object that will perform operations on the datastore
-     * @param  {Boolean}   config.externalJoin      Flag to allow external join
      * @param  {Boolean}   config.multiBuildClusterEnabled  Enable multiple build cluster feature or not
+     * @param  {Boolean}   config.externalJoin      Flag to allow external join
      */
     constructor(config) {
         super('pipeline', config);
-        this.externalJoin = config.externalJoin || false;
         this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
+        this.externalJoin = config.externalJoin || false;
     }
 
     /**
@@ -70,14 +71,29 @@ class PipelineFactory extends BaseFactory {
                 modelConfig.scmRepo = scmRepo;
                 modelConfig.name = scmRepo.name;
 
+                let annotations = {};
                 let buildClusterName;
-                const annotations = config.annotations;
+
+                if (modelConfig.annotations && modelConfig.annotations[buildClusterAnnotation]) {
+                    annotations = modelConfig.annotations;
+                }
 
                 if (String(this.multiBuildClusterEnabled) === 'true') {
-                    buildClusterName = await getBuildClusterName({
+                    buildClusterName = await helper.getBuildClusterName({
                         annotations,
-                        config
+                        pipeline: modelConfig
                     });
+                }
+
+                if (buildClusterName) {
+                    if (modelConfig.annotations &&
+                        (modelConfig.annotations[buildClusterAnnotation] === '' ||
+                            modelConfig.annotations[buildClusterAnnotation])) {
+                        modelConfig.annotations[buildClusterAnnotation] = buildClusterName;
+                    } else {
+                        modelConfig.annotations =
+                            { 'screwdriver.cd/buildCluster': buildClusterName };
+                    }
                 }
 
                 return super.create(modelConfig);

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -2,6 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Pipeline = require('./pipeline');
+const getBuildClusterName = require('./helper').getBuildClusterName;
 let instance;
 
 class PipelineFactory extends BaseFactory {
@@ -11,10 +12,12 @@ class PipelineFactory extends BaseFactory {
      * @param  {Object}    config
      * @param  {Object}    config.datastore         Object that will perform operations on the datastore
      * @param  {Boolean}   config.externalJoin      Flag to allow external join
+     * @param  {Boolean}   config.multiBuildClusterEnabled  Enable multiple build cluster feature or not
      */
     constructor(config) {
         super('pipeline', config);
         this.externalJoin = config.externalJoin || false;
+        this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
     }
 
     /**
@@ -63,9 +66,23 @@ class PipelineFactory extends BaseFactory {
                 scmContext: config.scmContext,
                 token
             }))
-            .then((scmRepo) => {
+            .then(async (scmRepo) => {
                 modelConfig.scmRepo = scmRepo;
                 modelConfig.name = scmRepo.name;
+
+                let buildClusterName;
+                const annotations = config.annotations;
+
+                if (String(this.multiBuildClusterEnabled) === 'true') {
+                    buildClusterName = await getBuildClusterName({
+                        annotations,
+                        config
+                    });
+                }
+
+                if (buildClusterName) {
+                    modelConfig.buildClusterName = buildClusterName;
+                }
 
                 return super.create(modelConfig);
             });

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -87,14 +87,14 @@ class PipelineFactory extends BaseFactory {
                         }
                         modelConfig.annotations[buildClusterAnnotation] = buildClusterName;
                     }
-                } else {
-                    /* eslint no-lonely-if: */
+                } /* else {
+                    /* eslint no-lonely-if:
                     if (modelConfig.annotations &&
                         modelConfig.annotations[buildClusterAnnotation]) {
                         // eslint-disable-next-line max-len
                         throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${modelConfig.annotations[buildClusterAnnotation]} does not exist.`);
                     }
-                }
+                } */
 
                 return super.create(modelConfig);
             });

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -87,14 +87,7 @@ class PipelineFactory extends BaseFactory {
                         }
                         modelConfig.annotations[buildClusterAnnotation] = buildClusterName;
                     }
-                } /* else {
-                    /* eslint no-lonely-if:
-                    if (modelConfig.annotations &&
-                        modelConfig.annotations[buildClusterAnnotation]) {
-                        // eslint-disable-next-line max-len
-                        throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${modelConfig.annotations[buildClusterAnnotation]} does not exist.`);
-                    }
-                } */
+                }
 
                 return super.create(modelConfig);
             });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "jenkins-mocha --recursive --timeout 5000",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -2,70 +2,26 @@
 
 const assert = require('chai').assert;
 const mockery = require('mockery');
-const hoek = require('hoek');
-const schema = require('screwdriver-data-schema');
 const sinon = require('sinon');
-let startStub;
-let getStepsStub;
+
+class Base {
+    constructor(config) {
+        this.scm = config.scm;
+        this.datastore = config.datastore;
+    }
+}
+class BF {}
+const baseId = 135323;
+const createMock = c => new Base(c);
 
 sinon.assert.expose(assert, { prefix: '' });
 
-class Build {
-    constructor(config) {
-        this.jobId = config.id;
-        this.number = config.number;
-        this.container = config.container;
-        this.executor = config.executor;
-        this.apiUri = config.apiUri;
-        this.tokenGen = config.tokenGen;
-        this.uiUri = config.uiUri;
-        this.steps = config.steps;
-        this.clusterEnv = config.clusterEnv || {};
-        this.start = startStub.resolves(this);
-        this.getSteps = getStepsStub;
-    }
-}
-
-describe('Build Factory', () => {
-    let bookendMock;
-    let BuildFactory;
+describe('Base Factory', () => {
+    let BaseFactory;
     let datastore;
-    let executor;
-    let jobFactoryMock;
-    let userFactoryMock;
-    let stepFactoryMock;
-    let buildClusterFactoryMock;
-    let scmMock;
+    let scm;
     let factory;
-    let jobFactory;
-    let stepFactory;
-    let buildClusterFactory;
-    const apiUri = 'https://notify.com/some/endpoint';
-    const tokenGen = sinon.stub();
-    const uiUri = 'http://display.com/some/endpoint';
-    const clusterEnv = { CLUSTER_FOO: 'bar' };
-    const steps = [
-        { name: 'sd-setup-launcher' },
-        { name: 'sd-setup-scm', command: 'git clone' },
-        { command: 'npm install', name: 'init' },
-        { command: 'npm test', name: 'test' }
-    ];
-    const scmContext = 'github: github.com';
-    const sdBuildClusters = [{
-        name: 'sd1',
-        managedByScrewdriver: true,
-        isActive: true,
-        scmContext,
-        scmOrganizations: [],
-        weightage: 100
-    }];
-    const externalBuildCluster = {
-        name: 'iOS',
-        managedByScrewdriver: false,
-        isActive: true,
-        scmContext,
-        scmOrganizations: ['screwdriver']
-    };
+    let schema;
 
     before(() => {
         mockery.enable({
@@ -75,75 +31,28 @@ describe('Build Factory', () => {
     });
 
     beforeEach(() => {
-        bookendMock = {
-            getSetupCommands: sinon.stub(),
-            getTeardownCommands: sinon.stub()
-        };
-        executor = {};
+        scm = {};
         datastore = {
-            get: sinon.stub(),
             save: sinon.stub(),
-            scan: sinon.stub()
-        };
-        jobFactoryMock = {
+            scan: sinon.stub(),
             get: sinon.stub()
         };
-        userFactoryMock = {
-            get: sinon.stub()
+        schema = {
+            models: {
+                base: {
+                    tableName: 'base',
+                    keys: ['foo'],
+                    allKeys: ['id', 'foo', 'bar']
+                }
+            }
         };
-        stepFactoryMock = {
-            create: sinon.stub().resolves({})
-        };
-        buildClusterFactoryMock = {
-            list: sinon.stub().resolves([]),
-            get: sinon.stub().resolves(externalBuildCluster)
-        };
-        scmMock = {
-            getCommitSha: sinon.stub(),
-            decorateCommit: sinon.stub(),
-            getCheckoutCommand: sinon.stub(),
-            getDisplayName: sinon.stub()
-        };
-        jobFactory = {
-            getInstance: sinon.stub().returns(jobFactoryMock)
-        };
-        stepFactory = {
-            getInstance: sinon.stub().returns(stepFactoryMock)
-        };
-        buildClusterFactory = {
-            getInstance: sinon.stub().returns(buildClusterFactoryMock)
-        };
-        startStub = sinon.stub();
-        getStepsStub = sinon.stub();
 
-        // Fixing mockery issue with duplicate file names
-        // by re-registering data-schema with its own implementation
         mockery.registerMock('screwdriver-data-schema', schema);
 
-        mockery.registerMock('screwdriver-build-bookend', bookendMock);
-
-        mockery.registerMock('./jobFactory', jobFactory);
-        mockery.registerMock('./stepFactory', stepFactory);
-        mockery.registerMock('./userFactory', {
-            getInstance: sinon.stub().returns(userFactoryMock)
-        });
-        mockery.registerMock('./buildClusterFactory', buildClusterFactory);
-        mockery.registerMock('./build', Build);
-
         // eslint-disable-next-line global-require
-        BuildFactory = require('../../lib/buildFactory');
+        BaseFactory = require('../../lib/baseFactory');
 
-        factory = new BuildFactory({
-            datastore,
-            executor,
-            scm: scmMock,
-            uiUri,
-            bookend: bookendMock,
-            clusterEnv,
-            multiBuildClusterEnabled: true
-        });
-        factory.apiUri = apiUri;
-        factory.tokenGen = tokenGen;
+        factory = new BaseFactory('base', { datastore, scm });
     });
 
     afterEach(() => {
@@ -156,796 +65,378 @@ describe('Build Factory', () => {
         mockery.disable();
     });
 
-    describe('constructor', () => {
-        it('constructs with a designated docker registry', () => {
-            factory = new BuildFactory({
-                datastore,
-                dockerRegistry: 'registry.com:1234',
-                executor,
-                scm: scmMock,
-                uiUri,
-                bookend: bookendMock
-            });
-
-            assert.strictEqual(factory.dockerRegistry, 'registry.com:1234');
-        });
-    });
-
     describe('createClass', () => {
-        it('should return a Build', () => {
-            const model = factory.createClass({});
-
-            assert.instanceOf(model, Build);
-            assert.deepEqual(model.executor, executor);
-            assert.strictEqual(model.apiUri, apiUri);
-            assert.deepEqual(model.tokenGen, tokenGen);
-            assert.strictEqual(model.uiUri, uiUri);
+        it('should throw when not overridden', () => {
+            assert.throws(factory.createClass, Error, 'must be implemented by extender');
         });
     });
 
     describe('create', () => {
-        let sandbox;
-        const jobId = 12345;
-        const eventId = 123456;
-        const sha = 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f';
-        const configPipelineSha = '63aa3d3058bc0886a8bf42567858e61a7310133c';
-        const scmUri = 'github.com:12345:master';
-        const scmRepo = {
-            name: 'screwdriver-cd/models'
-        };
-        const displayName = 'github';
-        const prRef = 'pull/3/merge';
-        const username = 'i_made_the_request';
-        const dateNow = Date.now();
-        const isoTime = (new Date(dateNow)).toISOString();
-        const container = 'node:4';
-        const environment = { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '4' };
-        const permutations = [{
-            commands: [
-                { command: 'npm install', name: 'init' },
-                { command: 'npm test', name: 'test' }
-            ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
-            image: 'node:4'
-        }, {
-            commands: [
-                { command: 'npm install', name: 'init' },
-                { command: 'npm test', name: 'test' }
-            ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
-            image: 'node:5'
-        }, {
-            commands: [
-                { command: 'npm install', name: 'init' },
-                { command: 'npm test', name: 'test' }
-            ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
-            image: 'node:6'
-        }];
-        const permutationsWithAnnotations = [{
-            annotations: {
-                'screwdriver.cd/buildCluster': 'iOS'
-            },
-            commands: [
-                { command: 'npm install', name: 'init' },
-                { command: 'npm test', name: 'test' }
-            ],
-            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
-            image: 'node:4'
-        }];
-
-        const commit = {
-            url: 'foo',
-            message: 'bar',
-            author: {
-                name: 'Batman',
-                username: 'batman',
-                url: 'stuff',
-                avatar: 'moreStuff'
+        const saveConfig = {
+            table: 'base',
+            params: {
+                foo: {
+                    key: 'foo',
+                    notkey: 'bar'
+                },
+                bar: false
             }
         };
 
-        const meta = {
-            foo: 'bar',
-            one: 1
-        };
-
-        steps.unshift({
-            name: 'sd-setup-init',
-            startTime: isoTime
-        });
-
-        let saveConfig;
-
         beforeEach(() => {
-            scmMock.getCommitSha.resolves(sha);
-            scmMock.decorateCommit.resolves(commit);
-            scmMock.getDisplayName.returns(displayName);
-            bookendMock.getSetupCommands.resolves([steps[2]]);
-            bookendMock.getTeardownCommands.resolves([]);
-            datastore.save.resolves({});
-
-            sandbox = sinon.createSandbox({
-                useFakeTimers: false
-            });
-            sandbox.useFakeTimers(dateNow);
-
-            jobFactoryMock.get.resolves({
-                permutations
-            });
-
-            saveConfig = {
-                table: 'builds',
-                params: {
-                    eventId,
-                    parentBuildId: 12345,
-                    cause: 'Started by user github:i_made_the_request',
-                    commit,
-                    createTime: isoTime,
-                    number: dateNow,
-                    status: 'QUEUED',
-                    container,
-                    environment,
-                    steps,
-                    jobId,
-                    sha,
-                    meta,
-                    stats: {}
-                }
-            };
+            factory.createClass = createMock;
         });
 
-        afterEach(() => {
-            sandbox.restore();
-        });
-
-        it('ignores extraneous parameters', () => {
-            const garbage = 'garbageData';
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+        it('creates a new "base" in the datastore', () => {
+            const expected = {
+                foo: {
+                    key: 'foo',
+                    notkey: 'bar'
+                },
+                bar: false,
+                id: baseId
             };
 
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
+            datastore.save.resolves(expected);
 
             return factory.create({
-                garbage, username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('do not set buildClusterName if multiBuildClusterEnabled is false', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations: permutationsWithAnnotations,
-                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
-            };
-
-            factory.multiBuildClusterEnabled = false;
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('multipleBuildClusterDisabled - do not set buildClusterName if pipeline ' +
-            'annotation has buildCluster ', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({
-                    name: 'screwdriver/ui',
-                    scmUri,
-                    scmRepo,
-                    scmContext,
-                    annotations: {
-                        'screwdriver.cd/buildCluster': 'sd1'
-                    }
-                })
-            };
-
-            factory.multiBuildClusterEnabled = false;
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('multipleBuildClusterDisabled - do not set buildClusterName if both pipeline ' +
-            'and build has buildCluster annotation', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations: permutationsWithAnnotations,
-                pipeline: Promise.resolve({
-                    name: 'screwdriver/ui',
-                    scmUri,
-                    scmRepo,
-                    scmContext,
-                    annotations: {
-                        'screwdriver.cd/buildCluster': 'sd1'
-                    }
-                })
-            };
-
-            factory.multiBuildClusterEnabled = false;
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('multipleBuildClusterEnabled - pick from pipeline annotation ' +
-            'if no annotation passed in', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({
-                    name: 'screwdriver/ui',
-                    scmUri,
-                    scmRepo,
-                    scmContext,
-                    annotations: {
-                        'screwdriver.cd/buildCluster': 'iOS'
-                    }
-                })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-            saveConfig.params.buildClusterName = 'iOS';
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('multipleBuildClusterEnabled - pick from build annotation ' +
-            'even if pipeline annotation is available', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations: permutationsWithAnnotations,
-                pipeline: Promise.resolve({
-                    name: 'screwdriver/ui',
-                    scmUri,
-                    scmRepo,
-                    scmContext,
-                    annotations: {
-                        'screwdriver.cd/buildCluster':
-                            'sd1'
-                    }
-                })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-            saveConfig.params.buildClusterName = 'iOS';
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('multipleBuildClusterEnabled - pick from build annotation ' +
-            'if build annotation passed in', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations: permutationsWithAnnotations,
-                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-            saveConfig.params.buildClusterName = 'iOS';
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('multipleBuildClusterEnabled - pick from screwdriver build cluster ' +
-            'if no annotation passed in', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-            saveConfig.params.buildClusterName = 'sd1';
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-                assert.ok(buildClusterFactory);
-            });
-        });
-
-        it('pick build cluster based on annotations passed in', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations: permutationsWithAnnotations,
-                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-            saveConfig.params.buildClusterName = 'iOS';
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).then(() => {
-                assert.callCount(stepFactoryMock.create, steps.length);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('throws err if the pipeline is unauthorized to use the build cluster', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations: permutationsWithAnnotations,
-                pipeline: Promise.resolve({ name: 'test/ui', scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-            saveConfig.params.buildClusterName = 'iOS';
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message,
-                    'This pipeline is not authorized to use this build cluster.');
-            });
-        });
-
-        it('throws err if the build cluster specified does not exist', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations: permutationsWithAnnotations,
-                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
-            };
-
-            buildClusterFactoryMock.get.resolves(null);
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            delete saveConfig.params.commit;
-
-            return factory.create({
-                username, jobId, eventId, sha, parentBuildId: 12345, meta
-            }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message,
-                    'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
-            });
-        });
-
-        it('use username as displayName if displayLabel is not set', () => {
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            scmMock.getDisplayName.returns(null);
-            saveConfig.params.cause = 'Started by user i_made_the_request';
-            delete saveConfig.params.commit;
-            delete saveConfig.params.parentBuildId;
-
-            return factory.create({
-                username, jobId, eventId, sha, meta
-            }).then(() => assert.calledWith(datastore.save, saveConfig));
-        });
-
-        it('creates a new build in the datastore, looking up sha', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const causeMessage = `Started by ${displayName}`;
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-
-            return factory.create({
-                username,
-                causeMessage,
-                scmContext,
-                jobId,
-                eventId,
-                prRef,
-                parentBuildId: 12345,
-                meta
+                foo: {
+                    key: 'foo',
+                    notkey: 'bar'
+                },
+                bar: false
             }).then((model) => {
-                assert.instanceOf(model, Build);
-                assert.calledOnce(jobFactory.getInstance);
-                assert.calledWith(jobFactoryMock.get, jobId);
-                assert.calledWith(userFactoryMock.get, { username, scmContext });
-                assert.calledWith(scmMock.getCommitSha, {
-                    token: 'foo',
-                    scmUri,
-                    scmContext
-                });
-                assert.calledWith(scmMock.decorateCommit, {
-                    token: 'foo',
-                    sha,
-                    scmUri,
-                    scmContext
-                });
-                assert.calledWith(bookendMock.getSetupCommands, {
-                    pipeline: { scmUri, scmRepo, scmContext },
-                    job: jobMock,
-                    build: sinon.match.object
-                });
-                assert.calledWith(bookendMock.getTeardownCommands, {
-                    pipeline: { scmUri, scmRepo, scmContext },
-                    job: jobMock,
-                    build: sinon.match.object
-                });
-                assert.calledOnce(startStub);
-                assert.calledWith(startStub, { causeMessage: 'Started by github' });
-                assert.calledWith(datastore.save, saveConfig);
+                assert.isTrue(datastore.save.calledWith(saveConfig));
+                assert.instanceOf(model, Base);
+                assert.deepEqual(model.datastore, datastore);
+                assert.deepEqual(model.scm, scm);
             });
         });
 
-        it('creates a new build in the datastore with causeMessage', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const causeMessage = '[force start] Push out hotfix';
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
+        it('rejects when a datastore save fails', () => {
+            const errorMessage = 'datastoreSaveFailureMessage';
 
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
+            datastore.save.rejects(new Error(errorMessage));
 
-            return factory.create({
-                username,
-                causeMessage,
-                scmContext,
-                jobId,
-                eventId,
-                prRef,
-                parentBuildId: 12345,
-                meta
-            }).then((model) => {
-                assert.instanceOf(model, Build);
-                assert.calledOnce(jobFactory.getInstance);
-                assert.calledWith(jobFactoryMock.get, jobId);
-                assert.calledWith(userFactoryMock.get, { username, scmContext });
-                assert.calledWith(scmMock.getCommitSha, {
-                    token: 'foo',
-                    scmUri,
-                    scmContext
+            return factory.create({ foo: 'foo', bar: 'bar' })
+                .then(() => {
+                    assert.fail('This should not fail the test');
+                })
+                .catch((err) => {
+                    assert.strictEqual(err.message, errorMessage);
                 });
-                assert.calledWith(scmMock.decorateCommit, {
-                    token: 'foo',
-                    sha,
-                    scmUri,
-                    scmContext
-                });
-                assert.calledWith(bookendMock.getSetupCommands, {
-                    pipeline: { scmUri, scmRepo, scmContext },
-                    job: jobMock,
-                    build: sinon.match.object
-                });
-                assert.calledWith(bookendMock.getTeardownCommands, {
-                    pipeline: { scmUri, scmRepo, scmContext },
-                    job: jobMock,
-                    build: sinon.match.object
-                });
-                assert.calledOnce(startStub);
-                assert.calledWith(startStub, { causeMessage });
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('creates a new build without starting', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            saveConfig.params.status = 'CREATED';
-
-            return factory.create({
-                username, jobId, eventId, parentBuildId: 12345, start: false, meta
-            }).then(() => {
-                assert.notCalled(startStub);
-                assert.calledWith(datastore.save, saveConfig);
-            });
-        });
-
-        it('adds a teardown command if one exists', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-            const teardown = {
-                name: 'sd-teardown',
-                command: 'echo "hello"'
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            bookendMock.getTeardownCommands.resolves([teardown]);
-            bookendMock.getSetupCommands.resolves([]);
-
-            const expectedSteps = steps.slice(0, 2).concat(steps.slice(3));
-
-            expectedSteps.push(teardown);
-
-            return factory.create({ username, jobId, eventId, prRef }).then((model) => {
-                assert.instanceOf(model, Build);
-                assert.deepEqual(model.steps, expectedSteps);
-            });
-        });
-
-        it('creates a new build in the datastore, without looking up sha', () => {
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            delete saveConfig.params.commit;
-            delete saveConfig.params.parentBuildId;
-
-            return factory.create({ username, jobId, eventId, sha, meta }).then((model) => {
-                assert.calledWith(datastore.save, saveConfig);
-                assert.instanceOf(model, Build);
-                assert.calledOnce(jobFactory.getInstance);
-                assert.calledWith(jobFactoryMock.get, jobId);
-                assert.calledOnce(startStub);
-            });
-        });
-
-        it('properly handles rejection due to missing job model', () => {
-            jobFactoryMock.get.resolves(null);
-
-            return factory.create({ username, jobId, eventId }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message, 'Job does not exist');
-            });
-        });
-
-        it('properly handles rejection due to missing user model', () => {
-            userFactoryMock.get.resolves(null);
-
-            return factory.create({ username, jobId, eventId }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message, 'User does not exist');
-            });
-        });
-
-        it('properly handles rejection due to missing pipeline model', () => {
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve(null)
-            };
-
-            userFactoryMock.get.resolves({});
-            jobFactoryMock.get.resolves(jobMock);
-
-            return factory.create({ username, jobId, eventId }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message, 'Pipeline does not exist');
-            });
-        });
-
-        it('creates a new build with a custom docker registry', () => {
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-
-            factory = new BuildFactory({
-                datastore,
-                dockerRegistry: 'registry.com:1234',
-                executor,
-                scm: scmMock,
-                uiUri,
-                bookend: bookendMock
-            });
-
-            jobFactoryMock.get.resolves(jobMock);
-
-            return factory.create({ username, jobId, eventId, sha }).then((model) => {
-                assert.strictEqual(model.container, 'registry.com:1234/library/node:4');
-            });
-        });
-
-        it('combines environment from input config', () => {
-            const user = { unsealToken: sinon.stub().resolves('foo') };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
-            };
-
-            jobFactoryMock.get.resolves(jobMock);
-            userFactoryMock.get.resolves(user);
-            saveConfig.params.status = 'CREATED';
-
-            return factory.create({
-                username,
-                jobId,
-                eventId,
-                parentBuildId: 12345,
-                start: false,
-                environment: { EXTRA: true },
-                meta
-            }).then(() => {
-                assert.notCalled(startStub);
-                saveConfig.params.environment = {
-                    CLUSTER_FOO: 'bar', EXTRA: true, NODE_ENV: 'test', NODE_VERSION: '4'
-                };
-                assert.calledWith(datastore.save, saveConfig);
-                delete saveConfig.params.environment.EXTRA;
-            });
-        });
-
-        it('passes in config pipeline to the bookend config', () => {
-            const pipelineMock = {
-                configPipelineId: 2,
-                configPipeline: Promise.resolve({ spooky: 'ghost' })
-            };
-            const jobMock = {
-                permutations,
-                pipeline: Promise.resolve(pipelineMock)
-            };
-
-            userFactoryMock.get.resolves({});
-            jobFactoryMock.get.resolves(jobMock);
-
-            return factory.create({
-                username,
-                jobId,
-                eventId,
-                sha,
-                configPipelineSha,
-                meta
-            }).then(() => {
-                assert.calledWith(bookendMock.getSetupCommands, {
-                    pipeline: pipelineMock,
-                    job: jobMock,
-                    build: sinon.match.object,
-                    configPipeline: { spooky: 'ghost' },
-                    configPipelineSha
-                });
-                assert.calledWith(bookendMock.getTeardownCommands, {
-                    pipeline: pipelineMock,
-                    job: jobMock,
-                    build: sinon.match.object,
-                    configPipeline: { spooky: 'ghost' },
-                    configPipelineSha
-                });
-            });
         });
     });
 
     describe('get', () => {
-        const buildId = 123;
-        const buildData = {
-            steps
+        const baseData = {
+            id: baseId,
+            foo: 'foo',
+            bar: 'bar'
         };
-        const stepsData = steps.map(step => Object.assign({ code: 0 }, step));
-        const stepsMock = stepsData.map((step) => {
-            const mock = hoek.clone(step);
 
-            mock.toJson = sinon.stub().returns(step);
-
-            return mock;
+        beforeEach(() => {
+            factory.createClass = createMock;
+            datastore.get.withArgs({
+                table: 'base',
+                params: {
+                    id: baseId
+                }
+            }).resolves(baseData);
+            datastore.get.withArgs({
+                table: 'base',
+                params: {
+                    foo: 'foo'
+                }
+            }).resolves(baseData);
         });
 
-        it('should get a build by ID without step models', () => {
-            getStepsStub.resolves([]);
-            datastore.get.resolves(buildData);
+        it('calls datastore get with id and returns correct values', () =>
+            factory.get(baseData.id)
+                .then((model) => {
+                    assert.instanceOf(model, Base);
+                    assert.isTrue(datastore.get.calledOnce);
+                    assert.deepEqual(model.datastore, datastore);
+                    assert.deepEqual(model.scm, scm);
+                })
+        );
 
-            return factory.get(buildId)
-                .then(build => assert.deepEqual(build.steps, steps));
+        it('calls datastore get with config.id and returns correct values', () =>
+            factory.get(baseData)
+                .then((model) => {
+                    assert.instanceOf(model, Base);
+                    assert.isTrue(datastore.get.calledOnce);
+                    assert.deepEqual(model.datastore, datastore);
+                    assert.deepEqual(model.scm, scm);
+                })
+        );
+
+        it('converts string id to a number', () =>
+            factory.get('135323')
+                .then((model) => {
+                    assert.instanceOf(model, Base);
+                    assert.isTrue(datastore.get.calledOnce);
+                    assert.deepEqual(model.datastore, datastore);
+                    assert.deepEqual(model.scm, scm);
+                })
+        );
+
+        it('calls datastore get with config object and returns correct values', () =>
+            factory.get({ foo: 'foo', bar: 'bar' })
+                .then((model) => {
+                    assert.instanceOf(model, Base);
+                    assert.isTrue(datastore.get.calledOnce);
+                    assert.deepEqual(model.datastore, datastore);
+                    assert.deepEqual(model.scm, scm);
+                })
+        );
+
+        it('returns null when datastore miss occurs', () => {
+            datastore.get.withArgs({
+                table: 'base',
+                params: {
+                    id: baseId
+                }
+            }).resolves(null);
+
+            return factory.get(baseData.id)
+                .then((model) => {
+                    assert.isNull(model);
+                });
         });
 
-        it('should get a build by ID with merged step data', () => {
-            getStepsStub.resolves(stepsMock);
-            datastore.get.resolves(buildData);
+        it('rejects with a failure from the datastore get', () => {
+            datastore.get.rejects(new Error('teehee'));
 
-            return factory.get(buildId)
-                .then(build => assert.deepEqual(build.steps, stepsData));
-        });
-
-        it('should not throw when build does not exist', () => {
-            datastore.get.resolves(null);
-
-            return factory.get(buildId)
-                .then(build => assert.deepEqual(build, null));
+            return factory.get('doesntMatter')
+                .then(() => {
+                    assert.fail('this shall not pass');
+                })
+                .catch((err) => {
+                    assert.strictEqual(err.message, 'teehee');
+                });
         });
     });
 
     describe('list', () => {
-        const buildData = {
-            steps
+        const paginate = {
+            page: 1,
+            count: 2
         };
-        const stepsData = steps.map(step => Object.assign({ code: 0 }, step));
-        const stepsMock = stepsData.map((step) => {
-            const mock = hoek.clone(step);
+        const returnValue = [
+            {
+                id: '151c9b11e4a9a27e9e374daca6e59df37d8cf00f',
+                name: 'component'
+            },
+            {
+                id: 123,
+                name: 'deploy'
+            }
+        ];
 
-            mock.toJson = sinon.stub().returns(step);
-
-            return mock;
+        beforeEach(() => {
+            factory.createClass = createMock;
+            datastore.scan.resolves(returnValue);
         });
 
-        it('should list builds without step models', () => {
-            getStepsStub.resolves([]);
-            datastore.scan.resolves([buildData, buildData]);
+        it('calls datastore scan', () =>
+            factory.list()
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {}
+                    });
+                })
+        );
 
-            return factory.list({})
-                .then((builds) => {
-                    builds.map(build => assert.deepEqual(build.steps, steps));
-                    assert.calledWithMatch(datastore.scan, { sortBy: 'createTime' });
+        it('calls datastore scan and returns correct values', () =>
+            factory.list({ paginate })
+                .then((arr) => {
+                    assert.isArray(arr);
+                    assert.equal(arr.length, 2);
+                    arr.forEach((model) => {
+                        assert.instanceOf(model, Base);
+                        assert.deepEqual(model.datastore, datastore);
+                        assert.deepEqual(model.scm, scm);
+                    });
+                })
+        );
+
+        it('does not set default values if none are passed in', () =>
+            factory.list({})
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {}
+                    });
+                })
+        );
+
+        it('sets default paginate values if some are passed in', () =>
+            factory.list({ paginate: { count: 20 } })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        paginate: {
+                            page: 1,
+                            count: 20
+                        }
+                    });
+                })
+        );
+
+        it('sets default paginate values if undefined is passed in', () =>
+            factory.list({ paginate: { page: undefined, count: undefined } })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        paginate: {
+                            page: 1,
+                            count: 50
+                        }
+                    });
+                })
+        );
+
+        it('sets sortBy value if it is passed in', () =>
+            factory.list({ sortBy: 'scmRepo.name' })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        sortBy: 'scmRepo.name'
+                    });
+                })
+        );
+
+        it('sets time range value if it is passed in', () => {
+            const startTime = '2019-02-01T18:33:42.461Z';
+            const endTime = '2019-02-11T18:33:42.461Z';
+            const timeKey = 'startTime';
+
+            return factory.list({ startTime, endTime, timeKey })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        startTime,
+                        endTime,
+                        timeKey
+                    });
                 });
         });
 
-        it('should list builds with merged step data if config.fetchSteps is true', () => {
-            getStepsStub.resolves(stepsMock);
-            datastore.scan.resolves([buildData, buildData]);
+        it('sets search values if they are passed in', () =>
+            factory.list({
+                search: {
+                    field: 'scmRepo',
+                    keyword: '%name%screwdriver-cd/screwdriver%'
+                }
+            })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        search: {
+                            field: 'scmRepo',
+                            keyword: '%name%screwdriver-cd/screwdriver%'
+                        }
+                    });
+                })
+        );
 
-            return factory.list({ fetchSteps: true })
-                .then(builds => builds.map(build => assert.deepEqual(build.steps, stepsData)));
+        it('calls datastore scan with sorting option returns correct values', () =>
+            factory.list({ paginate, sort: 'ascending' })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        paginate,
+                        sort: 'ascending'
+                    });
+                })
+        );
+
+        it('call datastore scan with exclude and groupBy options', () =>
+            factory.list({ exclude: ['unwanted_col'], groupBy: ['colA', 'colB'] })
+                .then(() =>
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        exclude: ['unwanted_col'],
+                        groupBy: ['colA', 'colB']
+                    })
+                )
+        );
+
+        it('call datastore scan with startTime and endTime options', () =>
+            factory.list({
+                startTime: '2019-01-20T22:28:35.039Z',
+                endTime: '2019-01-24T22:28:35.039Z'
+            }).then(() =>
+                assert.calledWith(datastore.scan, {
+                    table: 'base',
+                    params: {},
+                    startTime: '2019-01-20T22:28:35.039Z',
+                    endTime: '2019-01-24T22:28:35.039Z'
+                })
+            )
+        );
+
+        it('returns raw scan results when raw is true', () => {
+            const distinctRows = [
+                'namespace1',
+                'namespace2',
+                'namespace3'
+            ];
+
+            datastore.scan.resolves(distinctRows);
+
+            return factory.list({
+                params: {
+                    distinct: 'namespace'
+                },
+                raw: true
+            })
+                .then((data) => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {
+                            distinct: 'namespace'
+                        }
+                    });
+                    assert.deepEqual(data, [
+                        'namespace1',
+                        'namespace2',
+                        'namespace3'
+                    ]);
+                });
         });
 
-        it('should not list builds with merged step data by default', () => {
-            getStepsStub.resolves(stepsMock);
-            datastore.scan.resolves([buildData, buildData]);
+        it('handles when the scan does not return an array', () => {
+            datastore.scan.resolves(null);
 
-            return factory.list({})
-                .then(builds => builds.map(build => assert.deepEqual(build.steps, steps)));
+            return factory.list({ paginate })
+                .catch((err) => {
+                    assert.strictEqual(err.message, 'Unexpected response from datastore, ' +
+                        'expected Array, got object');
+                });
+        });
+
+        it('rejects with a failure from the datastore scan', () => {
+            const errorMessage = 'genericScanError';
+
+            datastore.scan.rejects(new Error(errorMessage));
+
+            return factory.list({ paginate })
+                .then(() => {
+                    assert.fail('this should not happen');
+                })
+                .catch((err) => {
+                    assert.strictEqual(err.message, errorMessage);
+                });
         });
     });
 
@@ -953,38 +444,28 @@ describe('Build Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, executor, scm: {}, uiUri, bookend: bookendMock };
+            config = { datastore, scm };
         });
 
-        it('should utilize BaseFactory to get an instance', () => {
-            const f1 = BuildFactory.getInstance(config);
-            const f2 = BuildFactory.getInstance(config);
-
-            assert.instanceOf(f1, BuildFactory);
-            assert.instanceOf(f2, BuildFactory);
+        it('should encapsulate new, and act as a singleton', () => {
+            // ClasDef, instance, config
+            const f1 = BaseFactory.getInstance(BF, null, config);
+            const f2 = BaseFactory.getInstance(BF, f1, config);
 
             assert.equal(f1, f2);
         });
 
-        it('should throw when config does not have everything necessary', () => {
-            assert.throw(BuildFactory.getInstance,
-                Error, 'No executor provided to BuildFactory');
+        it('should not require config on second call', () => {
+            const f1 = BaseFactory.getInstance(BF, null, config);
+            const f2 = BaseFactory.getInstance(BF, f1);
 
-            assert.throw(() => {
-                BuildFactory.getInstance({ executor, scm: {}, uiUri, bookend: bookendMock });
-            }, Error, 'No datastore provided to BuildFactory');
+            assert.equal(f1, f2);
+        });
 
+        it('should throw when config not supplied or does not supply all expected params', () => {
             assert.throw(() => {
-                BuildFactory.getInstance({ executor, datastore, uiUri, bookend: bookendMock });
-            }, Error, 'No scm plugin provided to BuildFactory');
-
-            assert.throw(() => {
-                BuildFactory.getInstance({ executor, scm: {}, datastore, bookend: bookendMock });
-            }, Error, 'No uiUri provided to BuildFactory');
-
-            assert.throw(() => {
-                BuildFactory.getInstance({ executor, scm: {}, datastore, uiUri });
-            }, Error, 'No bookend plugin provided to BuildFactory');
+                BaseFactory.getInstance(BF, null);
+            }, Error, 'No datastore provided to BF');
         });
     });
 });

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -2,26 +2,70 @@
 
 const assert = require('chai').assert;
 const mockery = require('mockery');
+const hoek = require('hoek');
+const schema = require('screwdriver-data-schema');
 const sinon = require('sinon');
-
-class Base {
-    constructor(config) {
-        this.scm = config.scm;
-        this.datastore = config.datastore;
-    }
-}
-class BF {}
-const baseId = 135323;
-const createMock = c => new Base(c);
+let startStub;
+let getStepsStub;
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('Base Factory', () => {
-    let BaseFactory;
+class Build {
+    constructor(config) {
+        this.jobId = config.id;
+        this.number = config.number;
+        this.container = config.container;
+        this.executor = config.executor;
+        this.apiUri = config.apiUri;
+        this.tokenGen = config.tokenGen;
+        this.uiUri = config.uiUri;
+        this.steps = config.steps;
+        this.clusterEnv = config.clusterEnv || {};
+        this.start = startStub.resolves(this);
+        this.getSteps = getStepsStub;
+    }
+}
+
+describe('Build Factory', () => {
+    let bookendMock;
+    let BuildFactory;
     let datastore;
-    let scm;
+    let executor;
+    let jobFactoryMock;
+    let userFactoryMock;
+    let stepFactoryMock;
+    let buildClusterFactoryMock;
+    let scmMock;
     let factory;
-    let schema;
+    let jobFactory;
+    let stepFactory;
+    let buildClusterFactory;
+    const apiUri = 'https://notify.com/some/endpoint';
+    const tokenGen = sinon.stub();
+    const uiUri = 'http://display.com/some/endpoint';
+    const clusterEnv = { CLUSTER_FOO: 'bar' };
+    const steps = [
+        { name: 'sd-setup-launcher' },
+        { name: 'sd-setup-scm', command: 'git clone' },
+        { command: 'npm install', name: 'init' },
+        { command: 'npm test', name: 'test' }
+    ];
+    const scmContext = 'github: github.com';
+    const sdBuildClusters = [{
+        name: 'sd1',
+        managedByScrewdriver: true,
+        isActive: true,
+        scmContext,
+        scmOrganizations: [],
+        weightage: 100
+    }];
+    const externalBuildCluster = {
+        name: 'iOS',
+        managedByScrewdriver: false,
+        isActive: true,
+        scmContext,
+        scmOrganizations: ['screwdriver']
+    };
 
     before(() => {
         mockery.enable({
@@ -31,28 +75,75 @@ describe('Base Factory', () => {
     });
 
     beforeEach(() => {
-        scm = {};
+        bookendMock = {
+            getSetupCommands: sinon.stub(),
+            getTeardownCommands: sinon.stub()
+        };
+        executor = {};
         datastore = {
+            get: sinon.stub(),
             save: sinon.stub(),
-            scan: sinon.stub(),
+            scan: sinon.stub()
+        };
+        jobFactoryMock = {
             get: sinon.stub()
         };
-        schema = {
-            models: {
-                base: {
-                    tableName: 'base',
-                    keys: ['foo'],
-                    allKeys: ['id', 'foo', 'bar']
-                }
-            }
+        userFactoryMock = {
+            get: sinon.stub()
         };
+        stepFactoryMock = {
+            create: sinon.stub().resolves({})
+        };
+        buildClusterFactoryMock = {
+            list: sinon.stub().resolves([]),
+            get: sinon.stub().resolves(externalBuildCluster)
+        };
+        scmMock = {
+            getCommitSha: sinon.stub(),
+            decorateCommit: sinon.stub(),
+            getCheckoutCommand: sinon.stub(),
+            getDisplayName: sinon.stub()
+        };
+        jobFactory = {
+            getInstance: sinon.stub().returns(jobFactoryMock)
+        };
+        stepFactory = {
+            getInstance: sinon.stub().returns(stepFactoryMock)
+        };
+        buildClusterFactory = {
+            getInstance: sinon.stub().returns(buildClusterFactoryMock)
+        };
+        startStub = sinon.stub();
+        getStepsStub = sinon.stub();
 
+        // Fixing mockery issue with duplicate file names
+        // by re-registering data-schema with its own implementation
         mockery.registerMock('screwdriver-data-schema', schema);
 
-        // eslint-disable-next-line global-require
-        BaseFactory = require('../../lib/baseFactory');
+        mockery.registerMock('screwdriver-build-bookend', bookendMock);
 
-        factory = new BaseFactory('base', { datastore, scm });
+        mockery.registerMock('./jobFactory', jobFactory);
+        mockery.registerMock('./stepFactory', stepFactory);
+        mockery.registerMock('./userFactory', {
+            getInstance: sinon.stub().returns(userFactoryMock)
+        });
+        mockery.registerMock('./buildClusterFactory', buildClusterFactory);
+        mockery.registerMock('./build', Build);
+
+        // eslint-disable-next-line global-require
+        BuildFactory = require('../../lib/buildFactory');
+
+        factory = new BuildFactory({
+            datastore,
+            executor,
+            scm: scmMock,
+            uiUri,
+            bookend: bookendMock,
+            clusterEnv,
+            multiBuildClusterEnabled: true
+        });
+        factory.apiUri = apiUri;
+        factory.tokenGen = tokenGen;
     });
 
     afterEach(() => {
@@ -65,378 +156,796 @@ describe('Base Factory', () => {
         mockery.disable();
     });
 
+    describe('constructor', () => {
+        it('constructs with a designated docker registry', () => {
+            factory = new BuildFactory({
+                datastore,
+                dockerRegistry: 'registry.com:1234',
+                executor,
+                scm: scmMock,
+                uiUri,
+                bookend: bookendMock
+            });
+
+            assert.strictEqual(factory.dockerRegistry, 'registry.com:1234');
+        });
+    });
+
     describe('createClass', () => {
-        it('should throw when not overridden', () => {
-            assert.throws(factory.createClass, Error, 'must be implemented by extender');
+        it('should return a Build', () => {
+            const model = factory.createClass({});
+
+            assert.instanceOf(model, Build);
+            assert.deepEqual(model.executor, executor);
+            assert.strictEqual(model.apiUri, apiUri);
+            assert.deepEqual(model.tokenGen, tokenGen);
+            assert.strictEqual(model.uiUri, uiUri);
         });
     });
 
     describe('create', () => {
-        const saveConfig = {
-            table: 'base',
-            params: {
-                foo: {
-                    key: 'foo',
-                    notkey: 'bar'
-                },
-                bar: false
+        let sandbox;
+        const jobId = 12345;
+        const eventId = 123456;
+        const sha = 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f';
+        const configPipelineSha = '63aa3d3058bc0886a8bf42567858e61a7310133c';
+        const scmUri = 'github.com:12345:master';
+        const scmRepo = {
+            name: 'screwdriver-cd/models'
+        };
+        const displayName = 'github';
+        const prRef = 'pull/3/merge';
+        const username = 'i_made_the_request';
+        const dateNow = Date.now();
+        const isoTime = (new Date(dateNow)).toISOString();
+        const container = 'node:4';
+        const environment = { CLUSTER_FOO: 'bar', NODE_ENV: 'test', NODE_VERSION: '4' };
+        const permutations = [{
+            commands: [
+                { command: 'npm install', name: 'init' },
+                { command: 'npm test', name: 'test' }
+            ],
+            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
+            image: 'node:4'
+        }, {
+            commands: [
+                { command: 'npm install', name: 'init' },
+                { command: 'npm test', name: 'test' }
+            ],
+            environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
+            image: 'node:5'
+        }, {
+            commands: [
+                { command: 'npm install', name: 'init' },
+                { command: 'npm test', name: 'test' }
+            ],
+            environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
+            image: 'node:6'
+        }];
+        const permutationsWithAnnotations = [{
+            annotations: {
+                'screwdriver.cd/buildCluster': 'iOS'
+            },
+            commands: [
+                { command: 'npm install', name: 'init' },
+                { command: 'npm test', name: 'test' }
+            ],
+            environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
+            image: 'node:4'
+        }];
+
+        const commit = {
+            url: 'foo',
+            message: 'bar',
+            author: {
+                name: 'Batman',
+                username: 'batman',
+                url: 'stuff',
+                avatar: 'moreStuff'
             }
         };
 
-        beforeEach(() => {
-            factory.createClass = createMock;
+        const meta = {
+            foo: 'bar',
+            one: 1
+        };
+
+        steps.unshift({
+            name: 'sd-setup-init',
+            startTime: isoTime
         });
 
-        it('creates a new "base" in the datastore', () => {
-            const expected = {
-                foo: {
-                    key: 'foo',
-                    notkey: 'bar'
-                },
-                bar: false,
-                id: baseId
+        let saveConfig;
+
+        beforeEach(() => {
+            scmMock.getCommitSha.resolves(sha);
+            scmMock.decorateCommit.resolves(commit);
+            scmMock.getDisplayName.returns(displayName);
+            bookendMock.getSetupCommands.resolves([steps[2]]);
+            bookendMock.getTeardownCommands.resolves([]);
+            datastore.save.resolves({});
+
+            sandbox = sinon.createSandbox({
+                useFakeTimers: false
+            });
+            sandbox.useFakeTimers(dateNow);
+
+            jobFactoryMock.get.resolves({
+                permutations
+            });
+
+            saveConfig = {
+                table: 'builds',
+                params: {
+                    eventId,
+                    parentBuildId: 12345,
+                    cause: 'Started by user github:i_made_the_request',
+                    commit,
+                    createTime: isoTime,
+                    number: dateNow,
+                    status: 'QUEUED',
+                    container,
+                    environment,
+                    steps,
+                    jobId,
+                    sha,
+                    meta,
+                    stats: {}
+                }
+            };
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('ignores extraneous parameters', () => {
+            const garbage = 'garbageData';
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
             };
 
-            datastore.save.resolves(expected);
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
 
             return factory.create({
-                foo: {
-                    key: 'foo',
-                    notkey: 'bar'
-                },
-                bar: false
-            }).then((model) => {
-                assert.isTrue(datastore.save.calledWith(saveConfig));
-                assert.instanceOf(model, Base);
-                assert.deepEqual(model.datastore, datastore);
-                assert.deepEqual(model.scm, scm);
+                garbage, username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
             });
         });
 
-        it('rejects when a datastore save fails', () => {
-            const errorMessage = 'datastoreSaveFailureMessage';
+        it('do not set buildClusterName if multiBuildClusterEnabled is false', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations: permutationsWithAnnotations,
+                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
+            };
 
-            datastore.save.rejects(new Error(errorMessage));
+            factory.multiBuildClusterEnabled = false;
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
 
-            return factory.create({ foo: 'foo', bar: 'bar' })
-                .then(() => {
-                    assert.fail('This should not fail the test');
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('multipleBuildClusterDisabled - do not set buildClusterName if pipeline ' +
+            'annotation has buildCluster ', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({
+                    name: 'screwdriver/ui',
+                    scmUri,
+                    scmRepo,
+                    scmContext,
+                    annotations: {
+                        'screwdriver.cd/buildCluster': 'sd1'
+                    }
                 })
-                .catch((err) => {
-                    assert.strictEqual(err.message, errorMessage);
+            };
+
+            factory.multiBuildClusterEnabled = false;
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('multipleBuildClusterDisabled - do not set buildClusterName if both pipeline ' +
+            'and build has buildCluster annotation', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations: permutationsWithAnnotations,
+                pipeline: Promise.resolve({
+                    name: 'screwdriver/ui',
+                    scmUri,
+                    scmRepo,
+                    scmContext,
+                    annotations: {
+                        'screwdriver.cd/buildCluster': 'sd1'
+                    }
+                })
+            };
+
+            factory.multiBuildClusterEnabled = false;
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('multipleBuildClusterEnabled - pick from pipeline annotation ' +
+            'if no annotation passed in', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({
+                    name: 'screwdriver/ui',
+                    scmUri,
+                    scmRepo,
+                    scmContext,
+                    annotations: {
+                        'screwdriver.cd/buildCluster': 'iOS'
+                    }
+                })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+            saveConfig.params.buildClusterName = 'iOS';
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('multipleBuildClusterEnabled - pick from build annotation ' +
+            'even if pipeline annotation is available', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations: permutationsWithAnnotations,
+                pipeline: Promise.resolve({
+                    name: 'screwdriver/ui',
+                    scmUri,
+                    scmRepo,
+                    scmContext,
+                    annotations: {
+                        'screwdriver.cd/buildCluster':
+                            'sd1'
+                    }
+                })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+            saveConfig.params.buildClusterName = 'iOS';
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('multipleBuildClusterEnabled - pick from build annotation ' +
+            'if build annotation passed in', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations: permutationsWithAnnotations,
+                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+            saveConfig.params.buildClusterName = 'iOS';
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('multipleBuildClusterEnabled - pick from screwdriver build cluster ' +
+            'if no annotation passed in', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+            saveConfig.params.buildClusterName = 'sd1';
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+                assert.ok(buildClusterFactory);
+            });
+        });
+
+        it('pick build cluster based on annotations passed in', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations: permutationsWithAnnotations,
+                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+            saveConfig.params.buildClusterName = 'iOS';
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).then(() => {
+                assert.callCount(stepFactoryMock.create, steps.length);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('throws err if the pipeline is unauthorized to use the build cluster', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations: permutationsWithAnnotations,
+                pipeline: Promise.resolve({ name: 'test/ui', scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+            saveConfig.params.buildClusterName = 'iOS';
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message,
+                    'This pipeline is not authorized to use this build cluster.');
+            });
+        });
+
+        it('throws err if the build cluster specified does not exist', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations: permutationsWithAnnotations,
+                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
+            };
+
+            buildClusterFactoryMock.get.resolves(null);
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            delete saveConfig.params.commit;
+
+            return factory.create({
+                username, jobId, eventId, sha, parentBuildId: 12345, meta
+            }).catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message,
+                    'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
+            });
+        });
+
+        it('use username as displayName if displayLabel is not set', () => {
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            scmMock.getDisplayName.returns(null);
+            saveConfig.params.cause = 'Started by user i_made_the_request';
+            delete saveConfig.params.commit;
+            delete saveConfig.params.parentBuildId;
+
+            return factory.create({
+                username, jobId, eventId, sha, meta
+            }).then(() => assert.calledWith(datastore.save, saveConfig));
+        });
+
+        it('creates a new build in the datastore, looking up sha', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const causeMessage = `Started by ${displayName}`;
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+
+            return factory.create({
+                username,
+                causeMessage,
+                scmContext,
+                jobId,
+                eventId,
+                prRef,
+                parentBuildId: 12345,
+                meta
+            }).then((model) => {
+                assert.instanceOf(model, Build);
+                assert.calledOnce(jobFactory.getInstance);
+                assert.calledWith(jobFactoryMock.get, jobId);
+                assert.calledWith(userFactoryMock.get, { username, scmContext });
+                assert.calledWith(scmMock.getCommitSha, {
+                    token: 'foo',
+                    scmUri,
+                    scmContext
                 });
+                assert.calledWith(scmMock.decorateCommit, {
+                    token: 'foo',
+                    sha,
+                    scmUri,
+                    scmContext
+                });
+                assert.calledWith(bookendMock.getSetupCommands, {
+                    pipeline: { scmUri, scmRepo, scmContext },
+                    job: jobMock,
+                    build: sinon.match.object
+                });
+                assert.calledWith(bookendMock.getTeardownCommands, {
+                    pipeline: { scmUri, scmRepo, scmContext },
+                    job: jobMock,
+                    build: sinon.match.object
+                });
+                assert.calledOnce(startStub);
+                assert.calledWith(startStub, { causeMessage: 'Started by github' });
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('creates a new build in the datastore with causeMessage', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const causeMessage = '[force start] Push out hotfix';
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+
+            return factory.create({
+                username,
+                causeMessage,
+                scmContext,
+                jobId,
+                eventId,
+                prRef,
+                parentBuildId: 12345,
+                meta
+            }).then((model) => {
+                assert.instanceOf(model, Build);
+                assert.calledOnce(jobFactory.getInstance);
+                assert.calledWith(jobFactoryMock.get, jobId);
+                assert.calledWith(userFactoryMock.get, { username, scmContext });
+                assert.calledWith(scmMock.getCommitSha, {
+                    token: 'foo',
+                    scmUri,
+                    scmContext
+                });
+                assert.calledWith(scmMock.decorateCommit, {
+                    token: 'foo',
+                    sha,
+                    scmUri,
+                    scmContext
+                });
+                assert.calledWith(bookendMock.getSetupCommands, {
+                    pipeline: { scmUri, scmRepo, scmContext },
+                    job: jobMock,
+                    build: sinon.match.object
+                });
+                assert.calledWith(bookendMock.getTeardownCommands, {
+                    pipeline: { scmUri, scmRepo, scmContext },
+                    job: jobMock,
+                    build: sinon.match.object
+                });
+                assert.calledOnce(startStub);
+                assert.calledWith(startStub, { causeMessage });
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('creates a new build without starting', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            saveConfig.params.status = 'CREATED';
+
+            return factory.create({
+                username, jobId, eventId, parentBuildId: 12345, start: false, meta
+            }).then(() => {
+                assert.notCalled(startStub);
+                assert.calledWith(datastore.save, saveConfig);
+            });
+        });
+
+        it('adds a teardown command if one exists', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+            const teardown = {
+                name: 'sd-teardown',
+                command: 'echo "hello"'
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            bookendMock.getTeardownCommands.resolves([teardown]);
+            bookendMock.getSetupCommands.resolves([]);
+
+            const expectedSteps = steps.slice(0, 2).concat(steps.slice(3));
+
+            expectedSteps.push(teardown);
+
+            return factory.create({ username, jobId, eventId, prRef }).then((model) => {
+                assert.instanceOf(model, Build);
+                assert.deepEqual(model.steps, expectedSteps);
+            });
+        });
+
+        it('creates a new build in the datastore, without looking up sha', () => {
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            delete saveConfig.params.commit;
+            delete saveConfig.params.parentBuildId;
+
+            return factory.create({ username, jobId, eventId, sha, meta }).then((model) => {
+                assert.calledWith(datastore.save, saveConfig);
+                assert.instanceOf(model, Build);
+                assert.calledOnce(jobFactory.getInstance);
+                assert.calledWith(jobFactoryMock.get, jobId);
+                assert.calledOnce(startStub);
+            });
+        });
+
+        it('properly handles rejection due to missing job model', () => {
+            jobFactoryMock.get.resolves(null);
+
+            return factory.create({ username, jobId, eventId }).catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message, 'Job does not exist');
+            });
+        });
+
+        it('properly handles rejection due to missing user model', () => {
+            userFactoryMock.get.resolves(null);
+
+            return factory.create({ username, jobId, eventId }).catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message, 'User does not exist');
+            });
+        });
+
+        it('properly handles rejection due to missing pipeline model', () => {
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve(null)
+            };
+
+            userFactoryMock.get.resolves({});
+            jobFactoryMock.get.resolves(jobMock);
+
+            return factory.create({ username, jobId, eventId }).catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message, 'Pipeline does not exist');
+            });
+        });
+
+        it('creates a new build with a custom docker registry', () => {
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            factory = new BuildFactory({
+                datastore,
+                dockerRegistry: 'registry.com:1234',
+                executor,
+                scm: scmMock,
+                uiUri,
+                bookend: bookendMock
+            });
+
+            jobFactoryMock.get.resolves(jobMock);
+
+            return factory.create({ username, jobId, eventId, sha }).then((model) => {
+                assert.strictEqual(model.container, 'registry.com:1234/library/node:4');
+            });
+        });
+
+        it('combines environment from input config', () => {
+            const user = { unsealToken: sinon.stub().resolves('foo') };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
+            };
+
+            jobFactoryMock.get.resolves(jobMock);
+            userFactoryMock.get.resolves(user);
+            saveConfig.params.status = 'CREATED';
+
+            return factory.create({
+                username,
+                jobId,
+                eventId,
+                parentBuildId: 12345,
+                start: false,
+                environment: { EXTRA: true },
+                meta
+            }).then(() => {
+                assert.notCalled(startStub);
+                saveConfig.params.environment = {
+                    CLUSTER_FOO: 'bar', EXTRA: true, NODE_ENV: 'test', NODE_VERSION: '4'
+                };
+                assert.calledWith(datastore.save, saveConfig);
+                delete saveConfig.params.environment.EXTRA;
+            });
+        });
+
+        it('passes in config pipeline to the bookend config', () => {
+            const pipelineMock = {
+                configPipelineId: 2,
+                configPipeline: Promise.resolve({ spooky: 'ghost' })
+            };
+            const jobMock = {
+                permutations,
+                pipeline: Promise.resolve(pipelineMock)
+            };
+
+            userFactoryMock.get.resolves({});
+            jobFactoryMock.get.resolves(jobMock);
+
+            return factory.create({
+                username,
+                jobId,
+                eventId,
+                sha,
+                configPipelineSha,
+                meta
+            }).then(() => {
+                assert.calledWith(bookendMock.getSetupCommands, {
+                    pipeline: pipelineMock,
+                    job: jobMock,
+                    build: sinon.match.object,
+                    configPipeline: { spooky: 'ghost' },
+                    configPipelineSha
+                });
+                assert.calledWith(bookendMock.getTeardownCommands, {
+                    pipeline: pipelineMock,
+                    job: jobMock,
+                    build: sinon.match.object,
+                    configPipeline: { spooky: 'ghost' },
+                    configPipelineSha
+                });
+            });
         });
     });
 
     describe('get', () => {
-        const baseData = {
-            id: baseId,
-            foo: 'foo',
-            bar: 'bar'
+        const buildId = 123;
+        const buildData = {
+            steps
         };
+        const stepsData = steps.map(step => Object.assign({ code: 0 }, step));
+        const stepsMock = stepsData.map((step) => {
+            const mock = hoek.clone(step);
 
-        beforeEach(() => {
-            factory.createClass = createMock;
-            datastore.get.withArgs({
-                table: 'base',
-                params: {
-                    id: baseId
-                }
-            }).resolves(baseData);
-            datastore.get.withArgs({
-                table: 'base',
-                params: {
-                    foo: 'foo'
-                }
-            }).resolves(baseData);
+            mock.toJson = sinon.stub().returns(step);
+
+            return mock;
         });
 
-        it('calls datastore get with id and returns correct values', () =>
-            factory.get(baseData.id)
-                .then((model) => {
-                    assert.instanceOf(model, Base);
-                    assert.isTrue(datastore.get.calledOnce);
-                    assert.deepEqual(model.datastore, datastore);
-                    assert.deepEqual(model.scm, scm);
-                })
-        );
+        it('should get a build by ID without step models', () => {
+            getStepsStub.resolves([]);
+            datastore.get.resolves(buildData);
 
-        it('calls datastore get with config.id and returns correct values', () =>
-            factory.get(baseData)
-                .then((model) => {
-                    assert.instanceOf(model, Base);
-                    assert.isTrue(datastore.get.calledOnce);
-                    assert.deepEqual(model.datastore, datastore);
-                    assert.deepEqual(model.scm, scm);
-                })
-        );
-
-        it('converts string id to a number', () =>
-            factory.get('135323')
-                .then((model) => {
-                    assert.instanceOf(model, Base);
-                    assert.isTrue(datastore.get.calledOnce);
-                    assert.deepEqual(model.datastore, datastore);
-                    assert.deepEqual(model.scm, scm);
-                })
-        );
-
-        it('calls datastore get with config object and returns correct values', () =>
-            factory.get({ foo: 'foo', bar: 'bar' })
-                .then((model) => {
-                    assert.instanceOf(model, Base);
-                    assert.isTrue(datastore.get.calledOnce);
-                    assert.deepEqual(model.datastore, datastore);
-                    assert.deepEqual(model.scm, scm);
-                })
-        );
-
-        it('returns null when datastore miss occurs', () => {
-            datastore.get.withArgs({
-                table: 'base',
-                params: {
-                    id: baseId
-                }
-            }).resolves(null);
-
-            return factory.get(baseData.id)
-                .then((model) => {
-                    assert.isNull(model);
-                });
+            return factory.get(buildId)
+                .then(build => assert.deepEqual(build.steps, steps));
         });
 
-        it('rejects with a failure from the datastore get', () => {
-            datastore.get.rejects(new Error('teehee'));
+        it('should get a build by ID with merged step data', () => {
+            getStepsStub.resolves(stepsMock);
+            datastore.get.resolves(buildData);
 
-            return factory.get('doesntMatter')
-                .then(() => {
-                    assert.fail('this shall not pass');
-                })
-                .catch((err) => {
-                    assert.strictEqual(err.message, 'teehee');
-                });
+            return factory.get(buildId)
+                .then(build => assert.deepEqual(build.steps, stepsData));
+        });
+
+        it('should not throw when build does not exist', () => {
+            datastore.get.resolves(null);
+
+            return factory.get(buildId)
+                .then(build => assert.deepEqual(build, null));
         });
     });
 
     describe('list', () => {
-        const paginate = {
-            page: 1,
-            count: 2
+        const buildData = {
+            steps
         };
-        const returnValue = [
-            {
-                id: '151c9b11e4a9a27e9e374daca6e59df37d8cf00f',
-                name: 'component'
-            },
-            {
-                id: 123,
-                name: 'deploy'
-            }
-        ];
+        const stepsData = steps.map(step => Object.assign({ code: 0 }, step));
+        const stepsMock = stepsData.map((step) => {
+            const mock = hoek.clone(step);
 
-        beforeEach(() => {
-            factory.createClass = createMock;
-            datastore.scan.resolves(returnValue);
+            mock.toJson = sinon.stub().returns(step);
+
+            return mock;
         });
 
-        it('calls datastore scan', () =>
-            factory.list()
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {}
-                    });
-                })
-        );
+        it('should list builds without step models', () => {
+            getStepsStub.resolves([]);
+            datastore.scan.resolves([buildData, buildData]);
 
-        it('calls datastore scan and returns correct values', () =>
-            factory.list({ paginate })
-                .then((arr) => {
-                    assert.isArray(arr);
-                    assert.equal(arr.length, 2);
-                    arr.forEach((model) => {
-                        assert.instanceOf(model, Base);
-                        assert.deepEqual(model.datastore, datastore);
-                        assert.deepEqual(model.scm, scm);
-                    });
-                })
-        );
-
-        it('does not set default values if none are passed in', () =>
-            factory.list({})
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {}
-                    });
-                })
-        );
-
-        it('sets default paginate values if some are passed in', () =>
-            factory.list({ paginate: { count: 20 } })
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {},
-                        paginate: {
-                            page: 1,
-                            count: 20
-                        }
-                    });
-                })
-        );
-
-        it('sets default paginate values if undefined is passed in', () =>
-            factory.list({ paginate: { page: undefined, count: undefined } })
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {},
-                        paginate: {
-                            page: 1,
-                            count: 50
-                        }
-                    });
-                })
-        );
-
-        it('sets sortBy value if it is passed in', () =>
-            factory.list({ sortBy: 'scmRepo.name' })
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {},
-                        sortBy: 'scmRepo.name'
-                    });
-                })
-        );
-
-        it('sets time range value if it is passed in', () => {
-            const startTime = '2019-02-01T18:33:42.461Z';
-            const endTime = '2019-02-11T18:33:42.461Z';
-            const timeKey = 'startTime';
-
-            return factory.list({ startTime, endTime, timeKey })
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {},
-                        startTime,
-                        endTime,
-                        timeKey
-                    });
+            return factory.list({})
+                .then((builds) => {
+                    builds.map(build => assert.deepEqual(build.steps, steps));
+                    assert.calledWithMatch(datastore.scan, { sortBy: 'createTime' });
                 });
         });
 
-        it('sets search values if they are passed in', () =>
-            factory.list({
-                search: {
-                    field: 'scmRepo',
-                    keyword: '%name%screwdriver-cd/screwdriver%'
-                }
-            })
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {},
-                        search: {
-                            field: 'scmRepo',
-                            keyword: '%name%screwdriver-cd/screwdriver%'
-                        }
-                    });
-                })
-        );
+        it('should list builds with merged step data if config.fetchSteps is true', () => {
+            getStepsStub.resolves(stepsMock);
+            datastore.scan.resolves([buildData, buildData]);
 
-        it('calls datastore scan with sorting option returns correct values', () =>
-            factory.list({ paginate, sort: 'ascending' })
-                .then(() => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {},
-                        paginate,
-                        sort: 'ascending'
-                    });
-                })
-        );
-
-        it('call datastore scan with exclude and groupBy options', () =>
-            factory.list({ exclude: ['unwanted_col'], groupBy: ['colA', 'colB'] })
-                .then(() =>
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {},
-                        exclude: ['unwanted_col'],
-                        groupBy: ['colA', 'colB']
-                    })
-                )
-        );
-
-        it('call datastore scan with startTime and endTime options', () =>
-            factory.list({
-                startTime: '2019-01-20T22:28:35.039Z',
-                endTime: '2019-01-24T22:28:35.039Z'
-            }).then(() =>
-                assert.calledWith(datastore.scan, {
-                    table: 'base',
-                    params: {},
-                    startTime: '2019-01-20T22:28:35.039Z',
-                    endTime: '2019-01-24T22:28:35.039Z'
-                })
-            )
-        );
-
-        it('returns raw scan results when raw is true', () => {
-            const distinctRows = [
-                'namespace1',
-                'namespace2',
-                'namespace3'
-            ];
-
-            datastore.scan.resolves(distinctRows);
-
-            return factory.list({
-                params: {
-                    distinct: 'namespace'
-                },
-                raw: true
-            })
-                .then((data) => {
-                    assert.calledWith(datastore.scan, {
-                        table: 'base',
-                        params: {
-                            distinct: 'namespace'
-                        }
-                    });
-                    assert.deepEqual(data, [
-                        'namespace1',
-                        'namespace2',
-                        'namespace3'
-                    ]);
-                });
+            return factory.list({ fetchSteps: true })
+                .then(builds => builds.map(build => assert.deepEqual(build.steps, stepsData)));
         });
 
-        it('handles when the scan does not return an array', () => {
-            datastore.scan.resolves(null);
+        it('should not list builds with merged step data by default', () => {
+            getStepsStub.resolves(stepsMock);
+            datastore.scan.resolves([buildData, buildData]);
 
-            return factory.list({ paginate })
-                .catch((err) => {
-                    assert.strictEqual(err.message, 'Unexpected response from datastore, ' +
-                        'expected Array, got object');
-                });
-        });
-
-        it('rejects with a failure from the datastore scan', () => {
-            const errorMessage = 'genericScanError';
-
-            datastore.scan.rejects(new Error(errorMessage));
-
-            return factory.list({ paginate })
-                .then(() => {
-                    assert.fail('this should not happen');
-                })
-                .catch((err) => {
-                    assert.strictEqual(err.message, errorMessage);
-                });
+            return factory.list({})
+                .then(builds => builds.map(build => assert.deepEqual(build.steps, steps)));
         });
     });
 
@@ -444,28 +953,38 @@ describe('Base Factory', () => {
         let config;
 
         beforeEach(() => {
-            config = { datastore, scm };
+            config = { datastore, executor, scm: {}, uiUri, bookend: bookendMock };
         });
 
-        it('should encapsulate new, and act as a singleton', () => {
-            // ClasDef, instance, config
-            const f1 = BaseFactory.getInstance(BF, null, config);
-            const f2 = BaseFactory.getInstance(BF, f1, config);
+        it('should utilize BaseFactory to get an instance', () => {
+            const f1 = BuildFactory.getInstance(config);
+            const f2 = BuildFactory.getInstance(config);
+
+            assert.instanceOf(f1, BuildFactory);
+            assert.instanceOf(f2, BuildFactory);
 
             assert.equal(f1, f2);
         });
 
-        it('should not require config on second call', () => {
-            const f1 = BaseFactory.getInstance(BF, null, config);
-            const f2 = BaseFactory.getInstance(BF, f1);
+        it('should throw when config does not have everything necessary', () => {
+            assert.throw(BuildFactory.getInstance,
+                Error, 'No executor provided to BuildFactory');
 
-            assert.equal(f1, f2);
-        });
-
-        it('should throw when config not supplied or does not supply all expected params', () => {
             assert.throw(() => {
-                BaseFactory.getInstance(BF, null);
-            }, Error, 'No datastore provided to BF');
+                BuildFactory.getInstance({ executor, scm: {}, uiUri, bookend: bookendMock });
+            }, Error, 'No datastore provided to BuildFactory');
+
+            assert.throw(() => {
+                BuildFactory.getInstance({ executor, datastore, uiUri, bookend: bookendMock });
+            }, Error, 'No scm plugin provided to BuildFactory');
+
+            assert.throw(() => {
+                BuildFactory.getInstance({ executor, scm: {}, datastore, bookend: bookendMock });
+            }, Error, 'No uiUri provided to BuildFactory');
+
+            assert.throw(() => {
+                BuildFactory.getInstance({ executor, scm: {}, datastore, uiUri });
+            }, Error, 'No bookend plugin provided to BuildFactory');
         });
     });
 });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1868,7 +1868,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('throw err - multipleBuildClusterDisabled with cluster annotations - ' +
+        /* it('throw err - multipleBuildClusterDisabled with cluster annotations - ' +
             'updates a pipelines scm repository and branch', () => {
             userFactoryMock.get.withArgs({
                 username: 'd2lam',
@@ -1897,7 +1897,7 @@ describe('Pipeline Model', () => {
                 assert.strictEqual(err.message,
                     'Cluster specified in screwdriver.cd/buildCluster sd1 does not exist.');
             });
-        });
+        }); */
 
         it('multipleBuildClusterDisabled with annotations - ' +
             'updates a pipelines scm repository and branch', () => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1868,37 +1868,6 @@ describe('Pipeline Model', () => {
             });
         });
 
-        /* it('throw err - multipleBuildClusterDisabled with cluster annotations - ' +
-            'updates a pipelines scm repository and branch', () => {
-            userFactoryMock.get.withArgs({
-                username: 'd2lam',
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo'),
-                getPermissions: sinon.stub().resolves({
-                    push: true
-                })
-            });
-            datastore.update.resolves({});
-
-            pipeline.scmUri = 'github.com:12345:master';
-            pipeline.scmContext = scmContext;
-            pipeline.admins = {
-                d2lam: true
-            };
-            pipeline.multiBuildClusterEnabled = false;
-            pipeline.annotations = {
-                'screwdriver.cd/prChain': 'fork',
-                'screwdriver.cd/buildCluster': 'sd1'
-            };
-
-            return pipeline.update().catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message,
-                    'Cluster specified in screwdriver.cd/buildCluster sd1 does not exist.');
-            });
-        }); */
-
         it('multipleBuildClusterDisabled with annotations - ' +
             'updates a pipelines scm repository and branch', () => {
             const expected = {

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -217,7 +217,7 @@ describe('Pipeline Factory', () => {
             });
         });
 
-        it('throw err - multipleBuildClusterDisabled with cluster annotations - ' +
+        /* it('throw err - multipleBuildClusterDisabled with cluster annotations - ' +
             'creates a new pipeline in the datastore', () => {
             factory.multiBuildClusterEnabled = false;
             scm.decorateUrl.resolves(scmRepo);
@@ -241,7 +241,7 @@ describe('Pipeline Factory', () => {
                 assert.strictEqual(err.message,
                     'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
             });
-        });
+        }); */
 
         it('multipleBuildClusterEnabled without annotations - ' +
             'creates a new pipeline in the datastore - ' +

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -16,6 +16,8 @@ describe('Pipeline Factory', () => {
     let factory;
     let userFactoryMock;
     let tokenFactoryMock;
+    let buildClusterFactoryMock;
+    let buildClusterFactory;
     const dateNow = 1111111111;
     const nowTime = (new Date(dateNow)).toISOString();
     const scmUri = 'github.com:12345:master';
@@ -26,6 +28,21 @@ describe('Pipeline Factory', () => {
         name: 'foo/bar',
         branch: 'master',
         url: 'https://github.com/foo/bar/tree/master'
+    };
+    const sdBuildClusters = [{
+        name: 'sd1',
+        managedByScrewdriver: true,
+        isActive: true,
+        scmContext,
+        scmOrganizations: [],
+        weightage: 100
+    }];
+    const externalBuildCluster = {
+        name: 'iOS',
+        managedByScrewdriver: false,
+        isActive: true,
+        scmContext,
+        scmOrganizations: ['screwdriver']
     };
     let pipelineConfig;
 
@@ -51,6 +68,13 @@ describe('Pipeline Factory', () => {
         tokenFactoryMock = {
             get: sinon.stub()
         };
+        buildClusterFactoryMock = {
+            list: sinon.stub().resolves([]),
+            get: sinon.stub().resolves(externalBuildCluster)
+        };
+        buildClusterFactory = {
+            getInstance: sinon.stub().returns(buildClusterFactoryMock)
+        };
 
         // Fixing mockery issue with duplicate file names
         // by re-registering data-schema with its own implementation
@@ -62,6 +86,7 @@ describe('Pipeline Factory', () => {
         mockery.registerMock('./tokenFactory', {
             getInstance: sinon.stub().returns(tokenFactoryMock)
         });
+        mockery.registerMock('./buildClusterFactory', buildClusterFactory);
 
         // eslint-disable-next-line global-require
         PipelineFactory = require('../../lib/pipelineFactory');
@@ -73,7 +98,8 @@ describe('Pipeline Factory', () => {
             scmUri,
             scmContext,
             createTime: nowTime,
-            admins
+            admins,
+            multiBuildClusterEnabled: true
         };
 
         factory = new PipelineFactory(pipelineConfig);
@@ -122,7 +148,8 @@ describe('Pipeline Factory', () => {
             sandbox.restore();
         });
 
-        it('creates a new pipeline in the datastore', () => {
+        it('multipleBuildClusterDisabled - creates a new pipeline in ' +
+            'the datastore', () => {
             const expected = {
                 id: testId,
                 admins,
@@ -131,8 +158,10 @@ describe('Pipeline Factory', () => {
                 scmRepo
             };
 
+            factory.multiBuildClusterEnabled = false;
             datastore.save.resolves(expected);
             scm.decorateUrl.resolves(scmRepo);
+
             userFactoryMock.get.withArgs({
                 username: Object.keys(admins)[0],
                 scmContext
@@ -148,6 +177,197 @@ describe('Pipeline Factory', () => {
                 assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
                 assert.calledWith(datastore.save, saveConfig);
                 assert.instanceOf(model, Pipeline);
+            });
+        });
+
+        it('multipleBuildClusterEnabled - creates a new pipeline in ' +
+            'the datastore without annotation', () => {
+            const expected = {
+                id: testId,
+                admins,
+                createTime: nowTime,
+                scmUri,
+                scmRepo,
+                annotations: { 'screwdriver.cd/buildCluster': 'sd1' }
+            };
+
+            datastore.save.resolves(expected);
+            scm.decorateUrl.resolves(scmRepo);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+            saveConfig.params.annotations = { 'screwdriver.cd/buildCluster': 'sd1' };
+
+            userFactoryMock.get.withArgs({
+                username: Object.keys(admins)[0],
+                scmContext
+            }).resolves({
+                unsealToken: sinon.stub().resolves('foo')
+            });
+
+            return factory.create({
+                scmUri,
+                scmContext,
+                admins
+            }).then((model) => {
+                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
+                assert.calledWith(datastore.save, saveConfig
+                );
+                assert.instanceOf(model, Pipeline);
+            });
+        });
+
+        it('multipleBuildClusterEnabled - creates a new pipeline in ' +
+            'the datastore with annotation', () => {
+            scmRepo.name = 'screwdriver/ui';
+            const expected = {
+                id: testId,
+                admins,
+                createTime: nowTime,
+                scmUri,
+                scmRepo,
+                annotations: {
+                    'screwdriver.cd/prChain': 'fork',
+                    'screwdriver.cd/buildCluster': 'iOS'
+                }
+            };
+
+            datastore.save.resolves(expected);
+            scm.decorateUrl.resolves(scmRepo);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+            saveConfig.params.annotations = { 'screwdriver.cd/prChain': 'fork',
+                'screwdriver.cd/buildCluster': 'iOS' };
+            saveConfig.params.name = scmRepo.name;
+
+            userFactoryMock.get.withArgs({
+                username: Object.keys(admins)[0],
+                scmContext
+            }).resolves({
+                unsealToken: sinon.stub().resolves('foo')
+            });
+
+            return factory.create({
+                scmUri,
+                scmContext,
+                admins,
+                annotations: { 'screwdriver.cd/prChain': 'fork',
+                    'screwdriver.cd/buildCluster': 'iOS' }
+            }).then((model) => {
+                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
+                assert.calledWith(datastore.save, saveConfig
+                );
+                assert.instanceOf(model, Pipeline);
+            });
+        });
+
+        it('multipleBuildClusterEnabled - creates a new pipeline in ' +
+            'the datastore with annotation - no value assignment', () => {
+            scmRepo.name = 'screwdriver/ui';
+            const expected = {
+                id: testId,
+                admins,
+                createTime: nowTime,
+                scmUri,
+                scmRepo,
+                annotations: {
+                    'screwdriver.cd/prChain': 'fork',
+                    'screwdriver.cd/buildCluster': 'sd1'
+                }
+            };
+
+            datastore.save.resolves(expected);
+            scm.decorateUrl.resolves(scmRepo);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+            saveConfig.params.annotations = { 'screwdriver.cd/prChain': 'fork',
+                'screwdriver.cd/buildCluster': 'sd1' };
+            saveConfig.params.name = scmRepo.name;
+
+            userFactoryMock.get.withArgs({
+                username: Object.keys(admins)[0],
+                scmContext
+            }).resolves({
+                unsealToken: sinon.stub().resolves('foo')
+            });
+
+            return factory.create({
+                scmUri,
+                scmContext,
+                admins,
+                annotations: { 'screwdriver.cd/prChain': 'fork',
+                    'screwdriver.cd/buildCluster': '' }
+            }).then((model) => {
+                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
+                assert.calledWith(datastore.save, saveConfig
+                );
+                assert.instanceOf(model, Pipeline);
+            });
+        });
+
+        it('throws err if the pipeline is unauthorized to use the build cluster', () => {
+            const expected = {
+                id: testId,
+                admins,
+                createTime: nowTime,
+                scmUri,
+                scmRepo,
+                annotations: { 'screwdriver.cd/buildCluster': 'iOS' }
+            };
+
+            datastore.save.resolves(expected);
+            scm.decorateUrl.resolves(scmRepo);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+            saveConfig.params.annotations = { 'screwdriver.cd/buildCluster': 'iOS' };
+
+            userFactoryMock.get.withArgs({
+                username: Object.keys(admins)[0],
+                scmContext
+            }).resolves({
+                unsealToken: sinon.stub().resolves('foo')
+            });
+
+            return factory.create({
+                scmUri,
+                scmContext,
+                admins,
+                annotations: { 'screwdriver.cd/prChain': 'fork',
+                    'screwdriver.cd/buildCluster': 'iOS' }
+            }).catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message,
+                    'This pipeline is not authorized to use this build cluster.');
+            });
+        });
+
+        it('throws err if the build cluster specified does not exist', () => {
+            const expected = {
+                id: testId,
+                admins,
+                createTime: nowTime,
+                scmUri,
+                scmRepo,
+                annotations: { 'screwdriver.cd/buildCluster': 'iOS' }
+            };
+
+            datastore.save.resolves(expected);
+            scm.decorateUrl.resolves(scmRepo);
+            buildClusterFactoryMock.get.resolves(null);
+            saveConfig.params.annotations = { 'screwdriver.cd/buildCluster': 'iOS' };
+
+            userFactoryMock.get.withArgs({
+                username: Object.keys(admins)[0],
+                scmContext
+            }).resolves({
+                unsealToken: sinon.stub().resolves('foo')
+            });
+
+            return factory.create({
+                scmUri,
+                scmContext,
+                admins,
+                annotations: { 'screwdriver.cd/prChain': 'fork',
+                    'screwdriver.cd/buildCluster': 'iOS' }
+            }).catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.strictEqual(err.message,
+                    'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
             });
         });
     });
@@ -234,6 +454,26 @@ describe('Pipeline Factory', () => {
             assert.throw(() => {
                 PipelineFactory.getInstance({ scm: {} });
             }, Error, 'No datastore provided to PipelineFactory');
+        });
+    });
+
+    describe('getExternalJoin', () => {
+        beforeEach(() => {
+            // eslint-disable-next-line global-require
+            PipelineFactory = require('../../lib/pipelineFactory');
+            pipelineConfig = {
+                externalJoin: false
+            };
+            factory = new PipelineFactory(pipelineConfig);
+        });
+
+        it('getExternalJoin returns true', () => {
+            factory.externalJoin = true;
+            assert.isTrue(factory.getExternalJoinFlag());
+        });
+
+        it('getExternalJoin returns false', () => {
+            assert.isFalse(factory.getExternalJoinFlag());
         });
     });
 });

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -217,32 +217,6 @@ describe('Pipeline Factory', () => {
             });
         });
 
-        /* it('throw err - multipleBuildClusterDisabled with cluster annotations - ' +
-            'creates a new pipeline in the datastore', () => {
-            factory.multiBuildClusterEnabled = false;
-            scm.decorateUrl.resolves(scmRepo);
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: {
-                    'screwdriver.cd/buildCluster': 'iOS'
-                }
-            }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message,
-                    'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
-            });
-        }); */
-
         it('multipleBuildClusterEnabled without annotations - ' +
             'creates a new pipeline in the datastore - ' +
             'pick screwdriver cluster', () => {


### PR DESCRIPTION
## Context

All builds in the pipeline should be automatically sent to the build cluster assigned at pipeline creation time

## Objective

Assign buildCluster for pipelines and builds

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
