### PR TITLE
fix(1865): [1] Remove builds.steps 

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -484,27 +484,18 @@ class BuildModel extends BaseModel {
             const now = (new Date()).toISOString();
 
             return this.getSteps().then((steps) => {
-                if (steps.length !== 0) {
-                    return Promise.all(steps.map((step) => {
-                        if (step.startTime && !step.endTime) {
-                            step.endTime = now;
-                            step.code = ABORT_CODE;
-                        }
-
-                        return step.update();
-                    }));
+                if (steps.length === 0) {
+                    return new Promise();
                 }
 
-                this.steps = this.steps.map((step) => {
+                return Promise.all(steps.map((step) => {
                     if (step.startTime && !step.endTime) {
                         step.endTime = now;
                         step.code = ABORT_CODE;
                     }
 
-                    return step;
-                });
-
-                return this.steps;
+                    return step.update();
+                }));
             });
         };
 
@@ -576,29 +567,30 @@ class BuildModel extends BaseModel {
     getMetrics(config = { stepName: null }) {
         // add build createTime to step metrics
         const createTime = this.createTime;
+
         // filter out old steps without id and buildId info
-        let steps = this.steps;
+        return this.getSteps().then((steps) => {
+            let targetSteps;
 
-        // If stepName, get only that step
-        if (config.stepName) {
-            steps = steps.filter(s => s.name === config.stepName);
-        }
-
-        // Generate metrics
-        const metrics = steps.map((s) => {
-            // For older steps, add buildId info to it
-            if (!s.buildId) {
-                s.buildId = this.id;
+            // If stepName, get only that step
+            if (config.stepName) {
+                targetSteps = steps.filter(s => s.name === config.stepName);
             }
-            const { id, name, code, startTime, endTime } = s;
-            const duration = startTime && endTime
-                ? dayjs(endTime).diff(dayjs(startTime), 'second')
-                : null;
 
-            return { id, name, code, duration, createTime };
+            // Generate metrics
+            return Promise.all(targetSteps.map((s) => {
+                // For older steps, add buildId info to it
+                if (!s.buildId) {
+                    s.buildId = this.id;
+                }
+                const { id, name, code, startTime, endTime } = s;
+                const duration = startTime && endTime
+                    ? dayjs(endTime).diff(dayjs(startTime), 'second')
+                    : null;
+
+                return { id, name, code, duration, createTime };
+            }));
         });
-
-        return metrics;
     }
 }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -608,7 +608,7 @@ class BuildModel extends BaseModel {
             sortBy: 'id',
             sort: 'ascending' })
             .then((steps) => {
-                if (!steps) {
+                if (!steps.length) {
                     throw new Error('Steps do not exist');
                 }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -592,6 +592,38 @@ class BuildModel extends BaseModel {
             }));
         });
     }
+
+    /**
+     * Get a JSON representation of the build data with steps
+     * @method toJsonWithSteps
+     * @return {Promise} Resolves JSON of build with steps
+     */
+    toJsonWithSteps() {
+        // eslint-disable-next-line global-require
+        const StepFactory = require('./stepFactory');
+        const stepFactory = StepFactory.getInstance();
+
+        return stepFactory.list({
+            params: { buildId: this.id },
+            sortBy: 'id',
+            sort: 'ascending' })
+            .then((steps) => {
+                if (!steps) {
+                    throw new Error('Steps do not exist');
+                }
+
+                // This if statement should be removed after enough time has passed since build.steps removed.
+                // Make orders of steps in completed builds sure,
+                // because steps in old builds in DB have the order not sorted.
+                if (this.endTime) {
+                    steps.sort((a, b) =>
+                        new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+                    );
+                }
+
+                return Object.assign(this.toJson(), { steps });
+            });
+    }
 }
 
 module.exports = BuildModel;

--- a/lib/build.js
+++ b/lib/build.js
@@ -3,6 +3,7 @@
 const BaseModel = require('./base');
 const dayjs = require('dayjs');
 const hoek = require('hoek');
+const deepcopy = require('deepcopy');
 const logger = require('screwdriver-logger');
 const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 
@@ -639,7 +640,7 @@ class BuildModel extends BaseModel {
                     );
                 }
 
-                return Object.assign(this.toJson(), { steps });
+                return Object.assign(deepcopy(this.toJson()), { steps });
             });
     }
 }

--- a/lib/build.js
+++ b/lib/build.js
@@ -570,7 +570,7 @@ class BuildModel extends BaseModel {
 
         // filter out old steps without id and buildId info
         return this.getSteps().then((steps) => {
-            let targetSteps;
+            let targetSteps = steps;
 
             // If stepName, get only that step
             if (config.stepName) {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -228,11 +228,6 @@ class BuildFactory extends BaseFactory {
                         permutation.environment
                     );
 
-                    let steps = permutation.commands.map(command => ({
-                        name: command.name,
-                        command: command.command
-                    }));
-
                     const bookendConfig = { pipeline, job, build: modelConfig };
 
                     if (pipeline.configPipelineId) {
@@ -245,14 +240,22 @@ class BuildFactory extends BaseFactory {
                         this.bookend.getTeardownCommands(bookendConfig)
                     ]);
 
-                    steps = setup.concat(steps, teardown);
-                    // Launcher is hardcoded to do some business in sd-setup-launcher
-                    steps.unshift({ name: 'sd-setup-launcher' });
                     modelConfig.createTime = (new Date(number)).toISOString();
-                    steps.unshift({
-                        name: 'sd-setup-init',
-                        startTime: modelConfig.createTime
-                    });
+                    const steps = [
+                        {
+                            name: 'sd-setup-init',
+                            startTime: modelConfig.createTime
+                        },
+                        // Launcher is hardcoded to do some business in sd-setup-launcher
+                        { name: 'sd-setup-launcher' },
+                        ...setup,
+                        ...permutation.commands.map(command => ({
+                            name: command.name,
+                            command: command.command
+                        })),
+                        ...teardown
+                    ];
+
                     modelConfig.stats = {};
 
                     const build = await super.create(modelConfig);

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -93,34 +93,6 @@ function dockerImageName({ container, dockerRegistry }) {
     return updatedName.fullname;
 }
 
-/**
- * Merge build with step models
- * @method mergeStepsModel
- * @param  {Build}        build     Build model
- * @return {Promise}                Build model with merged steps
- */
-function mergeStepsModel(build) {
-    if (!build) {
-        return Promise.resolve(build);
-    }
-
-    return build.getSteps()
-        .then((stepsModel) => {
-            build.steps = build.steps.map((step) => {
-                const stepModel = stepsModel.find(s => s.name === step.name);
-
-                // For backward compatibility, old builds do not have stepModel
-                if (stepModel) {
-                    return stepModel.toJson();
-                }
-
-                return step;
-            });
-
-            return build;
-        });
-}
-
 class BuildFactory extends BaseFactory {
     /**
      * Construct a JobFactory object
@@ -302,16 +274,6 @@ class BuildFactory extends BaseFactory {
     }
 
     /**
-     * Get a build based on id
-     * @method get
-     * @param  {Mixed}   config    The configuration from which an id is generated or the actual id
-     * @return {Promise}           Resolve build model after merging with step models
-     */
-    get(config) {
-        return super.get(config).then(mergeStepsModel);
-    }
-
-    /**
      * List secrets with pagination and filter options
      * @method list
      * @param  {Object}   config                  Config object
@@ -320,22 +282,12 @@ class BuildFactory extends BaseFactory {
      * @param  {Number}   config.paginate.count   Number of items per page
      * @param  {Number}   config.paginate.page    Specific page of the set to return
      * @param  {String}   config.sortBy           Key to sort builds table
-     * @param  {Boolean}  [config.fetchSteps]     Fetch steps for all the builds, default is true
      * @return {Promise}                          Resolve builds after merging with step models
      */
     list(config) {
-        const fetchSteps = config.fetchSteps || false;
-
         config.sortBy = config.sortBy || 'createTime';
 
-        return super.list(config)
-            .then((builds) => {
-                if (fetchSteps) {
-                    return Promise.all(builds.map(mergeStepsModel));
-                }
-
-                return builds;
-            });
+        return super.list(config);
     }
 
     /**

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -240,36 +240,36 @@ class BuildFactory extends BaseFactory {
                         bookendConfig.configPipelineSha = configPipelineSha;
                     }
 
-                    return Promise.all([
+                    const [setup, teardown] = await Promise.all([
                         this.bookend.getSetupCommands(bookendConfig),
                         this.bookend.getTeardownCommands(bookendConfig)
-                    ]).then(([setup, teardown]) => {
-                        modelConfig.steps = setup.concat(modelConfig.steps, teardown);
-                        // Launcher is hardcoded to do some business in sd-setup-launcher
-                        modelConfig.steps.unshift({ name: 'sd-setup-launcher' });
-                        modelConfig.createTime = (new Date(number)).toISOString();
-                        modelConfig.steps.unshift({
-                            name: 'sd-setup-init',
-                            startTime: modelConfig.createTime
-                        });
-                        modelConfig.stats = {};
+                    ]);
 
-                        return super.create(modelConfig);
+                    modelConfig.steps = setup.concat(modelConfig.steps, teardown);
+                    // Launcher is hardcoded to do some business in sd-setup-launcher
+                    modelConfig.steps.unshift({ name: 'sd-setup-launcher' });
+                    modelConfig.createTime = (new Date(number)).toISOString();
+                    modelConfig.steps.unshift({
+                        name: 'sd-setup-init',
+                        startTime: modelConfig.createTime
                     });
-                })
-                    .then(build => Promise.all(modelConfig.steps.map(step =>
-                        stepFactory.create(Object.assign(
+                    modelConfig.stats = {};
+
+                    const build = await super.create(modelConfig);
+
+                    await modelConfig.steps.reduce((p, step) =>
+                        p.then(() => stepFactory.create(Object.assign(
                             { buildId: build.id },
                             step
-                        )))).then(() => build)
-                    )
-                    .then((build) => {
-                        if (start === false) {
-                            return build;
-                        }
+                        )))
+                        , Promise.resolve());
 
-                        return build.start({ causeMessage });
-                    });
+                    if (start === false) {
+                        return build;
+                    }
+
+                    return build.start({ causeMessage });
+                });
             });
     }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -228,7 +228,7 @@ class BuildFactory extends BaseFactory {
                         permutation.environment
                     );
 
-                    modelConfig.steps = permutation.commands.map(command => ({
+                    let steps = permutation.commands.map(command => ({
                         name: command.name,
                         command: command.command
                     }));
@@ -245,11 +245,11 @@ class BuildFactory extends BaseFactory {
                         this.bookend.getTeardownCommands(bookendConfig)
                     ]);
 
-                    modelConfig.steps = setup.concat(modelConfig.steps, teardown);
+                    steps = setup.concat(steps, teardown);
                     // Launcher is hardcoded to do some business in sd-setup-launcher
-                    modelConfig.steps.unshift({ name: 'sd-setup-launcher' });
+                    steps.unshift({ name: 'sd-setup-launcher' });
                     modelConfig.createTime = (new Date(number)).toISOString();
-                    modelConfig.steps.unshift({
+                    steps.unshift({
                         name: 'sd-setup-init',
                         startTime: modelConfig.createTime
                     });
@@ -257,7 +257,7 @@ class BuildFactory extends BaseFactory {
 
                     const build = await super.create(modelConfig);
 
-                    await modelConfig.steps.reduce((p, step) =>
+                    await steps.reduce((p, step) =>
                         p.then(() => stepFactory.create(Object.assign(
                             { buildId: build.id },
                             step

--- a/lib/job.js
+++ b/lib/job.js
@@ -297,8 +297,8 @@ class Job extends BaseModel {
         const allBuilds = await getAllRecords.call(this,
             'getBuilds', config.aggregateInterval, options, [[]]);
 
-        return Promise.all(allBuilds.map((sameIntervalBuilds) => {
-            return Promise.all(sameIntervalBuilds.map(b =>
+        return Promise.all(allBuilds.map(sameIntervalBuilds =>
+            Promise.all(sameIntervalBuilds.map(b =>
                 findMetrics(b, config.stepName, config.aggregateInterval)
                     .then(metrics => metrics.duration)))
                 .then((metrics) => {
@@ -320,10 +320,9 @@ class Job extends BaseModel {
                     return {
                         createTime: sameIntervalBuilds[0].createTime,
                         duration
-                    }
+                    };
                 }
-            );
-        }));
+                )));
     }
 }
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -17,7 +17,7 @@ const DEFAULT_COUNT = 10;
  * @param  {Object}    build              build object
  * @param  {String}    stepName           only include this step
  * @param  {String}    aggregateInterval  Include step metrics if no aggregation
- * @return {Array}                        Array of metrics
+ * @return {Promise}                      Resolves of metrics
  */
 async function findMetrics(build, stepName, aggregateInterval) {
     const { id, jobId, eventId, createTime, sha, status, startTime, endTime } = build;

--- a/lib/job.js
+++ b/lib/job.js
@@ -19,7 +19,7 @@ const DEFAULT_COUNT = 10;
  * @param  {String}    aggregateInterval  Include step metrics if no aggregation
  * @return {Array}                        Array of metrics
  */
-function findMetrics(build, stepName, aggregateInterval) {
+async function findMetrics(build, stepName, aggregateInterval) {
     const { id, jobId, eventId, createTime, sha, status, startTime, endTime } = build;
     const duration = startTime && endTime
         ? dayjs(endTime).diff(dayjs(startTime), 'second')
@@ -27,7 +27,7 @@ function findMetrics(build, stepName, aggregateInterval) {
     const metrics = { id, jobId, eventId, createTime, sha, status, duration };
 
     if (!aggregateInterval || aggregateInterval === 'none') {
-        metrics.steps = build.getMetrics({ stepName });
+        metrics.steps = await build.getMetrics({ stepName });
     }
 
     return metrics;
@@ -288,39 +288,42 @@ class Job extends BaseModel {
             const builds = await this.getBuilds(options);
 
             // Generate metrics
-            return builds.map(b => findMetrics(b, config.stepName, config.aggregateInterval));
+            return Promise.all(builds.map(b => findMetrics(
+                b, config.stepName, config.aggregateInterval
+            )));
         }
 
         options.paginate.page = 1;
         const allBuilds = await getAllRecords.call(this,
             'getBuilds', config.aggregateInterval, options, [[]]);
-        const aggregatedMetrics = [];
 
-        allBuilds.forEach((sameIntervalBuilds) => {
-            const metrics = sameIntervalBuilds.map(b =>
-                findMetrics(b, config.stepName, config.aggregateInterval).duration);
-            let emptyCount = 0;
+        return Promise.all(allBuilds.map((sameIntervalBuilds) => {
+            return Promise.all(sameIntervalBuilds.map(b =>
+                findMetrics(b, config.stepName, config.aggregateInterval)
+                    .then(metrics => metrics.duration)))
+                .then((metrics) => {
+                    let emptyCount = 0;
 
-            const totalDuration = metrics.reduce((acc, current) => {
-                if (current) {
-                    return acc + current;
+                    const totalDuration = metrics.reduce((acc, current) => {
+                        if (current) {
+                            return acc + current;
+                        }
+
+                        emptyCount += 1;
+
+                        return acc;
+                    });
+                    const duration = metrics.length > emptyCount
+                        ? +(totalDuration / (metrics.length - emptyCount)).toFixed(2)
+                        : null;
+
+                    return {
+                        createTime: sameIntervalBuilds[0].createTime,
+                        duration
+                    }
                 }
-
-                emptyCount += 1;
-
-                return acc;
-            });
-            const duration = metrics.length > emptyCount
-                ? +(totalDuration / (metrics.length - emptyCount)).toFixed(2)
-                : null;
-
-            aggregatedMetrics.push({
-                createTime: sameIntervalBuilds[0].createTime,
-                duration
-            });
-        });
-
-        return aggregatedMetrics;
+            );
+        }));
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.15",
-    "mocha": "^7.0.0",
     "screwdriver-config-parser": "^5.1.0",
     "screwdriver-data-schema": "^19.1.1",
     "screwdriver-logger": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,13 +49,15 @@
     "base64url": "^3.0.1",
     "compare-versions": "^3.5.1",
     "dayjs": "^1.8.16",
+    "deepcopy": "^2.0.0",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.15",
+    "mocha": "^7.0.0",
     "screwdriver-config-parser": "^5.1.0",
     "screwdriver-data-schema": "^19.1.1",
-    "screwdriver-workflow-parser": "^2.0.0",
-    "screwdriver-logger": "^1.0.0"
+    "screwdriver-logger": "^1.0.0",
+    "screwdriver-workflow-parser": "^2.0.0"
   }
 }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -597,7 +597,6 @@ describe('Build Model', () => {
             config.status = 'UNSTABLE';
             build = new BuildModel(config);
 
-            build.steps = [step0, step1, step2];
             build.endTime = '2018-06-27T18:22:20.153Z';
 
             return build.update()

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1623,25 +1623,44 @@ describe('Build Model', () => {
         let stepsMock;
 
         beforeEach(() => {
-            stepsMock = [step2, step3, step1];
+            stepsMock = [step1, step2, step3];
             stepFactoryMock.list.resolves(stepsMock);
         });
 
-        it('returns the JSON with steps', () => {
+        it('returns the JSON with steps sorted by step.id', () =>
             build.toJsonWithSteps()
                 .then((json) => {
-                    assert.deepEqual(json, Object.assign(build.toJson(), { stepsMock }));
+                    const expected = Object.assign({}, build.toJson(),
+                        { steps: [step1, step2, step3] });
+
+                    assert.deepStrictEqual(json, expected);
+                })
+        );
+
+        it('returns the JSON with steps sorted by step.createTime', () => {
+            const configWithEndTime = Object.assign({}, config);
+
+            configWithEndTime.endTime = '2019-01-22T22:30: 00.000Z';
+            build = new BuildModel(configWithEndTime);
+
+            return build.toJsonWithSteps()
+                .then((json) => {
+                    const expected = Object.assign({}, build.toJson(),
+                        { steps: [step2, step3, step1] });
+
+                    assert.deepStrictEqual(json, expected);
                 });
         });
+
         it('throws error if steps missing ', () => {
             stepFactoryMock.list.resolves([]);
 
             return build.toJsonWithSteps()
-                .then(() => {
-                    assert.fail('nope');
-                }).catch((err) => {
-                    assert.equal('Steps do not exist', err.message);
-                });
+                .then(() =>
+                    assert.fail('nope')
+                ).catch(err =>
+                    assert.equal('Steps do not exist', err.message)
+                );
         });
     });
 });

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -216,17 +216,23 @@ describe('Build Model', () => {
         let step0;
         let step1;
         let step2;
+        let stepsMock;
 
         beforeEach(() => {
             step0 = { name: 'task0', startTime: 'now', endTime: 'then', code: 0 };
             step1 = { name: 'task1', startTime: 'now' };
             step2 = { name: 'task2' };
 
-            build.steps = [step0, step1, step2];
+            const step0Mock = Object.assign({ update: sinon.stub().resolves({}) }, step0);
+            const step1Mock = Object.assign({ update: sinon.stub().resolves({}) }, step1);
+            const step2Mock = Object.assign({ update: sinon.stub().resolves({}) }, step2);
+
+            stepsMock = [step0Mock, step1Mock, step2Mock];
 
             executorMock.stop.resolves(null);
             datastore.update.resolves({});
             jobFactoryMock.get.resolves(jobMock);
+            stepFactoryMock.list.resolves(stepsMock);
         });
 
         it('promises to update a build, stop the executor, and update status to failure', () => {
@@ -255,14 +261,16 @@ describe('Build Model', () => {
                         freezeWindows,
                         blockedBy: [jobId]
                     });
-
+                    delete stepsMock[0].update;
+                    delete stepsMock[1].update;
+                    delete stepsMock[2].update;
                     // Completed step is not modified
-                    assert.deepEqual(build.steps[0], step0);
+                    assert.deepEqual(stepsMock[0], step0);
                     // In progress step is aborted
-                    assert.ok(build.steps[1].endTime);
-                    assert.equal(build.steps[1].code, 130);
+                    assert.ok(stepsMock[1].endTime);
+                    assert.equal(stepsMock[1].code, 130);
                     // Unstarted step is not modified
-                    assert.deepEqual(build.steps[2], step2);
+                    assert.deepEqual(stepsMock[2], step2);
 
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
@@ -326,14 +334,16 @@ describe('Build Model', () => {
                         freezeWindows,
                         blockedBy: [jobId]
                     });
-
+                    delete stepsMock[0].update;
+                    delete stepsMock[1].update;
+                    delete stepsMock[2].update;
                     // Completed step is not modified
-                    assert.deepEqual(build.steps[0], step0);
+                    assert.deepEqual(stepsMock[0], step0);
                     // In progress step is aborted
-                    assert.ok(build.steps[1].endTime);
-                    assert.equal(build.steps[1].code, 130);
+                    assert.ok(stepsMock[1].endTime);
+                    assert.equal(stepsMock[1].code, 130);
                     // Unstarted step is not modified
-                    assert.deepEqual(build.steps[2], step2);
+                    assert.deepEqual(stepsMock[2], step2);
                     assert.calledWith(scmMock.updateCommitStatus.firstCall, {
                         token: 'foo',
                         scmUri,
@@ -407,13 +417,16 @@ describe('Build Model', () => {
                         blockedBy: [jobId]
                     });
 
+                    delete stepsMock[0].update;
+                    delete stepsMock[1].update;
+                    delete stepsMock[2].update;
                     // Completed step is not modified
-                    assert.deepEqual(build.steps[0], step0);
+                    assert.deepEqual(stepsMock[0], step0);
                     // In progress step is aborted
-                    assert.ok(build.steps[1].endTime);
-                    assert.equal(build.steps[1].code, 130);
+                    assert.ok(stepsMock[1].endTime);
+                    assert.equal(stepsMock[1].code, 130);
                     // Unstarted step is not modified
-                    assert.deepEqual(build.steps[2], step2);
+                    assert.deepEqual(stepsMock[2], step2);
                     assert.calledWith(scmMock.updateCommitStatus.firstCall, {
                         token: 'foo',
                         scmUri,
@@ -465,13 +478,16 @@ describe('Build Model', () => {
                         blockedBy: [jobId]
                     });
 
+                    delete stepsMock[0].update;
+                    delete stepsMock[1].update;
+                    delete stepsMock[2].update;
                     // Completed step is not modified
-                    assert.deepEqual(build.steps[0], step0);
+                    assert.deepEqual(stepsMock[0], step0);
                     // In progress step is aborted
-                    assert.ok(build.steps[1].endTime);
-                    assert.equal(build.steps[1].code, 130);
+                    assert.ok(stepsMock[1].endTime);
+                    assert.equal(stepsMock[1].code, 130);
                     // Unstarted step is not modified
-                    assert.deepEqual(build.steps[2], step2);
+                    assert.deepEqual(stepsMock[2], step2);
 
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
@@ -487,19 +503,13 @@ describe('Build Model', () => {
         });
 
         it('aborts running steps, and sets an endTime with step models', () => {
-            const step0Mock = Object.assign({ update: sinon.stub().resolves({}) }, step0);
-            const step1Mock = Object.assign({ update: sinon.stub().resolves({}) }, step1);
-            const step2Mock = Object.assign({ update: sinon.stub().resolves({}) }, step2);
-            const stepsMock = [step0Mock, step1Mock, step2Mock];
-
             build.status = 'ABORTED';
-            stepFactoryMock.list.resolves(stepsMock);
 
             return build.update()
                 .then(() => {
-                    assert.calledOnce(step0Mock.update);
-                    assert.calledOnce(step1Mock.update);
-                    assert.calledOnce(step2Mock.update);
+                    assert.calledOnce(stepsMock[0].update);
+                    assert.calledOnce(stepsMock[1].update);
+                    assert.calledOnce(stepsMock[2].update);
                     assert.calledWith(executorMock.stop, {
                         buildId,
                         jobId,
@@ -508,16 +518,16 @@ describe('Build Model', () => {
                         blockedBy: [jobId]
                     });
 
+                    delete stepsMock[0].update;
+                    delete stepsMock[1].update;
+                    delete stepsMock[2].update;
                     // Completed step is not modified
-                    delete step0Mock.update;
-                    delete step1Mock.update;
-                    delete step2Mock.update;
-                    assert.deepEqual(step0Mock, step0);
+                    assert.deepEqual(stepsMock[0], step0);
                     // In progress step is aborted
-                    assert.ok(step1Mock.endTime);
-                    assert.equal(step1Mock.code, 130);
+                    assert.ok(stepsMock[1].endTime);
+                    assert.equal(stepsMock[1].code, 130);
                     // Unstarted step is not modified
-                    assert.deepEqual(step2Mock, step2);
+                    assert.deepEqual(stepsMock[2], step2);
 
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
@@ -634,12 +644,15 @@ describe('Build Model', () => {
                     });
 
                     // Completed step is not modified
-                    assert.deepEqual(build.steps[0], step0);
+                    delete stepsMock[0].update;
+                    delete stepsMock[1].update;
+                    delete stepsMock[2].update;
+                    assert.deepEqual(stepsMock[0], step0);
                     // In progress step is aborted
-                    assert.ok(build.steps[1].endTime);
-                    assert.equal(build.steps[1].code, 130);
+                    assert.ok(stepsMock[1].endTime);
+                    assert.equal(stepsMock[1].code, 130);
                     // Unstarted step is not modified
-                    assert.deepEqual(build.steps[2], step2);
+                    assert.deepEqual(stepsMock[2], step2);
                     assert.calledWith(scmMock.updateCommitStatus, {
                         token: 'foo',
                         scmUri,
@@ -1481,8 +1494,12 @@ describe('Build Model', () => {
         const duration2 = (new Date(step2.endTime) - new Date(step2.startTime)) / 1000;
         const duration3 = (new Date(step3.endTime) - new Date(step3.startTime)) / 1000;
         let metrics;
+        let stepsMock;
 
         beforeEach(() => {
+            stepsMock = [step1, step2, step3];
+            stepFactoryMock.list.resolves(stepsMock);
+
             metrics = [{
                 id: step1.id,
                 name: step1.name,
@@ -1504,25 +1521,22 @@ describe('Build Model', () => {
             }];
         });
 
-        it('generates metrics', () => {
-            build.steps = [step1, step2, step3];
-
-            assert.deepEqual(build.getMetrics(), metrics);
-        });
+        it('generates metrics', () => build.getMetrics().then(m => assert.deepEqual(m, metrics)));
 
         it('does not fail if empty steps', () => {
-            build.steps = [];
+            stepFactoryMock.list.resolves([]);
 
-            assert.deepEqual(build.getMetrics(), []);
+            return build.getMetrics().then(m => assert.deepEqual(m, []));
         });
 
         it('works with no startTime or endTime params passed in', () => {
             const stepName = 'sd-setup-scm';
 
-            build.steps = [step1, step2];
             metrics = metrics.filter(m => m.name === stepName);
 
-            assert.deepEqual(build.getMetrics({ stepName }), metrics);
+            return build.getMetrics({ stepName }).then((m) => {
+                assert.deepEqual(m, metrics);
+            });
         });
     });
 });

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1571,20 +1571,19 @@ describe('Build Model', () => {
 
         it('returns the JSON with steps', () => {
             build.toJsonWithSteps()
-                .then(json => {
+                .then((json) => {
                     assert.deepEqual(json, Object.assign(build.toJson(), { stepsMock }));
-                })
+                });
         });
         it('throws error if steps missing ', () => {
-            stepFactoryMock.list.resolves(null);
+            stepFactoryMock.list.resolves([]);
 
             return build.toJsonWithSteps()
-            .then(() => {
-                assert.fail('nope');
-            }).catch(err => {
-                assert.equal('Steps do not exist', err.message);
-            });
+                .then(() => {
+                    assert.fail('nope');
+                }).catch((err) => {
+                    assert.equal('Steps do not exist', err.message);
+                });
         });
-
     });
 });

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1538,4 +1538,53 @@ describe('Build Model', () => {
             });
         });
     });
+
+    describe('get JSON with steps', () => {
+        const step1 = {
+            id: 11,
+            buildId,
+            name: 'install',
+            startTime: '2019-01-22T21:31:00.000Z',
+            endTime: '2019-01-22T22:35:00.000Z',
+            code: 0
+        };
+        const step2 = {
+            id: 12,
+            buildId,
+            name: 'sd-setup-init',
+            startTime: '2019-01-22T21:08:00.000Z',
+            endTime: '2019-01-22T21:30:00.000Z',
+            code: 127
+        };
+        const step3 = {
+            name: 'sd-setup-scm',
+            startTime: '2019-01-22T21:21:00.000Z',
+            endTime: '2019-01-22T22:30:00.000Z',
+            code: 127
+        };
+        let stepsMock;
+
+        beforeEach(() => {
+            stepsMock = [step2, step3, step1];
+            stepFactoryMock.list.resolves(stepsMock);
+        });
+
+        it('returns the JSON with steps', () => {
+            build.toJsonWithSteps()
+                .then(json => {
+                    assert.deepEqual(json, Object.assign(build.toJson(), { stepsMock }));
+                })
+        });
+        it('throws error if steps missing ', () => {
+            stepFactoryMock.list.resolves(null);
+
+            return build.toJsonWithSteps()
+            .then(() => {
+                assert.fail('nope');
+            }).catch(err => {
+                assert.equal('Steps do not exist', err.message);
+            });
+        });
+
+    });
 });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -2,7 +2,6 @@
 
 const assert = require('chai').assert;
 const mockery = require('mockery');
-const hoek = require('hoek');
 const schema = require('screwdriver-data-schema');
 const sinon = require('sinon');
 let startStub;
@@ -845,12 +844,11 @@ describe('Build Factory', () => {
     });
 
     describe('list', () => {
-
         it('should list builds without step models', () => {
             datastore.scan.resolves([]);
 
             return factory.list({})
-                .then((builds) => {
+                .then(() => {
                     assert.calledWithMatch(datastore.scan, { sortBy: 'createTime' });
                 });
         });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -302,7 +302,6 @@ describe('Build Factory', () => {
                     status: 'QUEUED',
                     container,
                     environment,
-                    steps,
                     jobId,
                     sha,
                     meta,
@@ -697,7 +696,12 @@ describe('Build Factory', () => {
 
             return factory.create({ username, jobId, eventId, prRef }).then((model) => {
                 assert.instanceOf(model, Build);
-                assert.deepEqual(model.steps, expectedSteps);
+                sinon.assert.callOrder(...expectedSteps.map(step =>
+                    stepFactoryMock.create.withArgs(Object.assign(
+                        { buildId: model.id },
+                        step
+                    ))
+                ));
             });
         });
 

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -844,82 +844,15 @@ describe('Build Factory', () => {
         });
     });
 
-    describe('get', () => {
-        const buildId = 123;
-        const buildData = {
-            steps
-        };
-        const stepsData = steps.map(step => Object.assign({ code: 0 }, step));
-        const stepsMock = stepsData.map((step) => {
-            const mock = hoek.clone(step);
-
-            mock.toJson = sinon.stub().returns(step);
-
-            return mock;
-        });
-
-        it('should get a build by ID without step models', () => {
-            getStepsStub.resolves([]);
-            datastore.get.resolves(buildData);
-
-            return factory.get(buildId)
-                .then(build => assert.deepEqual(build.steps, steps));
-        });
-
-        it('should get a build by ID with merged step data', () => {
-            getStepsStub.resolves(stepsMock);
-            datastore.get.resolves(buildData);
-
-            return factory.get(buildId)
-                .then(build => assert.deepEqual(build.steps, stepsData));
-        });
-
-        it('should not throw when build does not exist', () => {
-            datastore.get.resolves(null);
-
-            return factory.get(buildId)
-                .then(build => assert.deepEqual(build, null));
-        });
-    });
-
     describe('list', () => {
-        const buildData = {
-            steps
-        };
-        const stepsData = steps.map(step => Object.assign({ code: 0 }, step));
-        const stepsMock = stepsData.map((step) => {
-            const mock = hoek.clone(step);
-
-            mock.toJson = sinon.stub().returns(step);
-
-            return mock;
-        });
 
         it('should list builds without step models', () => {
-            getStepsStub.resolves([]);
-            datastore.scan.resolves([buildData, buildData]);
+            datastore.scan.resolves([]);
 
             return factory.list({})
                 .then((builds) => {
-                    builds.map(build => assert.deepEqual(build.steps, steps));
                     assert.calledWithMatch(datastore.scan, { sortBy: 'createTime' });
                 });
-        });
-
-        it('should list builds with merged step data if config.fetchSteps is true', () => {
-            getStepsStub.resolves(stepsMock);
-            datastore.scan.resolves([buildData, buildData]);
-
-            return factory.list({ fetchSteps: true })
-                .then(builds => builds.map(build => assert.deepEqual(build.steps, stepsData)));
-        });
-
-        it('should not list builds with merged step data by default', () => {
-            getStepsStub.resolves(stepsMock);
-            datastore.scan.resolves([buildData, buildData]);
-
-            return factory.list({})
-                .then(builds => builds.map(build => assert.deepEqual(build.steps, steps)));
         });
     });
 

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -848,7 +848,7 @@ describe('Build Factory', () => {
     });
 
     describe('list', () => {
-        it('should list builds without step models', () => {
+        it('should list builds sorted by createTime', () => {
             datastore.scan.resolves([]);
 
             return factory.list({})

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1136,7 +1136,7 @@ describe('Event Factory', () => {
             config.creator = creatorTest;
             expected.creator = creatorTest;
 
-            eventFactory.create(config).then((model) => {
+            return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.notCalled(scm.decorateAuthor);
                 assert.calledWith(scm.decorateCommit, {
@@ -1162,8 +1162,14 @@ describe('Event Factory', () => {
 
             config.baseBranch = baseBranchTest;
             expected.baseBranch = baseBranchTest;
+            config.creator = {
+                name: 'St John',
+                username: 'stjohn',
+                avatar: "https://avatars.githubusercontent.com/u/2042?v=3",
+                url: "https://github.com/stjohn"
+            };
 
-            eventFactory.create(config).then((model) => {
+            return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
                 assert.notCalled(scm.decorateAuthor);
                 assert.calledWith(scm.decorateCommit, {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1165,8 +1165,8 @@ describe('Event Factory', () => {
             config.creator = {
                 name: 'St John',
                 username: 'stjohn',
-                avatar: "https://avatars.githubusercontent.com/u/2042?v=3",
-                url: "https://github.com/stjohn"
+                avatar: 'https://avatars.githubusercontent.com/u/2042?v=3',
+                url: 'https://github.com/stjohn'
             };
 
             return eventFactory.create(config).then((model) => {


### PR DESCRIPTION
## Context
As mentioned here screwdriver-cd/screwdriver#1865 , `builds.steps` and `steps.command` are both same data.
And these steps are defined by user's yaml and it tends to have a big size.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR reduces DB size by remove builds.steps in build table.
And did some refactoring.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1865

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
