### PR TITLE
feat(1091): add templateId to builds, add templateFactory listWithMetrics method

### DIFF
--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -203,7 +203,7 @@ class BaseFactory {
                         `expected Array, got ${typeof data}`);
                 }
 
-                if(scanConfig.aggregationField) {
+                if (scanConfig.aggregationField) {
                     return data;
                 }
 

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -143,7 +143,8 @@ class BaseFactory {
 
         if (config) {
             const {
-                search, sort, sortBy, paginate, exclude, groupBy, startTime, endTime, timeKey, raw
+                search, sort, sortBy, paginate, exclude, groupBy, startTime, endTime, timeKey, raw,
+                aggregationField
             } = config;
 
             if (search) {
@@ -186,6 +187,10 @@ class BaseFactory {
                 scanConfig.groupBy = groupBy;
             }
 
+            if (aggregationField) {
+                scanConfig.aggregationField = aggregationField;
+            }
+
             if (raw) {
                 return datastoreForLookup.scan(scanConfig);
             }
@@ -196,6 +201,10 @@ class BaseFactory {
                 if (!Array.isArray(data)) {
                     throw new Error('Unexpected response from datastore, ' +
                         `expected Array, got ${typeof data}`);
+                }
+
+                if(scanConfig.aggregationField) {
+                    return data;
                 }
 
                 const result = [];

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -282,6 +282,8 @@ class BuildFactory extends BaseFactory {
                         });
                         modelConfig.stats = {};
 
+                        modelConfig.templateId = job.templateId;
+
                         return super.create(modelConfig);
                     });
                 })

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -789,7 +789,6 @@ class PipelineModel extends BaseModel {
                         // Loop through all defined jobs in the yaml
                         Object.keys(parsedConfig.jobs).forEach((jobName) => {
                             const permutations = parsedConfig.jobs[jobName];
-
                             const jobConfig = {
                                 pipelineId,
                                 name: jobName,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -758,10 +758,15 @@ class PipelineModel extends BaseModel {
 
                             // if it's in the yaml, update it
                             if (parsedConfigJobNames.includes(jobName)) {
+                                const templateId = parsedConfig.jobs[jobName][0].templateId;
+
+                                delete parsedConfig.jobs[jobName][0].templateId;
+
                                 const permutations = parsedConfig.jobs[jobName];
 
                                 requiresList = permutations[0].requires || [];
                                 job.permutations = permutations;
+                                job.templateId = templateId;
                                 job.archived = false;
                                 jobsToSync.push(job.update());
                                 // if it's not in the yaml then archive it
@@ -783,11 +788,17 @@ class PipelineModel extends BaseModel {
 
                         // Loop through all defined jobs in the yaml
                         Object.keys(parsedConfig.jobs).forEach((jobName) => {
+                            const templateId = parsedConfig.jobs[jobName][0].templateId;
+
+                            delete parsedConfig.jobs[jobName][0].templateId;
+
                             const permutations = parsedConfig.jobs[jobName];
+
                             const jobConfig = {
                                 pipelineId,
                                 name: jobName,
-                                permutations
+                                permutations,
+                                templateId
                             };
                             const requiresList = permutations[0].requires || [];
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -788,17 +788,12 @@ class PipelineModel extends BaseModel {
 
                         // Loop through all defined jobs in the yaml
                         Object.keys(parsedConfig.jobs).forEach((jobName) => {
-                            const templateId = parsedConfig.jobs[jobName][0].templateId;
-
-                            delete parsedConfig.jobs[jobName][0].templateId;
-
                             const permutations = parsedConfig.jobs[jobName];
 
                             const jobConfig = {
                                 pipelineId,
                                 name: jobName,
-                                permutations,
-                                templateId
+                                permutations
                             };
                             const requiresList = permutations[0].requires || [];
 

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -188,6 +188,45 @@ class TemplateFactory extends BaseFactory {
     }
 
     /**
+     * List templates and associated metrics with pagination and filter options
+     * @method listWithMetrics
+     * @param  {Object}   config                  Config object
+     * @param  {Object}   config.params           Parameters to filter on
+     * @param  {Object}   config.paginate         Pagination parameters
+     * @param  {Number}   config.paginate.count   Number of items per page
+     * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @return {Promise}
+     */
+    listWithMetrics(config) {
+        return this.list(config).then((templates) => {
+            //make this query the read only data store
+            const JobFactory = require('./jobFactory');
+            const JobFactoryInstance = JobFactory.getInstance();
+
+            const templateIds = templates.map((t) => {return t.id});
+
+            const listConfig = {
+                params: { templateId: templateIds },
+                readOnly: true
+            };
+
+            return JobFactoryInstance.list(listConfig).then((jobs) => {
+                return templates.map((t) => {
+                    const numJobs = jobs.filter(j => j.templateId != undefined && j.templateId === t.id).length;
+
+                    t.metrics = {
+                        jobs: {
+                            count: numJobs
+                        }
+                    }
+
+                    return t;
+                });
+            });
+        });
+    }
+
+    /**
      * Get a template
      * @method get
      * @param  {Mixed}     config

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -215,24 +215,25 @@ class TemplateFactory extends BaseFactory {
 
             const listConfig = {
                 params: { templateId: templateIds },
-                readOnly: true
+                readOnly: true,
+                aggregationField: 'templateId'
             };
 
             return Promise.all([
                 jobFactory.list(listConfig),
                 buildFactory.list(listConfig)]
-            ).then(([jobs, builds]) =>
+            ).then(([jCount, bCount]) =>
                 templates.map((t) => {
-                    const numJobs = jobs.filter(j => j.templateId === t.id).length;
+                    const jobCount = jCount.find(j => j.templateId === t.id);
 
-                    const numBuilds = builds.filter(b => b.templateId === t.id).length;
+                    const buildCount = bCount.find(b => b.templateId === t.id);
 
                     t.metrics = {
                         jobs: {
-                            count: numJobs
+                            count: jobCount ? jobCount.count : 0
                         },
                         builds: {
-                            count: numBuilds
+                            count: buildCount ? buildCount.count : 0
                         }
                     };
 

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -218,30 +218,26 @@ class TemplateFactory extends BaseFactory {
                 readOnly: true
             };
 
-            return jobFactory.list(listConfig).then(jobs =>
-                buildFactory.list(listConfig).then(builds =>
-                    templates.map((t) => {
-                        const numJobs = jobs.filter(
-                            j => j.templateId !== undefined &&
-                            j.templateId === t.id
-                        ).length;
+            return Promise.all([
+                jobFactory.list(listConfig),
+                buildFactory.list(listConfig)]
+            ).then(([jobs, builds]) =>
+                templates.map((t) => {
+                    const numJobs = jobs.filter(j => j.templateId === t.id).length;
 
-                        const numBuilds = builds.filter(
-                            b => b.templateId !== undefined &&
-                            b.templateId === t.id
-                        ).length;
+                    const numBuilds = builds.filter(b => b.templateId === t.id).length;
 
-                        t.metrics = {
-                            jobs: {
-                                count: numJobs
-                            },
-                            builds: {
-                                count: numBuilds
-                            }
-                        };
+                    t.metrics = {
+                        jobs: {
+                            count: numJobs
+                        },
+                        builds: {
+                            count: numBuilds
+                        }
+                    };
 
-                        return t;
-                    })));
+                    return t;
+                }));
         });
     }
 

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -199,30 +199,49 @@ class TemplateFactory extends BaseFactory {
      */
     listWithMetrics(config) {
         return this.list(config).then((templates) => {
-            //make this query the read only data store
-            const JobFactory = require('./jobFactory');
-            const JobFactoryInstance = JobFactory.getInstance();
+            if (templates.length === 0) {
+                return templates;
+            }
 
-            const templateIds = templates.map((t) => {return t.id});
+            // eslint-disable-next-line global-require
+            const JobFactory = require('./jobFactory');
+            const jobFactory = JobFactory.getInstance();
+
+            // eslint-disable-next-line global-require
+            const BuildFactory = require('./buildFactory');
+            const buildFactory = BuildFactory.getInstance();
+
+            const templateIds = templates.map(t => t.id);
 
             const listConfig = {
                 params: { templateId: templateIds },
                 readOnly: true
             };
 
-            return JobFactoryInstance.list(listConfig).then((jobs) => {
-                return templates.map((t) => {
-                    const numJobs = jobs.filter(j => j.templateId != undefined && j.templateId === t.id).length;
+            return jobFactory.list(listConfig).then(jobs =>
+                buildFactory.list(listConfig).then(builds =>
+                    templates.map((t) => {
+                        const numJobs = jobs.filter(
+                            j => j.templateId !== undefined &&
+                            j.templateId === t.id
+                        ).length;
 
-                    t.metrics = {
-                        jobs: {
-                            count: numJobs
-                        }
-                    }
+                        const numBuilds = builds.filter(
+                            b => b.templateId !== undefined &&
+                            b.templateId === t.id
+                        ).length;
 
-                    return t;
-                });
-            });
+                        t.metrics = {
+                            jobs: {
+                                count: numJobs
+                            },
+                            builds: {
+                                count: numBuilds
+                            }
+                        };
+
+                        return t;
+                    })));
         });
     }
 

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -286,6 +286,17 @@ describe('Base Factory', () => {
                 })
         );
 
+        it('sets aggregationField if it is passed in', () =>
+            factory.list({ aggregationField: 'templateId' })
+                .then(() => {
+                    assert.calledWith(datastore.scan, {
+                        table: 'base',
+                        params: {},
+                        aggregationField: 'templateId'
+                    });
+                })
+        );
+
         it('sets default paginate values if undefined is passed in', () =>
             factory.list({ paginate: { page: undefined, count: undefined } })
                 .then(() => {

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -650,7 +650,7 @@ describe('Template Factory', () => {
             ];
         });
 
-        /* it('should list templates with metrics when namespace is passed in', () => {
+        it('should list templates with metrics when namespace is passed in', () => {
             expected = [returnValue[0], returnValue[1], returnValue[2]];
             datastore.scan.resolves(expected);
             buildFactoryMock.list.resolves(buildsMock);
@@ -666,7 +666,7 @@ describe('Template Factory', () => {
                     i += 1;
                 });
             });
-        }); */
+        });
 
         it('should list templates with metrics when no namespace is passed in', () => {
             expected = [returnValue[3]];

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -29,6 +29,8 @@ describe('Template Factory', () => {
     let templateTagFactoryMock;
     let factory;
     let Template;
+    let jobFactoryMock;
+    let buildFactoryMock;
 
     before(() => {
         mockery.enable({
@@ -46,9 +48,21 @@ describe('Template Factory', () => {
         templateTagFactoryMock = {
             get: sinon.stub()
         };
+        jobFactoryMock = {
+            list: sinon.stub()
+        };
+        buildFactoryMock = {
+            list: sinon.stub()
+        };
 
         mockery.registerMock('./templateTagFactory', {
             getInstance: sinon.stub().returns(templateTagFactoryMock)
+        });
+        mockery.registerMock('./jobFactory', {
+            getInstance: sinon.stub().returns(jobFactoryMock)
+        });
+        mockery.registerMock('./buildFactory', {
+            getInstance: sinon.stub().returns(buildFactoryMock)
         });
 
         /* eslint-disable global-require */
@@ -441,6 +455,234 @@ describe('Template Factory', () => {
 
             return factory.list(config).then((model) => {
                 assert.instanceOf(model[0], Template);
+            });
+        });
+    });
+
+    describe('listWithMetrics', () => {
+        let config;
+        let expected;
+        let returnValue;
+        let jobsMock;
+        let buildsMock;
+
+        beforeEach(() => {
+            config = {
+                params: {
+                    name,
+                    namespace,
+                    version: '1.0.2'
+                }
+            };
+
+            jobsMock = [
+                {
+                    name: 'job1',
+                    pipelineId: 7,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 1,
+                    permutations: {},
+                    templateId: 1
+                },
+                {
+                    name: 'job2',
+                    pipelineId: 7,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 2,
+                    permutations: {},
+                    templateId: 1
+                },
+                {
+                    name: 'job3',
+                    pipelineId: 7,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 3,
+                    permutations: {},
+                    templateId: 4
+                },
+                {
+                    name: 'job4',
+                    pipelineId: 7,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 4,
+                    permutations: {},
+                    templateId: undefined
+                },
+                {
+                    name: 'job5',
+                    pipelineId: 7,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 5,
+                    permutations: {}
+                },
+                {
+                    name: 'job6',
+                    pipelineId: 7,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 6,
+                    permutations: {},
+                    templateId: 1
+                },
+                {
+                    name: 'job7',
+                    pipelineId: 7,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 7,
+                    permutations: {},
+                    templateId: 4
+                },
+                {
+                    name: 'job8',
+                    pipelineId: 8,
+                    state: 'ENABLED',
+                    archived: false,
+                    id: 7,
+                    permutations: {},
+                    templateId: 10
+                }
+            ];
+
+            buildsMock = [
+                {
+                    id: 1,
+                    templateId: 1
+                },
+                {
+                    id: 2,
+                    templateId: 1
+                },
+                {
+                    id: 3,
+                    templateId: 4
+                },
+                {
+                    id: 4,
+                    templateId: undefined
+                },
+                {
+                    id: 5
+                },
+                {
+                    id: 6,
+                    templateId: 1
+                },
+                {
+                    id: 7,
+                    templateId: 4
+                },
+                {
+                    id: 8,
+                    templateId: 10
+                },
+                {
+                    id: 9,
+                    templateId: 1
+                },
+                {
+                    id: 10,
+                    templateId: 4
+                }
+            ];
+
+            returnValue = [
+                {
+                    id: 1,
+                    name,
+                    namespace,
+                    version: '1.0.1',
+                    metrics: {
+                        jobs: {
+                            count: 3
+                        },
+                        builds: {
+                            count: 4
+                        }
+                    }
+                },
+                {
+                    id: 3,
+                    name,
+                    namespace,
+                    version: '1.0.3',
+                    metrics: {
+                        jobs: {
+                            count: 0
+                        },
+                        builds: {
+                            count: 0
+                        }
+                    }
+                },
+                {
+                    id: 2,
+                    name,
+                    namespace,
+                    version: '1.0.2',
+                    metrics: {
+                        jobs: {
+                            count: 0
+                        },
+                        builds: {
+                            count: 0
+                        }
+                    }
+                },
+                {
+                    id: 4,
+                    name: `${namespace}/${name}`,
+                    version: '1.0.2',
+                    metrics: {
+                        jobs: {
+                            count: 2
+                        },
+                        builds: {
+                            count: 3
+                        }
+                    }
+                }
+            ];
+        });
+
+        /* it('should list templates with metrics when namespace is passed in', () => {
+            expected = [returnValue[0], returnValue[1], returnValue[2]];
+            datastore.scan.resolves(expected);
+            buildFactoryMock.list.resolves(buildsMock);
+            jobFactoryMock.list.resolves(jobsMock);
+
+            return factory.listWithMetrics(config).then((templates) => {
+                let i = 0;
+
+                templates.forEach((t) => {
+                    assert.deepEqual(t.id, expected[i].id);
+                    assert.deepEqual(t.metrics.jobs.count, expected[i].metrics.jobs.count);
+                    assert.deepEqual(t.metrics.builds.count, expected[i].metrics.builds.count);
+                    i += 1;
+                });
+            });
+        }); */
+
+        it('should list templates with metrics when no namespace is passed in', () => {
+            expected = [returnValue[3]];
+            datastore.scan.resolves(expected);
+            buildFactoryMock.list.resolves(buildsMock);
+            jobFactoryMock.list.resolves(jobsMock);
+
+            delete config.namespace;
+
+            return factory.listWithMetrics(config).then((templates) => {
+                assert.deepEqual(templates.length, 1);
+                assert.deepEqual(templates[0].metrics.jobs.count, expected[0].metrics.jobs.count);
+                assert.deepEqual(
+                    templates[0].metrics.builds.count,
+                    expected[0].metrics.builds.count
+                );
             });
         });
     });

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -463,8 +463,8 @@ describe('Template Factory', () => {
         let config;
         let expected;
         let returnValue;
-        let jobsMock;
-        let buildsMock;
+        let jobsCount;
+        let buildsCount;
 
         beforeEach(() => {
             config = {
@@ -475,119 +475,49 @@ describe('Template Factory', () => {
                 }
             };
 
-            jobsMock = [
+            jobsCount = [
                 {
-                    name: 'job1',
-                    pipelineId: 7,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 1,
-                    permutations: {},
-                    templateId: 1
+                    templateId: 1,
+                    count: 3
                 },
                 {
-                    name: 'job2',
-                    pipelineId: 7,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 2,
-                    permutations: {},
-                    templateId: 1
+                    templateId: 2,
+                    count: 0
                 },
                 {
-                    name: 'job3',
-                    pipelineId: 7,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 3,
-                    permutations: {},
-                    templateId: 4
+                    templateId: 3,
+                    count: 0
                 },
                 {
-                    name: 'job4',
-                    pipelineId: 7,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 4,
-                    permutations: {},
-                    templateId: undefined
+                    templateId: 4,
+                    count: 2
                 },
                 {
-                    name: 'job5',
-                    pipelineId: 7,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 5,
-                    permutations: {}
-                },
-                {
-                    name: 'job6',
-                    pipelineId: 7,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 6,
-                    permutations: {},
-                    templateId: 1
-                },
-                {
-                    name: 'job7',
-                    pipelineId: 7,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 7,
-                    permutations: {},
-                    templateId: 4
-                },
-                {
-                    name: 'job8',
-                    pipelineId: 8,
-                    state: 'ENABLED',
-                    archived: false,
-                    id: 7,
-                    permutations: {},
-                    templateId: 10
+                    templateId: 5,
+                    count: 7
                 }
             ];
 
-            buildsMock = [
+            buildsCount = [
                 {
-                    id: 1,
-                    templateId: 1
+                    templateId: 1,
+                    count: 4
                 },
                 {
-                    id: 2,
-                    templateId: 1
+                    templateId: 2,
+                    count: 0
                 },
                 {
-                    id: 3,
-                    templateId: 4
+                    templateId: 3,
+                    count: 0
                 },
                 {
-                    id: 4,
-                    templateId: undefined
+                    templateId: 4,
+                    count: 3
                 },
                 {
-                    id: 5
-                },
-                {
-                    id: 6,
-                    templateId: 1
-                },
-                {
-                    id: 7,
-                    templateId: 4
-                },
-                {
-                    id: 8,
-                    templateId: 10
-                },
-                {
-                    id: 9,
-                    templateId: 1
-                },
-                {
-                    id: 10,
-                    templateId: 4
+                    templateId: 9,
+                    count: 100
                 }
             ];
 
@@ -653,8 +583,8 @@ describe('Template Factory', () => {
         it('should list templates with metrics when namespace is passed in', () => {
             expected = [returnValue[0], returnValue[1], returnValue[2]];
             datastore.scan.resolves(expected);
-            buildFactoryMock.list.resolves(buildsMock);
-            jobFactoryMock.list.resolves(jobsMock);
+            buildFactoryMock.list.resolves(buildsCount);
+            jobFactoryMock.list.resolves(jobsCount);
 
             return factory.listWithMetrics(config).then((templates) => {
                 let i = 0;
@@ -671,8 +601,8 @@ describe('Template Factory', () => {
         it('should list templates with metrics when no namespace is passed in', () => {
             expected = [returnValue[3]];
             datastore.scan.resolves(expected);
-            buildFactoryMock.list.resolves(buildsMock);
-            jobFactoryMock.list.resolves(jobsMock);
+            buildFactoryMock.list.resolves(buildsCount);
+            jobFactoryMock.list.resolves(jobsCount);
 
             delete config.namespace;
 


### PR DESCRIPTION
## Context

Need to add templateId to builds so metrics about the number of builds using some template can be aggregated. Need to add functionality so that template versions can be listed along with their associated metrics.

## Objective

This PR adds templateId to build on create. This PR also adds the listWithMetrics method to templateFactory; this method returns the different versions of a template and associated popularity metrics.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
