### PR TITLE
feat(1785): Save groupEventId to event [2]

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -156,6 +156,7 @@ class BuildFactory extends BaseFactory {
      * @param  {String}    [config.configPipelineSha]  The sha of the config pipeline
      * @param  {String}    [config.prRef]              The PR branch or reference
      * @param  {String}    [config.parentBuildId]      Id of the build that triggers this build
+     * @param  {Object}    [config.parentBuilds]       Parent builds information
      * @param  {Boolean}   [config.start]              Whether to start the build after creating
      * @param  {Object}    [config.environment]        Dynamically injected environment variables
      * @param  {Object}    [config.meta]               Metadata tied to this build

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -481,9 +481,11 @@ class EventFactory extends BaseFactory {
      *                                              Optional for backwards compatibility
      * @param  {String}  [config.causeMessage]      Message that describes why the event was created
      * @param  {Object}  [config.creator]           Creator of the event
-     * @param  {String}  [config.parentBuildId]     Id of the build that starts this event
-     * @param  {String}  [config.parentEventId]     Id of the parent event
-     * @param  {String}  [config.workflowGraph]     workflowGraph of parentEvent if there is a parentEvent
+     * @param  {Number}  [config.parentBuildId]     Id of the build that starts this event
+     * @param  {Object}  [config.parentBuilds]      Parent builds information
+     * @param  {Number}  [config.groupEventId]      Group parent event ID
+     * @param  {Number}  [config.parentEventId]     Id of the parent event
+     * @param  {Object}  [config.workflowGraph]     workflowGraph of parentEvent if there is a parentEvent
      * @param  {Array}   [config.changedFiles]      Array of files that were changed
      * @param  {Boolean} [config.webhooks]          If the create came from a webhook (pr or push) or not
      * @param  {Object}  [config.meta]              Metadata tied to this event
@@ -500,7 +502,7 @@ class EventFactory extends BaseFactory {
         const pipelineFactory = PipelineFactory.getInstance();
         const { pipelineId, configPipelineSha, username, scmContext,
             parentEventId, sha, startFrom, changedFiles, webhooks, prSource,
-            prInfo, prTitle, prRef, prNum, skipMessage, chainPR } = config;
+            prInfo, prTitle, prRef, prNum, skipMessage, chainPR, groupEventId } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
         const modelConfig = {
@@ -518,6 +520,10 @@ class EventFactory extends BaseFactory {
         };
         let prevChainPR = '';
         let decoratedCommit;
+
+        if (groupEventId) {
+            modelConfig.groupEventId = groupEventId;
+        }
 
         return pipelineFactory.get(pipelineId)
             // Sync pipeline to make sure workflowGraph is generated

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -651,6 +651,15 @@ class EventFactory extends BaseFactory {
                     return super.create(modelConfig);
                 })
                 .then((event) => {
+                    if (!event.groupEventId) {
+                        event.groupEventId = event.id;
+
+                        return event.update();
+                    }
+
+                    return Promise.resolve(event);
+                })
+                .then((event) => {
                     if (modelConfig.type === 'pipeline') {
                         pipeline.lastEventId = event.id;
                     }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -10,8 +10,7 @@ const hoek = require('hoek');
 const dayjs = require('dayjs');
 const _ = require('lodash');
 const { getAllRecords, getBuildClusterName } = require('./helper.js');
-const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
-const EXTERNAL_TRIGGER = /^~?sd@(\d+):([\w-]+)$/;
+const { PR_JOB_NAME, EXTERNAL_TRIGGER_ALL } = require('screwdriver-data-schema').config.regex;
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
     job: 2 // main or undefined if using legacy
@@ -200,7 +199,7 @@ function syncExternalTriggers(config) {
             // if the src is not in the old src list, then create in datastore
             const oldSrcList = records.map(r => r.src); // get the old src list
             const toCreate = newSrcList.filter(src =>
-                !oldSrcList.includes(src) && EXTERNAL_TRIGGER.test(src));
+                !oldSrcList.includes(src) && EXTERNAL_TRIGGER_ALL.test(src));
 
             toRemove.forEach(rec => processed.push(rec.remove()));
             toCreate.forEach(src => processed.push(triggerFactory.create({

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1129,6 +1129,35 @@ describe('Event Factory', () => {
             });
         });
 
+        it('should create an Event with groupEventId', () => {
+            config.groupEventId = 12345;
+            expected.groupEventId = 12345;
+
+            return eventFactory.create(config).then((model) => {
+                assert.instanceOf(model, Event);
+                assert.calledWith(scm.decorateAuthor, {
+                    username: 'stjohn',
+                    scmContext,
+                    token: 'foo'
+                });
+                assert.calledWith(scm.decorateCommit, {
+                    scmUri: 'github.com:1234:branch',
+                    scmContext,
+                    sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
+                    token: 'foo'
+                });
+                assert.strictEqual(syncedPipelineMock.lastEventId, model.id);
+                assert.strictEqual(config.prInfo.url, model.pr.url);
+                Object.keys(expected).forEach((key) => {
+                    if (key === 'workflowGraph' || key === 'meta') {
+                        assert.deepEqual(model[key], expected[key]);
+                    } else {
+                        assert.strictEqual(model[key], expected[key]);
+                    }
+                });
+            });
+        });
+
         it('should create an Event with creator', () => {
             const creatorTest = {
                 name: 'sd:scheduler',


### PR DESCRIPTION
## Context

When an event is created, the groupEventId should be saved to track the master parent event id.

## Objective

This PR saves the `groupEventId` to the event if it is passed in. If it is not passed in, it will update the `groupEventId` as its own event `id` after the event is created.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1785

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
