### PR TITLE
fix(1830): tag build cluster as part of pipeline sync and update

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -99,6 +99,7 @@ class BaseFactory {
 
                 data.datastore = this.datastore;
                 data.scm = this.scm;
+                data.multiBuildClusterEnabled = this.multiBuildClusterEnabled;
 
                 return this.createClass(data);
             });

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -122,12 +122,13 @@ function getRandomCluster(clusters) {
 /**
  * Get build cluster name based on annotations
  * @method getBuildClusterName
- * @param  {Object}         config
- * @param  {Object}         config.annotations              Annotations for the job
- * @param  {PipelineModel}  config.pipeline                 Pipeline model
- * @return {String}        Build cluster name
+ * @param  {Object}             config
+ * @param  {Object}             config.annotations              Annotations for the job
+ * @param  {PipelineModel}      config.pipeline                 Pipeline model
+ * @param  {isPipelineUpdate}   from pipeline update
+ * @return {String}             Build cluster name
  */
-async function getBuildClusterName({ annotations, pipeline }) {
+async function getBuildClusterName({ annotations, pipeline, isPipelineUpdate = false }) {
     const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
     const pipelineAnnotations = hoek.reach(pipeline, 'annotations', { default: {} });
     let buildClusterName;
@@ -145,44 +146,42 @@ async function getBuildClusterName({ annotations, pipeline }) {
     // eslint-disable-next-line global-require
     const BuildClusterFactory = require('./buildClusterFactory');
     const buildClusterFactory = BuildClusterFactory.getInstance();
+    const allBuildClusters = await buildClusterFactory.list();
+    const activeManagedBuildClusters = allBuildClusters.filter(cluster =>
+        cluster.managedByScrewdriver === true && cluster.isActive === true);
 
     if (!buildClusterName) {
-        return buildClusterFactory.list({
-            params: {
-                managedByScrewdriver: true,
-                isActive: true
-            }
-        }).then((buildClusters) => {
-            if (buildClusters.length === 0) {
-                return '';
-            }
+        if (activeManagedBuildClusters.length === 0) {
+            return '';
+        }
 
-            return getRandomCluster(buildClusters);
-        });
+        return getRandomCluster(activeManagedBuildClusters);
+    }
+    let buildCluster = allBuildClusters.filter(cluster => cluster.name === buildClusterName);
+
+    if (buildCluster.length === 0) {
+        // eslint-disable-next-line max-len
+        throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} does not exist.`);
     }
 
-    return buildClusterFactory.get({
-        name: buildClusterName
-    }).then((buildCluster) => {
-        if (!buildCluster) {
-            // eslint-disable-next-line max-len
-            throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} does not exist.`);
-        }
+    buildCluster = buildCluster[0];
+    // Check if this pipeline's org is authorized to use the build cluster
+    // pipeline name example: screwdriver-cd/ui
+    const regex = /^([^/]+)\/.*/;
+    const matched = pipeline.name.match(regex);
+    const org = matched ? matched[1] : '';
 
-        // Check if this pipeline's org is authorized to use the build cluster
-        // pipeline name example: screwdriver-cd/ui
-        const regex = /^([^/]+)\/.*/;
-        const matched = pipeline.name.match(regex);
-        const org = matched ? matched[1] : '';
+    if (buildCluster.scmContext !== pipeline.scmContext
+        || (buildCluster.managedByScrewdriver === false
+            && !buildCluster.scmOrganizations.includes(org))) {
+        throw new Error('This pipeline is not authorized to use this build cluster.');
+    }
 
-        if (buildCluster.scmContext !== pipeline.scmContext
-            || (buildCluster.managedByScrewdriver === false
-                && !buildCluster.scmOrganizations.includes(org))) {
-            throw new Error('This pipeline is not authorized to use this build cluster.');
-        }
+    if (!buildCluster.isActive && !isPipelineUpdate) {
+        return getRandomCluster(activeManagedBuildClusters);
+    }
 
-        return buildCluster.name;
-    });
+    return buildCluster.name;
 }
 
 module.exports = {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -707,6 +707,21 @@ class PipelineModel extends BaseModel {
         // get the pipeline configuration
         return this.getConfiguration({ ref })
             .then((parsedConfig) => {
+                const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+                const parsedConfigAnnotations = hoek.reach(parsedConfig,
+                    'annotations', { default: {} });
+                const buildCluster = parsedConfigAnnotations[buildClusterAnnotation] || '';
+
+                if (!buildCluster) {
+                    const dbClusterAnnotations = hoek.reach(this,
+                        'annotations', { default: {} });
+
+                    if (dbClusterAnnotations) {
+                        parsedConfig.annotations[buildClusterAnnotation] =
+                            dbClusterAnnotations[buildClusterAnnotation];
+                    }
+                }
+
                 // If it is an external config pipeline, sync all children
                 if ((this.childPipelines || parsedConfig.childPipelines)
                     && !this.configPipelineId && !parsedConfig.errors) {
@@ -1192,7 +1207,8 @@ class PipelineModel extends BaseModel {
                 if (String(this.multiBuildClusterEnabled) === 'true') {
                     buildClusterName = await getBuildClusterName({
                         annotations,
-                        pipeline: this
+                        pipeline: this,
+                        isPipelineUpdate: true
                     });
 
                     if (buildClusterName) {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -80,7 +80,16 @@ describe('Pipeline Model', () => {
         scmContext,
         scmOrganizations: [],
         weightage: 100
-    }];
+    },
+    {
+        name: 'iOS',
+        managedByScrewdriver: false,
+        isActive: true,
+        scmContext,
+        scmOrganizations: ['screwdriver'],
+        weightage: 0
+    }
+    ];
 
     const externalBuildCluster = {
         name: 'iOS',
@@ -579,6 +588,24 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('store annotations with buildCluster to pipeline', () => {
+            jobs = [];
+            jobFactoryMock.list.resolves(jobs);
+            jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
+            jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+
+            pipeline.annotations = { 'screwdriver.cd/buildCluster': 'sd1' };
+
+            return pipeline.sync().then(() => {
+                assert.deepEqual(pipeline.annotations, {
+                    'beta.screwdriver.cd/executor': 'screwdriver-executor-vm',
+                    'screwdriver.cd/chainPR': true,
+                    'screwdriver.cd/buildCluster': 'sd1'
+                });
+            });
+        });
+
         it('stores chainPR to pipeline', () => {
             const configMock = Object.assign({}, PARSED_YAML);
             const defatulChainPR = false;
@@ -589,6 +616,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.list.resolves(jobs);
             jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
             jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync(null, defatulChainPR).then(() => {
                 assert.equal(pipeline.chainPR, true);
@@ -600,6 +628,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.list.resolves(jobs);
             jobFactoryMock.create.withArgs(publishMock).resolves(publishMock);
             jobFactoryMock.create.withArgs(mainMock).resolves(mainMock);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync()
                 .then((p) => {
@@ -626,6 +655,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.list.resolves(jobs);
             mainModelMock.update.resolves(mainModelMock);
             publishModelMock.update.resolves(publishModelMock);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync()
                 .then(() => {
@@ -680,6 +710,7 @@ describe('Pipeline Model', () => {
             mainModelMock.update.resolves(mainModelMock);
             publishModelMock.update.resolves(publishModelMock);
             disableJobMock.update.resolves(disableJobMock);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync()
                 .then(() => {
@@ -700,6 +731,7 @@ describe('Pipeline Model', () => {
             mainModelMock.update.resolves(mainModelMock);
             publishModelMock.update.resolves(publishModelMock);
             jobFactoryMock.list.resolves(jobs);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync()
                 .then(() => {
@@ -814,6 +846,7 @@ describe('Pipeline Model', () => {
                     'bar.git'
                 ]
             };
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync()
                 .then((p) => {
@@ -2052,7 +2085,9 @@ describe('Pipeline Model', () => {
                     push: true
                 })
             });
+
             datastore.update.resolves({});
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
             scmMock.decorateUrl.resolves({
                 branch: 'master',
                 name: 'screwdriver/ui',
@@ -2087,6 +2122,7 @@ describe('Pipeline Model', () => {
                 })
             });
             datastore.update.resolves({});
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
             pipeline.scmUri = 'github.com:12345:master';
             pipeline.scmContext = scmContext;
             pipeline.admins = {

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -36,6 +36,22 @@ describe('Pipeline Factory', () => {
         scmContext,
         scmOrganizations: [],
         weightage: 100
+    },
+    {
+        name: 'sd2',
+        managedByScrewdriver: true,
+        isActive: false,
+        scmContext,
+        scmOrganizations: [],
+        weightage: 0
+    },
+    {
+        name: 'iOS',
+        managedByScrewdriver: false,
+        isActive: true,
+        scmContext,
+        scmOrganizations: ['screwdriver'],
+        weightage: 0
     }];
     const externalBuildCluster = {
         name: 'iOS',
@@ -309,16 +325,16 @@ describe('Pipeline Factory', () => {
                 scmRepo,
                 annotations: {
                     'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'iOS'
+                    'screwdriver.cd/buildCluster': 'sd1'
                 }
             };
 
             datastore.save.resolves(expected);
             scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.get.resolves(externalBuildCluster);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
             saveConfig.params.annotations = {
                 'screwdriver.cd/prChain': 'fork',
-                'screwdriver.cd/buildCluster': 'iOS'
+                'screwdriver.cd/buildCluster': 'sd1'
             };
             saveConfig.params.name = scmRepo.name;
 
@@ -335,7 +351,7 @@ describe('Pipeline Factory', () => {
                 admins,
                 annotations: {
                     'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'iOS'
+                    'screwdriver.cd/buildCluster': 'sd1'
                 }
             }).then((model) => {
                 assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });


### PR DESCRIPTION
## Objective

PR fixes random assignment of build cluster, every time the pipeline is synced or updated. 

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
