### PR TITLE
fix(1830): fix get build cluster for pipeline update

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -9,6 +9,7 @@ const model = Symbol('model');
 const table = Symbol('table');
 const datastore = Symbol('datastore');
 const scm = Symbol('scm');
+const multiBuildClusterEnabled = Symbol('multiBuildClusterEnabled');
 
 class BaseModel {
     /**
@@ -24,6 +25,7 @@ class BaseModel {
         this[table] = this[model].tableName;
         this[datastore] = config.datastore;
         this[scm] = config.scm;
+        this[multiBuildClusterEnabled] = config.multiBuildClusterEnabled;
         this[rowData] = {};
         this[dirty] = [];
 
@@ -42,6 +44,10 @@ class BaseModel {
                 enumerable: true
             });
         });
+    }
+
+    get multiBuildClusterEnabled() {
+        return this[multiBuildClusterEnabled];
     }
 
     get scm() {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -218,7 +218,6 @@ class PipelineModel extends BaseModel {
     constructor(config) {
         super('pipeline', config);
         this.scmContext = config.scmContext;
-        this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
     }
 
     /**

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -33,6 +33,7 @@ class PipelineFactory extends BaseFactory {
      * @return {Pipeline}
      */
     createClass(config) {
+        config.multiBuildClusterEnabled = this.multiBuildClusterEnabled;
         return new Pipeline(config);
     }
 

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -34,6 +34,7 @@ class PipelineFactory extends BaseFactory {
      */
     createClass(config) {
         config.multiBuildClusterEnabled = this.multiBuildClusterEnabled;
+
         return new Pipeline(config);
     }
 

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -13,6 +13,7 @@ describe('Base Model', () => {
     let base;
     let config;
     let scm;
+    let multiBuildClusterEnabled;
 
     before(() => {
         mockery.enable({
@@ -25,6 +26,7 @@ describe('Base Model', () => {
         scm = {
             foo: 'foo'
         };
+        multiBuildClusterEnabled = false;
         datastore = {
             get: sinon.stub(),
             scan: sinon.stub(),
@@ -48,6 +50,7 @@ describe('Base Model', () => {
         config = {
             datastore,
             scm,
+            multiBuildClusterEnabled,
             id: 12345,
             foo: 'foo',
             bar: 'bar'
@@ -190,6 +193,12 @@ describe('Base Model', () => {
     describe('scm', () => {
         it('should have a getter for the scm plugin', () => {
             assert.equal(base.scm, scm);
+        });
+    });
+
+    describe('multiBuildClusterEnabled', () => {
+        it('should have a getter for the multiBuildCluster plugin', () => {
+            assert.equal(base.multiBuildClusterEnabled, multiBuildClusterEnabled);
         });
     });
 });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1852,7 +1852,6 @@ describe('Pipeline Model', () => {
             pipeline.admins = {
                 d2lam: true
             };
-            pipeline.multiBuildClusterEnabled = false;
 
             return pipeline.update().then((p) => {
                 assert.calledWith(scmMock.decorateUrl, {
@@ -1902,7 +1901,6 @@ describe('Pipeline Model', () => {
             pipeline.admins = {
                 d2lam: true
             };
-            pipeline.multiBuildClusterEnabled = false;
             pipeline.annotations = {
                 'screwdriver.cd/prChain': 'fork'
             };


### PR DESCRIPTION
## Context

multiBuildClusterEnabled flag is not available when updating pipeline

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
