### PR TITLE
fix(1091): set job templateId to null when job doesn't use a template

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -766,7 +766,7 @@ class PipelineModel extends BaseModel {
 
                             // if it's in the yaml, update it
                             if (parsedConfigJobNames.includes(jobName)) {
-                                const templateId = parsedConfig.jobs[jobName][0].templateId;
+                                const templateId = parsedConfig.jobs[jobName][0].templateId || null;
 
                                 delete parsedConfig.jobs[jobName][0].templateId;
 


### PR DESCRIPTION
## Context

Job's templateId is not set to undefined when a job's template is removed. This is due to a clause within sequalize where if a model is being updated and one of its fields is set to undefined that field is ignored and not updated.

## Objective

This PR explicitly sets templateId to null if a job is not using a template; as such on updates the templateId will be set to null.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
