### PR TITLE
[DNM]fix(1865): correct sort order when steps are skipped

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -634,10 +634,19 @@ class BuildModel extends BaseModel {
                 // This if statement should be removed after enough time has passed since build.steps removed.
                 // Make orders of steps in completed builds sure,
                 // because steps in old builds in DB have the order not sorted.
+
                 if (this.endTime) {
-                    steps.sort((a, b) =>
-                        new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
-                    );
+                    let lastStartTime;
+
+                    steps.sort((a, b) => {
+                        // handle case when startTime is not defined for skipped steps during build failure
+                        lastStartTime = a.startTime || b.startTime || lastStartTime;
+
+                        const aTime = a.startTime || lastStartTime;
+                        const bTime = b.startTime || lastStartTime;
+
+                        return new Date(aTime).getTime() - new Date(bTime).getTime();
+                    });
                 }
 
                 return Object.assign(deepcopy(this.toJson()), { steps });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 5000",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 5000 --retries 1 --exit --allow-uncaught true --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -39,8 +39,9 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^8.0.0",
+    "mocha": "^7.0.1",
     "mockery": "^2.0.0",
+    "nyc": "^15.0.0",
     "rewire": "^4.0.1",
     "sinon": "^7.5.0"
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1599,31 +1599,78 @@ describe('Build Model', () => {
 
     describe('get JSON with steps', () => {
         const step1 = {
-            id: 11,
-            buildId,
-            name: 'install',
-            startTime: '2019-01-22T21:31:00.000Z',
-            endTime: '2019-01-22T22:35:00.000Z',
-            code: 0
-        };
-        const step2 = {
-            id: 12,
+            id: 10,
             buildId,
             name: 'sd-setup-init',
             startTime: '2019-01-22T21:08:00.000Z',
-            endTime: '2019-01-22T21:30:00.000Z',
-            code: 127
+            endTime: '2019-01-22T21:21:00.000Z',
+            code: 0
         };
-        const step3 = {
+        const step2 = {
+            id: 11,
             name: 'sd-setup-scm',
             startTime: '2019-01-22T21:21:00.000Z',
-            endTime: '2019-01-22T22:30:00.000Z',
+            endTime: '2019-01-22T21:30:00.000Z',
+            code: 0
+        };
+        const step21 = {
+            id: 12,
+            name: 'sd-setup-scm',
+            startTime: '2019-01-22T21:30:01.000Z',
+            endTime: '2019-01-22T21:30:02.000Z',
+            code: 0
+        };
+        const step3 = {
+            id: 13,
+            buildId,
+            name: 'install',
+            startTime: '2019-01-22T21:31:00.000Z',
+            endTime: '2019-01-22T21:35:00.000Z',
+            code: 0
+        };
+        const step31 = {
+            id: 14,
+            buildId,
+            name: 'test',
+            startTime: '2019-01-22T21:35:01.000Z',
+            endTime: '2019-01-22T21:36:00.000Z',
             code: 127
         };
+        const step4 = {
+            id: 15,
+            buildId,
+            name: 'deploy'
+        };
+        const step5 = {
+            id: 16,
+            buildId,
+            name: 'teardown-coverage',
+            startTime: '2019-01-22T21:41:00.000Z',
+            endTime: '2019-01-22T21:45:00.000Z',
+            code: 0
+        };
+        const step6 = {
+            id: 17,
+            buildId,
+            name: 'teardown-artifact',
+            startTime: '2019-01-22T21:45:00.000Z',
+            endTime: '2019-01-22T21:50:00.000Z',
+            code: 0
+        };
+
+        const step7 = {
+            id: 18,
+            buildId,
+            name: 'teardown-cache',
+            startTime: '2019-01-22T21:51:00.000Z',
+            endTime: '2019-01-22T21:52:00.000Z',
+            code: 0
+        };
+
         let stepsMock;
 
         beforeEach(() => {
-            stepsMock = [step1, step2, step3];
+            stepsMock = [step1, step2, step3, step4, step5];
             stepFactoryMock.list.resolves(stepsMock);
         });
 
@@ -1631,13 +1678,16 @@ describe('Build Model', () => {
             build.toJsonWithSteps()
                 .then((json) => {
                     const expected = Object.assign({}, build.toJson(),
-                        { steps: [step1, step2, step3] });
+                        { steps: [step1, step2, step3, step4, step5] });
 
                     assert.deepStrictEqual(json, expected);
                 })
         );
 
         it('returns the JSON with steps sorted by step.createTime', () => {
+            stepsMock = [step1, step2, step21, step3, step31, step4, step5, step6, step7];
+            stepFactoryMock.list.resolves(stepsMock);
+
             const configWithEndTime = Object.assign({}, config);
 
             configWithEndTime.endTime = '2019-01-22T22:30: 00.000Z';
@@ -1646,7 +1696,9 @@ describe('Build Model', () => {
             return build.toJsonWithSteps()
                 .then((json) => {
                     const expected = Object.assign({}, build.toJson(),
-                        { steps: [step2, step3, step1] });
+                        { steps: [
+                            step1, step2, step21, step3, step31, step4, step5, step6, step7
+                        ] });
 
                     assert.deepStrictEqual(json, expected);
                 });


### PR DESCRIPTION
## Context

As part of fix for https://github.com/screwdriver-cd/screwdriver/issues/1865 we added sorting to handle older builds. But this causes problem with failed bulids where step `startTime` is not defined.

## Objective

For steps which do not have `startTime`, re-use `startTime` from previous step. For builds after the DB change for dropping `build.steps` this will return correct information. But for builds prior to DB change, this could return out of order results, since we don't have the order maintained anymore. While we could lookup `job` table for grabbing proper step order, that will be an overkill just to handle failed builds prior to DB change.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1865
https://github.com/screwdriver-cd/models/pull/423/files#diff-26b681bd4dac10f25d5293c7595c435bR634-R641

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
