### PR TITLE
fix(1930): handle case when using private scm instance

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -929,7 +929,7 @@ class PipelineModel extends BaseModel {
      */
     async getFirstAdmin() {
         const newAdmins = this.admins;
-        const handleStatus = [401, 404];
+        const handleStatuses = [401, 404];
         /* eslint-disable global-require */
         const UserFactory = require('./userFactory');
         /* eslint-enable global-require */
@@ -950,7 +950,7 @@ class PipelineModel extends BaseModel {
                 // eslint-disable-next-line no-await-in-loop
                 permission = await user.getPermissions(this.scmUri);
             } catch (err) {
-                if (handleStatus.includes(err.status)) {
+                if (handleStatuses.includes(err.status)) {
                     permission.push = false;
                 } else {
                     throw err;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -20,6 +20,7 @@ const MAX_COUNT = 1000;
 // The default page for fetching not by aggregatedInteval
 // And the start page for fetching by aggregatedInteval
 const DEFAULT_PAGE = 1;
+const SCM_NO_ACCESS_STATUSES = [401, 404];
 
 const logger = require('screwdriver-logger');
 
@@ -929,7 +930,7 @@ class PipelineModel extends BaseModel {
      */
     async getFirstAdmin() {
         const newAdmins = this.admins;
-        const handleStatuses = [401, 404];
+
         /* eslint-disable global-require */
         const UserFactory = require('./userFactory');
         /* eslint-enable global-require */

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -951,7 +951,7 @@ class PipelineModel extends BaseModel {
                 // eslint-disable-next-line no-await-in-loop
                 permission = await user.getPermissions(this.scmUri);
             } catch (err) {
-                if (handleStatuses.includes(err.status)) {
+                if (SCM_NO_ACCESS_STATUSES.includes(err.status)) {
                     permission.push = false;
                 } else {
                     throw err;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -929,7 +929,7 @@ class PipelineModel extends BaseModel {
      */
     async getFirstAdmin() {
         const newAdmins = this.admins;
-
+        const handleStatus = [401, 404];
         /* eslint-disable global-require */
         const UserFactory = require('./userFactory');
         /* eslint-enable global-require */
@@ -950,7 +950,7 @@ class PipelineModel extends BaseModel {
                 // eslint-disable-next-line no-await-in-loop
                 permission = await user.getPermissions(this.scmUri);
             } catch (err) {
-                if (err.status === 401) {
+                if (handleStatus.includes(err.status)) {
                     permission.push = false;
                 } else {
                     throw err;

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1424,6 +1424,21 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('catch 404 from get permission', () => {
+            const error = new Error('Not found');
+
+            error.status = 404;
+            userFactoryMock.get.withArgs({ username: 'batman', scmContext }).resolves({
+                unsealToken: sinon.stub().resolves('foo'),
+                getPermissions: sinon.stub().throws(error),
+                username: 'batman'
+            });
+
+            return pipeline.getFirstAdmin().then((realAdmin) => {
+                assert.equal(realAdmin.username, 'robin');
+            });
+        });
+
         it('does not catch other error', () => {
             const error = new Error('fails to get permissions');
 


### PR DESCRIPTION
## Context
When we using private scm instance and being removed first admin for pipeline, scm returns `404` error instead of `401` error.
We should handle `404` error too.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
correctly handle the thrown `404` error from getPermission()

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#431 
screwdriver-cd/screwdriver#1930

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
