### PR TITLE
fix(1339): add null check on evenConfig.meta

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -406,7 +406,7 @@ function updateEventParameters(config) {
         }
 
         allowedParameters[name] = { value: defaultParameterValue };
-        if (eventConfig.meta.parameters) {
+        if (eventConfig.meta && eventConfig.meta.parameters) {
             let actualParameterValue = eventConfig.meta.parameters[name];
 
             if (typeof actualParameterValue === 'object') {


### PR DESCRIPTION
## Context

in previous pull request I used different config object where one did not replace missing meta with empty object, which lead to internal server error.

## Objective

add null check against it

## References

https://github.com/screwdriver-cd/models/pull/412

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
