### PR TITLE
[Don't Merge]feat(1716): enhance latest build end point

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -204,7 +204,7 @@ class Job extends BaseModel {
         const parsedPoistion = Number(position);
         let relativePosition = -1;
 
-        if (parsedPoistion && parsedPoistion > 0) {
+        if (parsedPoistion === 0 || parsedPoistion > 0) {
             relativePosition = parsedPoistion;
         } else if (position === 'latestBuild') { // to retain old behavior
             relativePosition = 0;

--- a/lib/job.js
+++ b/lib/job.js
@@ -193,13 +193,25 @@ class Job extends BaseModel {
 
     /**
      * Return latest build that belong to this job
-     * @param  {Object}   [config]                  Configuration object
-     * @param  {String}   [config.status]           Return latest build with this status
-     * @return {Promise}                            Lastest build
+     * @param  {Object}   [config]              Configuration object
+     * @param  {String}   [config.status]       Return build with this status
+     * @param  {String}   [config.position]     Return build with this position relative to latest build
+     * @return {Promise}                        Lastest build
      */
     getLatestBuild(config = {}) {
-        return this.getBuilds({ status: config.status })
-            .then(latestBuilds => latestBuilds[0] || {});
+        const { position, status } = config;
+        // passing string instead of number to retain old behavior
+        const parsedPoistion = Number(position);
+        let relativePosition = -1;
+
+        if (parsedPoistion && parsedPoistion > 0) {
+            relativePosition = parsedPoistion;
+        } else if (position === 'latestBuild') { // to retain old behavior
+            relativePosition = 0;
+        }
+
+        return this.getBuilds({ status })
+            .then(latestBuilds => latestBuilds[relativePosition] || {});
     }
 
     /**

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -371,10 +371,70 @@ describe('Job Model', () => {
                 sort: 'descending'
             };
 
-            return job.getLatestBuild()
+            return job.getLatestBuild({ position: 'latestBuild' })
                 .then((latestBuild) => {
                     assert.calledWith(buildFactoryMock.list, expected);
                     assert.equal(latestBuild, build3);
+                });
+        });
+
+        it('gets second to latest build', () => {
+            buildFactoryMock.list.resolves([build3, build2]);
+
+            const expected = {
+                paginate: {
+                    count: 10
+                },
+                params: {
+                    jobId: 1234
+                },
+                sort: 'descending'
+            };
+
+            return job.getLatestBuild({ position: '1' })
+                .then((latestBuild) => {
+                    assert.calledWith(buildFactoryMock.list, expected);
+                    assert.equal(latestBuild, build2);
+                });
+        });
+
+        it('return empty object on invalid position', () => {
+            buildFactoryMock.list.resolves([build3, build2]);
+
+            const expected = {
+                paginate: {
+                    count: 10
+                },
+                params: {
+                    jobId: 1234
+                },
+                sort: 'descending'
+            };
+
+            return job.getLatestBuild({ position: '13' })
+                .then((latestBuild) => {
+                    assert.calledWith(buildFactoryMock.list, expected);
+                    assert.isEmpty(latestBuild);
+                });
+        });
+
+        it('return empty object on invalid position', () => {
+            buildFactoryMock.list.resolves([build3, build2]);
+
+            const expected = {
+                paginate: {
+                    count: 10
+                },
+                params: {
+                    jobId: 1234
+                },
+                sort: 'descending'
+            };
+
+            return job.getLatestBuild({ position: 'hello' })
+                .then((latestBuild) => {
+                    assert.calledWith(buildFactoryMock.list, expected);
+                    assert.isEmpty(latestBuild);
                 });
         });
 
@@ -392,7 +452,7 @@ describe('Job Model', () => {
                 sort: 'descending'
             };
 
-            return job.getLatestBuild({ status: 'QUEUED' })
+            return job.getLatestBuild({ position: 'latestBuild', status: 'QUEUED' })
                 .then((queueBuild) => {
                     assert.calledWith(buildFactoryMock.list, expected);
                     assert.equal(queueBuild, build2);
@@ -413,7 +473,7 @@ describe('Job Model', () => {
                 sort: 'descending'
             };
 
-            return job.getLatestBuild({ status: 'FAILURE' })
+            return job.getLatestBuild({ position: 'latestBuild', status: 'FAILURE' })
                 .then((failureBuild) => {
                     assert.calledWith(buildFactoryMock.list, expected);
                     assert.isEmpty(failureBuild);


### PR DESCRIPTION
## Context

currently latest build end point only returns latest build, we should allow fetching build in relative position to latest build, such as second to latest build.

## Objective

fetching build in relative position to latest build

## References

https://github.com/screwdriver-cd/screwdriver/issues/1716

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
