### PR TITLE
fix(1949):External config cleanup deleted non-child pipelines

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -660,7 +660,8 @@ class PipelineModel extends BaseModel {
 
         const pipeline = await pipelineFactory.get({ scmUri });
 
-        if (pipeline) {
+        // remove pipeline only if it's a child pipeline and belongs to current pipeline
+        if (pipeline && pipeline.configPipelineId === this.id) {
             logger.info(`pipelineId:${this.id}: Removing child pipeline for ${scmUrl} with ` +
                 `pipelineId:${pipeline.id}.`);
             pipeline.remove();

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -870,6 +870,29 @@ describe('Pipeline Model', () => {
                 });
         });
 
+        it('does not remove child pipelines if does not belong to this parent', () => {
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
+                checkoutUrl: 'bar.git'
+            })).resolves('bar');
+            childPipelineMock.configPipelineId = 789;
+            pipelineFactoryMock.get.resolves(childPipelineMock);
+            pipeline.childPipelines = {
+                scmUrls: [
+                    'bar.git'
+                ]
+            };
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+
+            return pipeline.sync()
+                .then((p) => {
+                    assert.equal(p.id, testId);
+                    assert.notCalled(childPipelineMock.remove);
+                });
+        });
+
         it('removes child pipeline and resets scmUrls if it is removed from new yaml', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -900,7 +900,7 @@ describe('Pipeline Model', () => {
             pipelineFactoryMock.scm.parseUrl.withArgs(sinon.match({
                 checkoutUrl: 'bar.git'
             })).resolves('bar');
-            childPipelineMock.configPipelineId = 456;
+            childPipelineMock.configPipelineId = 123;
             pipelineFactoryMock.get.resolves(childPipelineMock);
             pipeline.childPipelines = {
                 scmUrls: [


### PR DESCRIPTION
## Context

External Config can automatically create child pipelines for listed scm url's. However if there is a pipeline which exists already it won't create a pipeline. Now when this child list is changed and child url is removed, the child pipelines are deleted.


## Objective

External config child pipelines should affect only the child pipelines which were created as part of that specific external pipeline's setup.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1949

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
