### PR TITLE
fix(1339): event not standardizing parameters:

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -234,38 +234,6 @@ function createBuilds(config) {
         return null;
     }
 
-    // enable pipeline parameters feature, if parameters exist in screwdriver.yaml
-    if (pipeline.parameters) {
-        const allowedParameters = Object.create(null);
-
-        Object.entries(pipeline.parameters).forEach(([name, val]) => {
-            let defaultParameterValue = val;
-
-            if (typeof val === 'object') {
-                defaultParameterValue = val.value;
-            }
-
-            allowedParameters[name] = { value: defaultParameterValue };
-            if (pipelineConfig.meta.parameters) {
-                let actualParameterValue = pipelineConfig.meta.parameters[name];
-
-                if (typeof actualParameterValue === 'object') {
-                    actualParameterValue = actualParameterValue.value;
-                }
-
-                if (actualParameterValue !== undefined) {
-                    allowedParameters[name] = { value: actualParameterValue };
-                }
-            }
-        });
-
-        if (pipelineConfig.meta) {
-            Object.assign(pipelineConfig.meta, { parameters: allowedParameters });
-        } else {
-            pipelineConfig.meta = { parameters: allowedParameters };
-        }
-    }
-
     return Promise.all([
         pipeline.branch,
         pipeline.getJobs(),
@@ -409,6 +377,49 @@ function updateWorkflowGraph(config) {
     }
 
     return Promise.resolve(workflowGraph);
+}
+
+/**
+ * Standardize event parameters
+ * @method updateWorkflowGraph
+ * @param  {Object}         config
+ * @param  {Pipeline}       config.pipeline                      Pipeline
+ * @param  {Object}         [config.pipeline.parameters]         Default build parameters
+ * @param  {Object}         config.eventConfig
+ * @param  {Object}         [config.eventConfig.meta.parameters] Customized build parameters
+ * @resolves {Object}                                            Resolves with standardized parameters
+ */
+function updateEventParameters(config) {
+    const { pipeline, eventConfig } = config;
+    const allowedParameters = Object.create(null);
+
+    // parameters not enabled
+    if (!pipeline.parameters) {
+        return Promise.resolve(null);
+    }
+
+    Object.entries(pipeline.parameters).forEach(([name, val]) => {
+        let defaultParameterValue = val;
+
+        if (typeof val === 'object') {
+            defaultParameterValue = val.value;
+        }
+
+        allowedParameters[name] = { value: defaultParameterValue };
+        if (eventConfig.meta.parameters) {
+            let actualParameterValue = eventConfig.meta.parameters[name];
+
+            if (typeof actualParameterValue === 'object') {
+                actualParameterValue = actualParameterValue.value;
+            }
+
+            if (actualParameterValue !== undefined) {
+                allowedParameters[name] = { value: actualParameterValue };
+            }
+        }
+    });
+
+    return Promise.resolve(allowedParameters);
 }
 
 class EventFactory extends BaseFactory {
@@ -607,8 +618,16 @@ class EventFactory extends BaseFactory {
                 }))
                 .then((updatedWorkflowGraph) => {
                     modelConfig.workflowGraph = updatedWorkflowGraph;
+                })
+                .then(() => updateEventParameters({
+                    pipeline,
+                    eventConfig: config
+                }))
+                .then((updatedParameters) => {
+                    if (updatedParameters) {
+                        modelConfig.meta.parameters = updatedParameters;
+                    }
 
-                    // create event model
                     return super.create(modelConfig);
                 })
                 .then((event) => {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -395,7 +395,7 @@ function updateEventParameters(config) {
 
     // parameters not enabled
     if (!pipeline.parameters) {
-        return Promise.resolve(null);
+        return null;
     }
 
     Object.entries(pipeline.parameters).forEach(([name, val]) => {
@@ -419,7 +419,7 @@ function updateEventParameters(config) {
         }
     });
 
-    return Promise.resolve(allowedParameters);
+    return allowedParameters;
 }
 
 class EventFactory extends BaseFactory {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1508,46 +1508,42 @@ describe('Event Factory', () => {
         });
 
         it('should have parameters if create with parameters', () => {
-            const currentPipelineConfig = Object.assign({
+            const pipelineWithParameter = Object.assign({
                 parameters: {
-                    user: 'actualValue'
-                }
-            }, syncedPipelineMock);
-
-            const fixedPipelineConfig = Object.assign({
-                parameters: {
-                    user: 'originalValue'
+                    user: 'adong'
                 }
             }, syncedPipelineMock);
 
             config.startFrom = 'main';
-            config.meta = currentPipelineConfig;
-            syncedPipelineMock.update = sinon.stub().resolves(fixedPipelineConfig);
+            config.meta = {
+                parameters: {
+                    user: 'batman'
+                }
+            };
+            pipelineMock.sync = sinon.stub().resolves(pipelineWithParameter);
 
             return eventFactory.create(config).then((model) => {
-                assert.equal(model.meta.parameters.user.value, 'actualValue');
+                assert.equal(model.meta.parameters.user.value, 'batman');
             });
         });
 
         it('should not have parameters if create without parameters', () => {
-            const currentPipelineConfig = Object.assign({
+            const pipelineWithParameter = Object.assign({
                 parameters: {
-                    thisIsNotFromPipeline: 'nonExistingValue'
-                }
-            }, syncedPipelineMock);
-
-            const fixedPipelineConfig = Object.assign({
-                parameters: {
-                    user: 'originalValue'
+                    user: 'adong'
                 }
             }, syncedPipelineMock);
 
             config.startFrom = 'main';
-            config.meta = currentPipelineConfig;
-            syncedPipelineMock.update = sinon.stub().resolves(fixedPipelineConfig);
+            config.meta = {
+                parameters: {
+                    random: 'batman'
+                }
+            };
+            pipelineMock.sync = sinon.stub().resolves(pipelineWithParameter);
 
             return eventFactory.create(config).then((model) => {
-                assert.equal(model.meta.parameters.user.value, 'originalValue');
+                assert.equal(model.meta.parameters.user.value, 'adong');
             });
         });
     });


### PR DESCRIPTION
## Context

Currently we are standardizing parameters when we create builds but not events. This delays display of parameters until a build finishes.

## Objective

standardizing parameters when we create events

## References

https://github.com/screwdriver-cd/screwdriver/issues/1339

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
