### PR TITLE
fix(1870): external pipeline triggered build's parameter not set

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -628,6 +628,10 @@ class EventFactory extends BaseFactory {
                         modelConfig.meta.parameters = updatedParameters;
                     }
 
+                    if (!config.meta) {
+                        config.meta = modelConfig.meta;
+                    }
+
                     return super.create(modelConfig);
                 })
                 .then((event) => {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1546,6 +1546,22 @@ describe('Event Factory', () => {
                 assert.equal(model.meta.parameters.user.value, 'adong');
             });
         });
+
+        it('should have default parameters if parameter enabled', () => {
+            const pipelineWithParameter = Object.assign({
+                parameters: {
+                    user: 'adong'
+                }
+            }, syncedPipelineMock);
+
+            pipelineMock.sync = sinon.stub().resolves(pipelineWithParameter);
+            config.startFrom = 'main';
+
+            return eventFactory.create(config).then((model) => {
+                assert.equal(model.meta.parameters.user.value, 'adong');
+                assert.equal(config.meta.parameters.user.value, 'adong');
+            });
+        });
     });
 
     describe('getInstance', () => {


### PR DESCRIPTION
## Context

If event is triggered by external pipeline, incoming config won't have meta property. So when we assign default parameter it only got set to event but not build due to event and build using different config.

## Objective

Set meta for build config if meta property is null.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1870

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
