### PR TITLE
fix(1710): Add EXTERNAL_JOIN_AND trigger

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -10,7 +10,8 @@ const hoek = require('hoek');
 const dayjs = require('dayjs');
 const _ = require('lodash');
 const { getAllRecords, getBuildClusterName } = require('./helper.js');
-const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
+const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
+const EXTERNAL_TRIGGER = /^~?sd@(\d+):([\w-]+)$/;
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
     job: 2 // main or undefined if using legacy
@@ -183,7 +184,10 @@ function syncExternalTriggers(config) {
 
     const triggerFactory = TriggerFactory.getInstance();
     const newSrcList = config.requiresList;
-    const dest = `~sd@${config.pipelineId}:${config.jobName}`;
+    const dest = [
+        `~sd@${config.pipelineId}:${config.jobName}`,
+        `sd@${config.pipelineId}:${config.jobName}`
+    ];
     const processed = [];
 
     // list records that would trigger this job
@@ -198,7 +202,10 @@ function syncExternalTriggers(config) {
                 !oldSrcList.includes(src) && EXTERNAL_TRIGGER.test(src));
 
             toRemove.forEach(rec => processed.push(rec.remove()));
-            toCreate.forEach(src => processed.push(triggerFactory.create({ src, dest })));
+            toCreate.forEach(src => processed.push(triggerFactory.create({
+                src,
+                dest: `~sd@${config.pipelineId}:${config.jobName}`
+            })));
 
             return Promise.all(processed);
         });

--- a/lib/triggerFactory.js
+++ b/lib/triggerFactory.js
@@ -60,7 +60,9 @@ class TriggerFactory extends BaseFactory {
                     // Get pipeline job names
                     return pipeline.getJobs({ type: type || 'pipeline' })
                         .then((jobs) => {
-                            const srcArray = jobs.map(j => `~sd@${pipelineId}:${j.name}`);
+                            let srcArray = jobs.map(j => `~sd@${pipelineId}:${j.name}`);
+
+                            srcArray = srcArray.concat(jobs.map(j => `sd@${pipelineId}:${j.name}`));
 
                             // Get dest triggers for each src job
                             return super.list({
@@ -71,7 +73,8 @@ class TriggerFactory extends BaseFactory {
                                 // Push jobName and dest triggers to result
                                 jobs.forEach((j) => {
                                     let matchArr = triggersArr.filter(t =>
-                                        t.src === `~sd@${pipelineId}:${j.name}`);
+                                        t.src === `~sd@${pipelineId}:${j.name}` ||
+                                        t.src === `sd@${pipelineId}:${j.name}`);
 
                                     matchArr = matchArr.map(m => m.dest);
 


### PR DESCRIPTION
## Context

Currently the EXTERNAL_TRIGGER only matches triggers with `~` prefix. In the future, external triggers might not have that prefix.

## Objective

This PR adds external trigger regex for the join case.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
