### PR TITLE
fix(1930): handle case where getPermission throws error

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -937,7 +937,11 @@ class PipelineModel extends BaseModel {
                 // eslint-disable-next-line no-await-in-loop
                 permission = await user.getPermissions(this.scmUri);
             } catch (err) {
-                permission.push = false;
+                if (err.status === 401) {
+                    permission.push = false;
+                } else {
+                    throw err;
+                }
             }
 
             if (!permission.push) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -931,9 +931,14 @@ class PipelineModel extends BaseModel {
                 username,
                 scmContext: this.scmContext
             });
+            let permission = {};
 
-            // eslint-disable-next-line no-await-in-loop
-            const permission = await user.getPermissions(this.scmUri);
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                permission = await user.getPermissions(this.scmUri);
+            } catch (err) {
+                permission.push = false;
+            }
 
             if (!permission.push) {
                 delete newAdmins[username];

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1358,7 +1358,7 @@ describe('Pipeline Model', () => {
         });
     });
 
-    describe('getFirstAdmin', () => {
+    describe.only('getFirstAdmin', () => {
         beforeEach(() => {
             getUserPermissionMocks({ username: 'batman', push: false });
             getUserPermissionMocks({ username: 'robin', push: true });
@@ -1383,6 +1383,20 @@ describe('Pipeline Model', () => {
             }).catch((e) => {
                 assert.isOk(e);
                 assert.equal(e.message, 'Pipeline has no admin');
+            });
+        });
+
+        it('handle get permission error', () => {
+            const error = new Error('fails to get permissions');
+
+            userFactoryMock.get.withArgs({ username: 'batman', scmContext }).resolves({
+                unsealToken: sinon.stub().resolves('foo'),
+                getPermissions: sinon.stub().throws(error),
+                username: 'batman'
+            });
+
+            return pipeline.getFirstAdmin().then((realAdmin) => {
+                assert.equal(realAdmin.username, 'robin');
             });
         });
     });


### PR DESCRIPTION
## Context

currently screwdriver can't delete user from admin list if they revoke their token.

## Objective

correctly handle the thrown error from getPermission()

## References

https://github.com/screwdriver-cd/screwdriver/issues/1930

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
