### PR TITLE
fix(1839): Start and stop build timer

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -527,7 +527,6 @@ class BuildModel extends BaseModel {
             .then(() => this.job.then((job) => { // get latest status
                 // status is changing to RUNNING so start timer
                 if (this.status === 'RUNNING' && this.isDirty('status')) {
-
                     const config = {
                         buildId: this.id,
                         jobId: job.id,

--- a/lib/build.js
+++ b/lib/build.js
@@ -458,7 +458,8 @@ class BuildModel extends BaseModel {
                         container: this.container,
                         tokenGen: this[tokenGen],
                         token: this[tokenGen](this.id, tokenGenConfig,
-                            pipeline.scmContext, TEMPORAL_JWT_TIMEOUT) };
+                            pipeline.scmContext, TEMPORAL_JWT_TIMEOUT)
+                    };
 
                     if (this.buildClusterName) {
                         config.buildClusterName = this.buildClusterName;
@@ -523,6 +524,23 @@ class BuildModel extends BaseModel {
         }
 
         return prom
+            .then(() => this.job.then((job) => { // get latest status
+                // status is changing to RUNNING so start timer
+                if (this.status === 'RUNNING' && this.isDirty('status')) {
+
+                    const config = {
+                        buildId: this.id,
+                        jobId: job.id,
+                        startTime: this.startTime,
+                        annotations: job.permutations[0].annotations,
+                        buildStatus: this.status
+                    };
+
+                    return this[executor].startTimer(config);
+                }
+
+                return Promise.resolve();
+            }))
             .then(() => super.update())
             .then(() => this);
     }
@@ -549,7 +567,8 @@ class BuildModel extends BaseModel {
                         config.buildClusterName = this.buildClusterName;
                     }
 
-                    return this[executor].stop(config);
+                    return this[executor].stop(config)
+                        .then(() => this[executor].stopTimer(config));
                 }))
             .then(() => this);
     }
@@ -561,7 +580,7 @@ class BuildModel extends BaseModel {
      */
     isDone() {
         return ['ABORTED', 'FAILURE', 'SUCCESS'].includes(this.status) ||
-        (this.status === 'UNSTABLE' && !!this.endTime);
+            (this.status === 'UNSTABLE' && !!this.endTime);
     }
 
     /**


### PR DESCRIPTION
## Context

To store and clear build start time information

## Objective

This PR will call executor startTimer function on build update when status is changing RUNNING and call stopTimer when the build is getting stopped.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1839

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
