### PR TITLE
fix(1830): when pipeline is created do not assign build cluster.

### DIFF
--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -1,9 +1,7 @@
 'use strict';
 
-const hoek = require('hoek');
 const BaseFactory = require('./baseFactory');
 const Pipeline = require('./pipeline');
-const helper = require('./helper');
 let instance;
 
 class PipelineFactory extends BaseFactory {
@@ -72,24 +70,6 @@ class PipelineFactory extends BaseFactory {
             .then(async (scmRepo) => {
                 modelConfig.scmRepo = scmRepo;
                 modelConfig.name = scmRepo.name;
-
-                let buildClusterName;
-                const annotations = hoek.reach(modelConfig, 'annotations', { default: {} });
-                const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
-
-                if (String(this.multiBuildClusterEnabled) === 'true') {
-                    buildClusterName = await helper.getBuildClusterName({
-                        annotations,
-                        pipeline: modelConfig
-                    });
-
-                    if (buildClusterName) {
-                        if (!modelConfig.annotations) {
-                            modelConfig.annotations = {};
-                        }
-                        modelConfig.annotations[buildClusterAnnotation] = buildClusterName;
-                    }
-                }
 
                 return super.create(modelConfig);
             });

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -16,8 +16,6 @@ describe('Pipeline Factory', () => {
     let factory;
     let userFactoryMock;
     let tokenFactoryMock;
-    let buildClusterFactoryMock;
-    let buildClusterFactory;
     const dateNow = 1111111111;
     const nowTime = (new Date(dateNow)).toISOString();
     const scmUri = 'github.com:12345:master';
@@ -28,37 +26,6 @@ describe('Pipeline Factory', () => {
         name: 'foo/bar',
         branch: 'master',
         url: 'https://github.com/foo/bar/tree/master'
-    };
-    const sdBuildClusters = [{
-        name: 'sd1',
-        managedByScrewdriver: true,
-        isActive: true,
-        scmContext,
-        scmOrganizations: [],
-        weightage: 100
-    },
-    {
-        name: 'sd2',
-        managedByScrewdriver: true,
-        isActive: false,
-        scmContext,
-        scmOrganizations: [],
-        weightage: 0
-    },
-    {
-        name: 'iOS',
-        managedByScrewdriver: false,
-        isActive: true,
-        scmContext,
-        scmOrganizations: ['screwdriver'],
-        weightage: 0
-    }];
-    const externalBuildCluster = {
-        name: 'iOS',
-        managedByScrewdriver: false,
-        isActive: true,
-        scmContext,
-        scmOrganizations: ['screwdriver']
     };
     let pipelineConfig;
 
@@ -84,13 +51,6 @@ describe('Pipeline Factory', () => {
         tokenFactoryMock = {
             get: sinon.stub()
         };
-        buildClusterFactoryMock = {
-            list: sinon.stub().resolves([]),
-            get: sinon.stub().resolves(externalBuildCluster)
-        };
-        buildClusterFactory = {
-            getInstance: sinon.stub().returns(buildClusterFactoryMock)
-        };
 
         // Fixing mockery issue with duplicate file names
         // by re-registering data-schema with its own implementation
@@ -102,7 +62,6 @@ describe('Pipeline Factory', () => {
         mockery.registerMock('./tokenFactory', {
             getInstance: sinon.stub().returns(tokenFactoryMock)
         });
-        mockery.registerMock('./buildClusterFactory', buildClusterFactory);
 
         // eslint-disable-next-line global-require
         PipelineFactory = require('../../lib/pipelineFactory');
@@ -164,8 +123,7 @@ describe('Pipeline Factory', () => {
             sandbox.restore();
         });
 
-        it('multipleBuildClusterDisabled without annotations - ' +
-            'creates a new pipeline in the datastore ', () => {
+        it('creates a new pipeline in the datastore', () => {
             const expected = {
                 id: testId,
                 admins,
@@ -174,7 +132,6 @@ describe('Pipeline Factory', () => {
                 scmRepo
             };
 
-            factory.multiBuildClusterEnabled = false;
             datastore.save.resolves(expected);
             scm.decorateUrl.resolves(scmRepo);
 
@@ -193,324 +150,6 @@ describe('Pipeline Factory', () => {
                 assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
                 assert.calledWith(datastore.save, saveConfig);
                 assert.instanceOf(model, Pipeline);
-            });
-        });
-
-        it('multipleBuildClusterDisabled with annotations - ' +
-            'creates a new pipeline in the datastore ', () => {
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: {
-                    'screwdriver.cd/prChain': 'fork'
-                }
-            };
-
-            factory.multiBuildClusterEnabled = false;
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-            saveConfig.params.annotations = { 'screwdriver.cd/prChain': 'fork' };
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: { 'screwdriver.cd/prChain': 'fork' }
-            }).then((model) => {
-                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
-                assert.calledWith(datastore.save, saveConfig);
-                assert.instanceOf(model, Pipeline);
-            });
-        });
-
-        it('multipleBuildClusterEnabled without annotations - ' +
-            'creates a new pipeline in the datastore - ' +
-            'pick screwdriver cluster', () => {
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: { 'screwdriver.cd/buildCluster': 'sd1' }
-            };
-
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-            saveConfig.params.annotations = { 'screwdriver.cd/buildCluster': 'sd1' };
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins
-            }).then((model) => {
-                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
-                assert.calledWith(datastore.save, saveConfig
-                );
-                assert.instanceOf(model, Pipeline);
-            });
-        });
-
-        it('multipleBuildClusterEnabled without cluster annotations - ' +
-            'creates a new pipeline in the datastore - ' +
-            'pick screwdriver cluster', () => {
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: {
-                    'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'sd1'
-                }
-            };
-
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-            saveConfig.params.annotations = {
-                'screwdriver.cd/prChain': 'fork',
-                'screwdriver.cd/buildCluster': 'sd1'
-            };
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: {
-                    'screwdriver.cd/prChain': 'fork'
-                }
-            }).then((model) => {
-                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
-                assert.calledWith(datastore.save, saveConfig
-                );
-                assert.instanceOf(model, Pipeline);
-            });
-        });
-
-        it('multipleBuildClusterEnabled with cluster annotations - ' +
-            'creates a new pipeline in the datastore', () => {
-            scmRepo.name = 'screwdriver/ui';
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: {
-                    'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'sd1'
-                }
-            };
-
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-            saveConfig.params.annotations = {
-                'screwdriver.cd/prChain': 'fork',
-                'screwdriver.cd/buildCluster': 'sd1'
-            };
-            saveConfig.params.name = scmRepo.name;
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: {
-                    'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'sd1'
-                }
-            }).then((model) => {
-                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
-                assert.calledWith(datastore.save, saveConfig);
-                assert.instanceOf(model, Pipeline);
-            });
-        });
-
-        it('multipleBuildClusterEnabled with cluster annotations no value - ' +
-            'creates a new pipeline in the datastore ' +
-            'pick screwdriver cluster', () => {
-            scmRepo.name = 'screwdriver/ui';
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: {
-                    'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'sd1'
-                }
-            };
-
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-            saveConfig.params.annotations = {
-                'screwdriver.cd/prChain': 'fork',
-                'screwdriver.cd/buildCluster': 'sd1'
-            };
-            saveConfig.params.name = scmRepo.name;
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: {
-                    'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': ''
-                }
-            }).then((model) => {
-                assert.calledWith(scm.decorateUrl, { scmUri, scmContext, token: 'foo' });
-                assert.calledWith(datastore.save, saveConfig
-                );
-                assert.instanceOf(model, Pipeline);
-            });
-        });
-
-        it('throws err if the pipeline is unauthorized to use the build cluster', () => {
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: { 'screwdriver.cd/buildCluster': 'iOS' }
-            };
-
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-            saveConfig.params.annotations = { 'screwdriver.cd/buildCluster': 'iOS' };
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: { 'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'iOS' }
-            }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message,
-                    'This pipeline is not authorized to use this build cluster.');
-            });
-        });
-
-        it('throws err with empty pipeline name is unauthorized to use the build cluster', () => {
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: { 'screwdriver.cd/buildCluster': 'iOS' }
-            };
-
-            scmRepo.name = 'dummy';
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-            saveConfig.params.annotations = { 'screwdriver.cd/buildCluster': 'iOS' };
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: { 'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'iOS' }
-            }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message,
-                    'This pipeline is not authorized to use this build cluster.');
-            });
-        });
-
-        it('throws err if the build cluster specified does not exist', () => {
-            const expected = {
-                id: testId,
-                admins,
-                createTime: nowTime,
-                scmUri,
-                scmRepo,
-                annotations: { 'screwdriver.cd/buildCluster': 'iOS' }
-            };
-
-            datastore.save.resolves(expected);
-            scm.decorateUrl.resolves(scmRepo);
-            buildClusterFactoryMock.get.resolves(null);
-            saveConfig.params.annotations = { 'screwdriver.cd/buildCluster': 'iOS' };
-
-            userFactoryMock.get.withArgs({
-                username: Object.keys(admins)[0],
-                scmContext
-            }).resolves({
-                unsealToken: sinon.stub().resolves('foo')
-            });
-
-            return factory.create({
-                scmUri,
-                scmContext,
-                admins,
-                annotations: { 'screwdriver.cd/prChain': 'fork',
-                    'screwdriver.cd/buildCluster': 'iOS' }
-            }).catch((err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(err.message,
-                    'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
             });
         });
     });


### PR DESCRIPTION
## Context

Pipeline update is called immediately after pipeline creation flow which leads to redundant multi build cluster assignment call.

## Objective

PR removes the multi-build cluster assignment as part of pipeline creation.

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
