### PR TITLE
fix: prevent updating pipeline for each job

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -820,7 +820,7 @@ class PipelineModel extends BaseModel {
                         const [, externalPipelineId, externalJobName] =
                             /sd@(\d+):([\w-]+)$/.exec(node.name);
 
-                        return pipelineFactory.get(externalPipelineId).then((externalPipeline) => {
+                        pipelineFactory.get(externalPipelineId).then((externalPipeline) => {
                             const externalJobId = externalPipeline.workflowGraph.nodes
                                 .find(n => n.name === externalJobName).id;
 
@@ -830,19 +830,21 @@ class PipelineModel extends BaseModel {
 
                             return this.update();
                         });
-                    }
-                    const job = updatedJobs.find(j => j.name === node.name);
+                    } else {
+                        const job = updatedJobs.find(j => j.name === node.name);
 
-                    // Handle internal nodes
-                    if (job) {
-                        node.id = job.id;
+                        // Handle internal nodes
+                        if (job) {
+                            node.id = job.id;
+                        }
                     }
                     // jobs updated or new jobs created during sync
                     // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
-                    delete this.jobs;
-
-                    return this.update();
                 });
+
+                delete this.jobs;
+
+                return this.update();
             })
             .then(() => this);
     }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -825,10 +825,6 @@ class PipelineModel extends BaseModel {
                                 .find(n => n.name === externalJobName).id;
 
                             node.id = externalJobId;
-                        }).then(() => {
-                            delete this.jobs;
-
-                            return this.update();
                         });
                     } else {
                         const job = updatedJobs.find(j => j.name === node.name);

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -813,34 +813,46 @@ class PipelineModel extends BaseModel {
                 const nodes = this.workflowGraph.nodes;
 
                 // Add jobId to workflowGraph.nodes
-                nodes.forEach((node) => {
+                return Promise.all(nodes.map((node) => {
                     // Handle external nodes
                     if (/sd@/.test(node.name)) {
                         const pipelineFactory = this._getPipelineFactory();
                         const [, externalPipelineId, externalJobName] =
                             /sd@(\d+):([\w-]+)$/.exec(node.name);
 
-                        pipelineFactory.get(externalPipelineId).then((externalPipeline) => {
-                            const externalJobId = externalPipeline.workflowGraph.nodes
-                                .find(n => n.name === externalJobName).id;
+                        return pipelineFactory.get(externalPipelineId).then((externalPipeline) => {
+                            const externalWorkflow = externalPipeline.workflowGraph;
 
-                            node.id = externalJobId;
+                            if (externalWorkflow && Array.isArray(externalWorkflow.nodes)) {
+                                const externalJobId = externalWorkflow.nodes
+                                    .find(n => n.name === externalJobName).id;
+
+                                node.id = externalJobId;
+                            } else {
+                                logger.error(`pipelineId:${externalPipelineId}: has no workflow.`);
+                            }
+
+                            return node;
+                        }).catch(() => {
+                            logger.error(`pipelineId:${externalPipelineId}: does not exist.`);
                         });
-                    } else {
-                        const job = updatedJobs.find(j => j.name === node.name);
-
-                        // Handle internal nodes
-                        if (job) {
-                            node.id = job.id;
-                        }
                     }
-                    // jobs updated or new jobs created during sync
-                    // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
-                });
+                    const job = updatedJobs.find(j => j.name === node.name);
 
-                delete this.jobs;
+                    // Handle internal nodes
+                    if (job) {
+                        node.id = job.id;
+                    }
 
-                return this.update();
+                    return node;
+                }))
+                    .then(() => {
+                        // jobs updated or new jobs created during sync
+                        // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
+                        delete this.jobs;
+
+                        return this.update();
+                    });
             })
             .then(() => this);
     }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -384,7 +384,7 @@ describe('Pipeline Model', () => {
         });
     });
 
-    describe('sync', () => {
+    describe.only('sync', () => {
         let publishMock;
         let mainMock;
         let externalMock;

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -384,7 +384,7 @@ describe('Pipeline Model', () => {
         });
     });
 
-    describe.only('sync', () => {
+    describe('sync', () => {
         let publishMock;
         let mainMock;
         let externalMock;
@@ -487,6 +487,7 @@ describe('Pipeline Model', () => {
 
         it('create external trigger in datastore for new jobs', () => {
             jobs = [];
+            sinon.spy(pipeline, 'update');
             parserMock.withArgs('superyamlcontent', templateFactoryMock, buildClusterFactoryMock)
                 .resolves(PARSED_YAML_WITH_REQUIRES);
             mainMock.permutations.forEach((p) => {
@@ -498,6 +499,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.create.withArgs(publishMock).resolves(publishModelMock);
 
             return pipeline.sync().then(() => {
+                assert.calledOnce(pipeline.update);
                 assert.calledOnce(triggerFactoryMock.create); // only create for external trigger
                 assert.calledWith(triggerFactoryMock.create, {
                     src: '~sd@12345:test',
@@ -547,6 +549,7 @@ describe('Pipeline Model', () => {
 
         it('stores workflowGraph to pipeline', () => {
             jobs = [];
+            sinon.spy(pipeline, 'update');
             jobFactoryMock.list.resolves(jobs);
             jobFactoryMock.create.withArgs(mainMock).resolves(mainModelMock);
             jobFactoryMock.create.withArgs(publishMock).resolves(publishModelMock);
@@ -563,6 +566,7 @@ describe('Pipeline Model', () => {
             });
 
             return pipeline.sync().then(() => {
+                assert.calledOnce(pipeline.update);
                 assert.deepEqual(pipeline.workflowGraph, {
                     nodes: [
                         { name: '~pr' },


### PR DESCRIPTION
## Context

Pipeline update is getting called for each job in the workflow graph. This should happen only once.

## Objective

When adding job id to workflow graph in pipeline, we are currently calling `update` for each node. But this should happen only once.

## References

https://github.com/screwdriver-cd/models/pull/424/files#diff-679e90b5b15ab1b73ddb7ed2377e7413R810-R848

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
