### PR TITLE
feat(1881): build cluster to support multiple scm contexts

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -148,7 +148,11 @@ async function getBuildClusterName({ annotations, pipeline, isPipelineUpdate = f
     const buildClusterFactory = BuildClusterFactory.getInstance();
     const allBuildClusters = await buildClusterFactory.list();
     const activeManagedBuildClusters = allBuildClusters.filter(cluster =>
-        cluster.managedByScrewdriver === true && cluster.isActive === true);
+        cluster.managedByScrewdriver === true && cluster.isActive === true &&
+        cluster.scmContext === pipeline.scmContext);
+    const activeExternalBuildClusters = allBuildClusters.filter(cluster =>
+        cluster.managedByScrewdriver === false && cluster.isActive === true &&
+        cluster.scmContext === pipeline.scmContext);
 
     if (!buildClusterName) {
         if (activeManagedBuildClusters.length === 0) {
@@ -157,11 +161,14 @@ async function getBuildClusterName({ annotations, pipeline, isPipelineUpdate = f
 
         return getRandomCluster(activeManagedBuildClusters);
     }
-    let buildCluster = allBuildClusters.filter(cluster => cluster.name === buildClusterName);
+
+    let buildCluster = allBuildClusters.filter(cluster => cluster.name === buildClusterName &&
+        cluster.scmContext === pipeline.scmContext);
 
     if (buildCluster.length === 0) {
         // eslint-disable-next-line max-len
-        throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} does not exist.`);
+        throw new Error(`Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} ` +
+            `for scmContext ${pipeline.scmContext} does not exist.`);
     }
 
     buildCluster = buildCluster[0];
@@ -178,7 +185,13 @@ async function getBuildClusterName({ annotations, pipeline, isPipelineUpdate = f
     }
 
     if (!buildCluster.isActive && !isPipelineUpdate) {
-        return getRandomCluster(activeManagedBuildClusters);
+        if (buildCluster.managedByScrewdriver) {
+            return getRandomCluster(activeManagedBuildClusters);
+        }
+
+        if (!buildCluster.managedByScrewdriver) {
+            return getRandomCluster(activeExternalBuildClusters);
+        }
     }
 
     return buildCluster.name;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "iron": "^5.0.6",
     "lodash": "^4.17.15",
     "screwdriver-config-parser": "^4.11.6",
-    "screwdriver-data-schema": "^18.47.8",
+    "screwdriver-data-schema": "^19.1.1",
     "screwdriver-workflow-parser": "^1.8.8",
     "screwdriver-logger": "^1.0.0"
   }

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -50,7 +50,7 @@ describe('Build Factory', () => {
         { command: 'npm install', name: 'init' },
         { command: 'npm test', name: 'test' }
     ];
-    const scmContext = 'github: github.com';
+    const scmContext = 'github:github.com';
     const sdBuildClusters = [{
         name: 'sd1',
         managedByScrewdriver: true,
@@ -531,7 +531,8 @@ describe('Build Factory', () => {
             }).catch((err) => {
                 assert.instanceOf(err, Error);
                 assert.strictEqual(err.message,
-                    'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
+                    'Cluster specified in screwdriver.cd/buildCluster iOS ' +
+                        `for scmContext ${scmContext} does not exist.`);
             });
         });
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2159,7 +2159,8 @@ describe('Pipeline Model', () => {
             return pipeline.update().catch((err) => {
                 assert.instanceOf(err, Error);
                 assert.strictEqual(err.message,
-                    'Cluster specified in screwdriver.cd/buildCluster iOS does not exist.');
+                    'Cluster specified in screwdriver.cd/buildCluster iOS ' +
+                        `for scmContext ${pipeline.scmContext} does not exist.`);
             });
         });
 


### PR DESCRIPTION
## Context

Build cluster supports only one SCM context, which leads to error "This pipeline is not authorized to use this build cluster." if the same build cluster is used for different SCM context.

## Objective

This PR is intended for a build cluster to support multiple SCM contexts

## References

[1881](https://github.com/screwdriver-cd/screwdriver/issues/1881)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
