### PR TITLE
fix(965)[2]: ChainPR does not work

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -499,7 +499,7 @@ class EventFactory extends BaseFactory {
         const PipelineFactory = require('./pipelineFactory');
         const pipelineFactory = PipelineFactory.getInstance();
         const { pipelineId, configPipelineSha, username, scmContext,
-            parentEventId, sha, startFrom, changedFiles, webhooks,
+            parentEventId, sha, startFrom, changedFiles, webhooks, prSource,
             prInfo, prTitle, prRef, prNum, skipMessage, chainPR } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
@@ -559,12 +559,22 @@ class EventFactory extends BaseFactory {
                 return p;
             })
             .then((p) => {
-                if (prInfo && prInfo.url) {
-                    modelConfig.pr.url = prInfo.url;
+                if (prInfo) {
+                    if (prInfo.url) {
+                        modelConfig.pr.url = prInfo.url;
+                    }
+
+                    if (prInfo.prBranchName) {
+                        modelConfig.pr.prBranchName = prInfo.prBranchName;
+                    }
                 }
 
                 if (prTitle) {
                     modelConfig.pr.title = prTitle;
+                }
+
+                if (prSource) {
+                    modelConfig.pr.prSource = prSource;
                 }
 
                 if (prRef) {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -143,9 +143,11 @@ describe('Event Factory', () => {
                 username: 'stjohn',
                 parentBuildId: 12345,
                 scmContext,
+                prSource: 'branch',
                 prInfo: {
                     url: 'https://github.com/screwdriver-cd/screwdriver/pull/1063',
-                    ref: 'branch'
+                    ref: 'branch',
+                    prBranchName: 'prBranchName'
                 }
             };
             expected = {
@@ -1222,7 +1224,9 @@ describe('Event Factory', () => {
 
             return eventFactory.create(config).then((model) => {
                 assert.instanceOf(model, Event);
-                assert.deepEqual(model.pr, config.prInfo);
+                assert.deepEqual(model.pr.prBranchName, config.prInfo.prBranchName);
+                assert.deepEqual(model.pr.prSource, config.prSource);
+                assert.deepEqual(model.pr.ref, config.prInfo.ref);
                 assert.deepEqual(model.prNum, config.prNum);
             });
         });
@@ -1238,7 +1242,9 @@ describe('Event Factory', () => {
                 assert.instanceOf(model, Event);
                 assert.neverCalledWith(pipelineMock.sync, config.configPipelineSha);
                 assert.neverCalledWith(pipelineMock.sync, config.sha);
-                assert.deepEqual(model.pr, config.prInfo);
+                assert.deepEqual(model.pr.prBranchName, config.prInfo.prBranchName);
+                assert.deepEqual(model.pr.prSource, config.prSource);
+                assert.deepEqual(model.pr.ref, config.prInfo.ref);
                 assert.deepEqual(model.prNum, config.prNum);
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I am fixing the following features:
[1] https://github.com/screwdriver-cd/data-schema/pull/386
[2] https://github.com/screwdriver-cd/scm-base/pull/75
[3] https://github.com/screwdriver-cd/scm-github/pull/150
[4] https://github.com/screwdriver-cd/screwdriver/pull/1980

[2] Chain PR stopped working after merge.
The reason is that the environment variables required to `BuildFactory` have not been added.
Therefore, we will modify chainPR to work.

## Objective

Add the following variables.
`prSource`, `prBranchName`
By adding two, ChainPR works.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
