### PR TITLE
fix(1710): Store jobId for external nodes in workflowgraph [2]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -810,22 +810,39 @@ class PipelineModel extends BaseModel {
             })
             // wait until all promises have resolved
             .then((updatedJobs) => {
-                // Add jobId to workflowGraph.nodes
                 const nodes = this.workflowGraph.nodes;
 
+                // Add jobId to workflowGraph.nodes
                 nodes.forEach((node) => {
+                    // Handle external nodes
+                    if (/sd@/.test(node.name)) {
+                        const pipelineFactory = this._getPipelineFactory();
+                        const [, externalPipelineId, externalJobName] =
+                            /sd@(\d+):([\w-]+)$/.exec(node.name);
+
+                        return pipelineFactory.get(externalPipelineId).then((externalPipeline) => {
+                            const externalJobId = externalPipeline.workflowGraph.nodes
+                                .find(n => n.name === externalJobName).id;
+
+                            node.id = externalJobId;
+                        }).then(() => {
+                            delete this.jobs;
+
+                            return this.update();
+                        });
+                    }
                     const job = updatedJobs.find(j => j.name === node.name);
 
+                    // Handle internal nodes
                     if (job) {
                         node.id = job.id;
                     }
+                    // jobs updated or new jobs created during sync
+                    // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
+                    delete this.jobs;
+
+                    return this.update();
                 });
-
-                // jobs updated or new jobs created during sync
-                // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
-                delete this.jobs;
-
-                return this.update();
             })
             .then(() => this);
     }

--- a/test/data/parser.json
+++ b/test/data/parser.json
@@ -82,12 +82,14 @@
             { "name": "~pr" },
             { "name": "~commit" },
             { "name": "main" },
-            { "name": "publish" }
+            { "name": "publish" },
+            { "name": "sd@123:main" }
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "publish" }
+            { "src": "main", "dest": "publish" },
+            { "src": "publish", "dest": "sd@123:main" }
         ]
     },
     "annotations": {


### PR DESCRIPTION
## Context

We currently do not store jobId for external nodes.

## Objective

This PR will look up the jobId for the external node and store it in the workflowgraph.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
