### PR TITLE
feat(1967): add ability to do raw query

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,21 @@ factory.get({ jobId, number }).then(model => {
 | config.jobId | Number | The unique ID for a job |
 | config.number | Number | build number |
 
+#### Get Build Statuses
+Get the statuses of the newest builds of jobs based on job ids. Can specify the number of build statuses desired per job id, this defaults to 1. Can specify the number of build statuses to skip per job id, this defaults to 0.
+```js
+factory.getBuildStatuses(config).then(statuses => {
+    // do stuff with the statuses
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.jobIds | Array | Yes | Ids of the jobs to get build statuses for |
+| config.numBuilds | Number | No | Number of build statuses to return per job |
+| config.offset | Number | No | Number of build statuses to skip per job|
+
 ### Build Model
 ```js
 'use strict';

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -221,6 +221,52 @@ class BaseFactory {
     }
 
     /**
+     * Run raw query
+     * @method query
+     * @param  {Object}         [config]
+     * @param  {Array<Object>}  [config.queries]      Map of database type to query
+     * @param  {Object}         [config.replacements] Parameters to replace in the query
+     * @param  {Boolean}        [config.rawResponse]  Return raw response without binding to model
+     * @param  {Boolean}        [config.readOnly]     Use readOnly datastore
+     * @return {Promise}
+     */
+    query(config) {
+        const queryConfig = {
+            table: this.table,
+            queries: hoek.reach(config, 'queries'),
+            replacements: hoek.reach(config, 'replacements', { default: {}}),
+            rawResponse: hoek.reach(config, 'rawResponse', { default: false})
+        };
+
+        let datastoreForLookup = this.datastore;
+        // use read only datastore if it is configured
+        const readOnly = hoek.reach(config, 'readOnly', { default: false });
+
+        if (readOnly) {
+            datastoreForLookup = this.datastoreRO;
+        }
+
+        return datastoreForLookup.query(queryConfig)
+            .then((data) => {
+
+                if (queryConfig.rawResponse) {
+                    return data;
+                }
+
+                const result = [];
+
+                data.forEach((item) => {
+                    item.datastore = datastoreForLookup;
+                    item.scm = this.scm;
+
+                    result.push(this.createClass(item));
+                });
+
+                return result;
+            });
+    }
+
+    /**
      * Cleanup
      */
     cleanUp() {

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -243,7 +243,7 @@ class BaseFactory {
 
         // use read only datastore if it is configured
         const readOnly = hoek.reach(config, 'readOnly', { default: false });
-        let datastoreForLookup = readOnly ? this.datastoreRO : this.datastore;
+        const datastoreForLookup = readOnly ? this.datastoreRO : this.datastore;
 
         return datastoreForLookup.query(queryConfig).then(data => {
             let formattedData = data;

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -250,10 +250,10 @@ class BaseFactory {
         }
 
         return datastoreForLookup.query(queryConfig).then(data => {
-            let toReturn = data;
+            let formattedData = data;
 
             if (!queryConfig.rawResponse) {
-                toReturn = data.map(item => {
+                formattedData = data.map(item => {
                     item.datastore = datastoreForLookup;
                     item.scm = this.scm;
 
@@ -261,7 +261,7 @@ class BaseFactory {
                 });
             }
 
-            return toReturn;
+            return formattedData;
         });
     }
 

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -234,8 +234,8 @@ class BaseFactory {
         const queryConfig = {
             table: this.table,
             queries: hoek.reach(config, 'queries'),
-            replacements: hoek.reach(config, 'replacements', { default: {}}),
-            rawResponse: hoek.reach(config, 'rawResponse', { default: false})
+            replacements: hoek.reach(config, 'replacements', { default: {} }),
+            rawResponse: hoek.reach(config, 'rawResponse', { default: false })
         };
 
         let datastoreForLookup = this.datastore;
@@ -248,7 +248,6 @@ class BaseFactory {
 
         return datastoreForLookup.query(queryConfig)
             .then((data) => {
-
                 if (queryConfig.rawResponse) {
                     return data;
                 }

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -241,13 +241,9 @@ class BaseFactory {
             rawResponse: hoek.reach(config, 'rawResponse', { default: false })
         };
 
-        let datastoreForLookup = this.datastore;
         // use read only datastore if it is configured
         const readOnly = hoek.reach(config, 'readOnly', { default: false });
-
-        if (readOnly) {
-            datastoreForLookup = this.datastoreRO;
-        }
+        let datastoreForLookup = readOnly ? this.datastoreRO : this.datastore;
 
         return datastoreForLookup.query(queryConfig).then(data => {
             let formattedData = data;

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -248,20 +248,16 @@ class BaseFactory {
 
         return datastoreForLookup.query(queryConfig)
             .then((data) => {
-                if (queryConfig.rawResponse) {
-                    return data;
+                if (!queryConfig.rawResponse) {
+                    data.map((item) => {
+                        item.datastore = datastoreForLookup;
+                        item.scm = this.scm;
+
+                        return this.createClass(item);
+                    });
                 }
 
-                const result = [];
-
-                data.forEach((item) => {
-                    item.datastore = datastoreForLookup;
-                    item.scm = this.scm;
-
-                    result.push(this.createClass(item));
-                });
-
-                return result;
+                return data;
             });
     }
 

--- a/lib/baseFactory.js
+++ b/lib/baseFactory.js
@@ -249,19 +249,20 @@ class BaseFactory {
             datastoreForLookup = this.datastoreRO;
         }
 
-        return datastoreForLookup.query(queryConfig)
-            .then((data) => {
-                if (!queryConfig.rawResponse) {
-                    data.map((item) => {
-                        item.datastore = datastoreForLookup;
-                        item.scm = this.scm;
+        return datastoreForLookup.query(queryConfig).then(data => {
+            let toReturn = data;
 
-                        return this.createClass(item);
-                    });
-                }
+            if (!queryConfig.rawResponse) {
+                toReturn = data.map(item => {
+                    item.datastore = datastoreForLookup;
+                    item.scm = this.scm;
 
-                return data;
-            });
+                    return this.createClass(item);
+                });
+            }
+
+            return toReturn;
+        });
     }
 
     /**

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -336,10 +336,10 @@ class BuildFactory extends BaseFactory {
             rawResponse: true
         };
 
-        return super.query(queryConfig).then((builds) => {
+        return super.query(queryConfig).then(builds => {
             const result = [];
 
-            config.jobIds.forEach((jobId) => {
+            config.jobIds.forEach(jobId => {
                 const jobBuilds = builds[0].filter(b => b.jobId === jobId);
 
                 result.push({

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -317,9 +317,9 @@ class BuildFactory extends BaseFactory {
      * @return {Promise}
      */
     getBuildStatuses(config) {
-        config.offset = config.offset || 0;
-        config.numBuilds = config.numBuilds || 1;
-        config.jobIds = config.jobIds || [];
+        const offset = config.offset || 0;
+        const numBuilds = config.numBuilds || 1;
+        const jobIds = config.jobIds || [];
 
         const queryConfig = {
             queries: [
@@ -329,9 +329,9 @@ class BuildFactory extends BaseFactory {
             ],
             readOnly: true,
             replacements: {
-                jobIds: config.jobIds,
-                offset: config.offset,
-                maxRank: config.numBuilds + config.offset
+                jobIds,
+                offset,
+                maxRank: numBuilds + offset
             },
             rawResponse: true
         };
@@ -339,7 +339,7 @@ class BuildFactory extends BaseFactory {
         return super.query(queryConfig).then(builds => {
             const result = [];
 
-            config.jobIds.forEach(jobId => {
+            jobIds.forEach(jobId => {
                 const jobBuilds = builds[0].filter(b => b.jobId === jobId);
 
                 result.push({

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -2,6 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
+const BuildQueries = require('./rawQueries').BuildFactoryQueries;
 const imageParser = require('docker-parse-image');
 const helper = require('./helper');
 const hoek = require('hoek');
@@ -309,30 +310,11 @@ class BuildFactory extends BaseFactory {
         config.numBuilds = config.numBuilds || 1;
         config.jobIds = config.jobIds || [];
 
-        const query =
-            'SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", '
-            + 'r."endTime" '
-            + 'FROM (SELECT "id", "jobId", "status", "startTime", "endTime", '
-            + 'RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank '
-            + 'FROM builds WHERE "jobId" in (:jobIds)) r '
-            + 'INNER JOIN jobs as j ON j."id" = r."jobId" '
-            + 'WHERE rank > :offset AND rank <= :maxRank '
-            + 'ORDER BY r."jobId", r."id" DESC';
-
-        const mysqlQuery =
-            'SELECT r.id, r.jobId, j.name as `jobName`, r.status, r.startTime, r.endTime FROM '
-            + '(SELECT id, jobId, status, startTime, endTime, '
-            + 'RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS `rank` '
-            + 'FROM builds WHERE jobId in (:jobIds)) r '
-            + 'INNER JOIN jobs as j ON j.id = r.jobId '
-            + 'WHERE `rank` > :offset AND `rank` <= :maxRank '
-            + 'ORDER BY r.jobId, r.id DESC';
-
         const queryConfig = {
             queries: [
-                { dbType: 'postgres', query },
-                { dbType: 'sqlite', query },
-                { dbType: 'mysql', query: mysqlQuery }
+                { dbType: 'postgres', query: BuildQueries.statusesQuery },
+                { dbType: 'sqlite', query: BuildQueries.statusesQuery },
+                { dbType: 'mysql', query: BuildQueries.statusesQueryMySql }
             ],
             readOnly: true,
             replacements: {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -342,12 +342,10 @@ class BuildFactory extends BaseFactory {
             config.jobIds.forEach((jobId) => {
                 const jobBuilds = builds[0].filter(b => b.jobId === jobId);
 
-                if (jobBuilds.length !== 0) {
-                    result.push({
-                        jobId,
-                        builds: jobBuilds
-                    });
-                }
+                result.push({
+                    jobId,
+                    builds: jobBuilds
+                });
             });
 
             return result;

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -309,42 +309,44 @@ class BuildFactory extends BaseFactory {
         config.numBuilds = config.numBuilds || 1;
         config.jobIds = config.jobIds || [];
 
-        const query = 
-            'SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", r."endTime" \
-            FROM (SELECT "id", "jobId", "status", "startTime", "endTime", \
-                RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank \
-            FROM builds WHERE "jobId" in (:jobIds)) r \
-            INNER JOIN jobs as j ON j."id" = r."jobId" \
-            WHERE rank > :offset AND rank <= :maxRank \
-            ORDER BY r."jobId", r."id" DESC';
+        const query =
+            'SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", '
+            + 'r."endTime" '
+            + 'FROM (SELECT "id", "jobId", "status", "startTime", "endTime", '
+            + 'RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank '
+            + 'FROM builds WHERE "jobId" in (:jobIds)) r '
+            + 'INNER JOIN jobs as j ON j."id" = r."jobId" '
+            + 'WHERE rank > :offset AND rank <= :maxRank '
+            + 'ORDER BY r."jobId", r."id" DESC';
 
-        const mysqlQuery = 
-            'SELECT r.id, r.jobId, j.name as `jobName`, r.status, r.startTime, r.endTime FROM \
-            (SELECT id, jobId, status, startTime, endTime, \
-                RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS `rank` \
-            FROM builds WHERE jobId in (:jobIds)) r \
-            INNER JOIN jobs as j ON j.id = r.jobId \
-            WHERE `rank` > :offset AND `rank` <= :maxRank \
-            ORDER BY r.jobId, r.id DESC';
+        const mysqlQuery =
+            'SELECT r.id, r.jobId, j.name as `jobName`, r.status, r.startTime, r.endTime FROM '
+            + '(SELECT id, jobId, status, startTime, endTime, '
+            + 'RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS `rank` '
+            + 'FROM builds WHERE jobId in (:jobIds)) r '
+            + 'INNER JOIN jobs as j ON j.id = r.jobId '
+            + 'WHERE `rank` > :offset AND `rank` <= :maxRank '
+            + 'ORDER BY r.jobId, r.id DESC';
 
         const queryConfig = {
             queries: [
-                { dbType: 'postgres', query: query },
-                { dbType: 'sqlite', query: query },
-                { dbType: 'mysql', query: mysqlQuery },
+                { dbType: 'postgres', query },
+                { dbType: 'sqlite', query },
+                { dbType: 'mysql', query: mysqlQuery }
             ],
             readOnly: true,
             replacements: {
                 jobIds: config.jobIds,
                 offset: config.offset,
-                maxRank: config.numBuilds +  config.offset
+                maxRank: config.numBuilds + config.offset
             },
             rawResponse: true
         };
 
-        return super.query(queryConfig).then(builds => {
+        return super.query(queryConfig).then((builds) => {
             const result = [];
-            config.jobIds.forEach(jobId => {
+
+            config.jobIds.forEach((jobId) => {
                 const jobBuilds = builds[0].filter(b => b.jobId === jobId);
 
                 if (jobBuilds.length !== 0) {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -296,6 +296,70 @@ class BuildFactory extends BaseFactory {
     }
 
     /**
+     * Get build statuses for jobs
+     * @method getBuildStatuses
+     * @param  {Object}   config                  Config object
+     * @param  {Array}    config.jobIds           Jobs to get build statuses for
+     * @param  {Number}   config.offset           Number of build statuses to skip
+     * @param  {Number}   config.numBuilds        Number of build statuses to return per job
+     * @return {Promise}
+     */
+    getBuildStatuses(config) {
+        config.offset = config.offset || 0;
+        config.numBuilds = config.numBuilds || 1;
+        config.jobIds = config.jobIds || [];
+
+        const query = 
+            'SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", r."endTime" \
+            FROM (SELECT "id", "jobId", "status", "startTime", "endTime", \
+                RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank \
+            FROM builds WHERE "jobId" in (:jobIds)) r \
+            INNER JOIN jobs as j ON j."id" = r."jobId" \
+            WHERE rank > :offset AND rank <= :maxRank \
+            ORDER BY r."jobId", r."id" DESC';
+
+        const mysqlQuery = 
+            'SELECT r.id, r.jobId, j.name as `jobName`, r.status, r.startTime, r.endTime FROM \
+            (SELECT id, jobId, status, startTime, endTime, \
+                RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS `rank` \
+            FROM builds WHERE jobId in (:jobIds)) r \
+            INNER JOIN jobs as j ON j.id = r.jobId \
+            WHERE `rank` > :offset AND `rank` <= :maxRank \
+            ORDER BY r.jobId, r.id DESC';
+
+        const queryConfig = {
+            queries: [
+                { dbType: 'postgres', query: query },
+                { dbType: 'sqlite', query: query },
+                { dbType: 'mysql', query: mysqlQuery },
+            ],
+            readOnly: true,
+            replacements: {
+                jobIds: config.jobIds,
+                offset: config.offset,
+                maxRank: config.numBuilds +  config.offset
+            },
+            rawResponse: true
+        };
+
+        return super.query(queryConfig).then(builds => {
+            const result = [];
+            config.jobIds.forEach(jobId => {
+                const jobBuilds = builds[0].filter(b => b.jobId === jobId);
+
+                if (jobBuilds.length !== 0) {
+                    result.push({
+                        jobId,
+                        builds: jobBuilds
+                    });
+                }
+            });
+
+            return result;
+        });
+    }
+
+    /**
      * Get an instance of the BuildFactory
      * @method getInstance
      * @param  {Object}     [config]            Configuration required for first call

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -2,7 +2,7 @@
 
 const BuildFactoryQueries = {
     statusesQuery:
-        `SELECT "id", "jobId", "name" as "jobName", "status", "startTime", "endTime"
+        `SELECT "id", "jobId", "status", "startTime", "endTime"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime",
         RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
         FROM builds WHERE "jobId" in (:jobIds))

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -4,14 +4,14 @@ const BuildFactoryQueries = {
     statusesQuery: `SELECT "id", "jobId", "status", "startTime", "endTime"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime",
         RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
-        FROM builds WHERE "jobId" in (:jobIds))
+        FROM builds WHERE "jobId" in (:jobIds)) as R
         WHERE rank > :offset AND rank <= :maxRank
         ORDER BY "jobId", "id" DESC`,
 
     statusesQueryMySql: `SELECT id, jobId, status, startTime, endTime
         FROM (SELECT id, jobId, status, startTime, endTime,
         RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
-        FROM builds WHERE jobId in (:jobIds))
+        FROM builds WHERE jobId in (:jobIds)) as R
         WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
         ORDER BY jobId, id DESC`
 };

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const BuildFactoryQueries = {
+    statusesQuery:
+        `SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", r."endTime"
+        FROM (SELECT "id", "jobId", "status", "startTime", "endTime",
+        RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
+        FROM builds WHERE "jobId" in (:jobIds)) r
+        INNER JOIN jobs as j ON j."id" = r."jobId"
+        WHERE rank > :offset AND rank <= :maxRank
+        ORDER BY r."jobId", r."id" DESC`,
+
+    statusesQueryMySql:
+        `SELECT r.id, r.jobId, j.name as \`jobName\`, r.status, r.startTime, r.endTime
+        FROM (SELECT id, jobId, status, startTime, endTime,
+        RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
+        FROM builds WHERE jobId in (:jobIds)) r
+        INNER JOIN jobs as j ON j.id = r.jobId
+        WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
+        ORDER BY r.jobId, r.id DESC`
+};
+
+module.exports = { BuildFactoryQueries };

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -1,16 +1,14 @@
 'use strict';
 
 const BuildFactoryQueries = {
-    statusesQuery:
-        `SELECT "id", "jobId", "status", "startTime", "endTime"
+    statusesQuery: `SELECT "id", "jobId", "status", "startTime", "endTime"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime",
         RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
         FROM builds WHERE "jobId" in (:jobIds))
         WHERE rank > :offset AND rank <= :maxRank
         ORDER BY "jobId", "id" DESC`,
 
-    statusesQueryMySql:
-        `SELECT id, jobId, status, startTime, endTime
+    statusesQueryMySql: `SELECT id, jobId, status, startTime, endTime
         FROM (SELECT id, jobId, status, startTime, endTime,
         RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
         FROM builds WHERE jobId in (:jobIds))

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -2,22 +2,20 @@
 
 const BuildFactoryQueries = {
     statusesQuery:
-        `SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", r."endTime"
+        `SELECT "id", "jobId", "name" as "jobName", "status", "startTime", "endTime"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime",
         RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
-        FROM builds WHERE "jobId" in (:jobIds)) r
-        INNER JOIN jobs as j ON j."id" = r."jobId"
+        FROM builds WHERE "jobId" in (:jobIds))
         WHERE rank > :offset AND rank <= :maxRank
-        ORDER BY r."jobId", r."id" DESC`,
+        ORDER BY "jobId", "id" DESC`,
 
     statusesQueryMySql:
-        `SELECT r.id, r.jobId, j.name as \`jobName\`, r.status, r.startTime, r.endTime
+        `SELECT id, jobId, status, startTime, endTime
         FROM (SELECT id, jobId, status, startTime, endTime,
         RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
-        FROM builds WHERE jobId in (:jobIds)) r
-        INNER JOIN jobs as j ON j.id = r.jobId
+        FROM builds WHERE jobId in (:jobIds))
         WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
-        ORDER BY r.jobId, r.id DESC`
+        ORDER BY jobId, id DESC`
 };
 
 module.exports = { BuildFactoryQueries };

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -35,7 +35,8 @@ describe('Base Factory', () => {
         datastore = {
             save: sinon.stub(),
             scan: sinon.stub(),
-            get: sinon.stub()
+            get: sinon.stub(),
+            query: sinon.stub()
         };
         schema = {
             models: {
@@ -477,6 +478,127 @@ describe('Base Factory', () => {
             assert.throw(() => {
                 BaseFactory.getInstance(BF, null);
             }, Error, 'No datastore provided to BF');
+        });
+    });
+
+    describe('query', () => {
+        const returnValue = [
+            {
+                id: '151c9b11e4a9a27e9e374daca6e59df37d8cf00f',
+                name: 'component'
+            },
+            {
+                id: 123,
+                name: 'deploy'
+            }
+        ];
+
+        const queryConfig = {
+            table: 'base',
+            queries: [
+                {
+                    dbType: 'postgres',
+                    query: 'postgresQuery'
+                },
+                {
+                    dbType: 'sqlite',
+                    query: 'sqliteQuery'
+                },
+                {
+                    dbType: 'mysql',
+                    query: 'mysqlQuery'
+                }
+            ],
+            rawResponse: false,
+            replacements: {
+                id: 1
+            }
+        };
+
+        const defaultQueryConfig = {
+            table: 'base',
+            queries: [
+                {
+                    dbType: 'postgres',
+                    query: 'postgresQuery'
+                },
+                {
+                    dbType: 'sqlite',
+                    query: 'sqliteQuery'
+                },
+                {
+                    dbType: 'mysql',
+                    query: 'mysqlQuery'
+                }
+            ]
+        };
+
+        beforeEach(() => {
+            factory.createClass = createMock;
+            datastore.query.resolves(returnValue);
+        });
+
+        it('calls datastore query with given config params', () =>
+            factory.query(queryConfig)
+                .then(() => {
+                    assert.calledWith(datastore.query, queryConfig);
+                })
+        );
+
+        it('calls datastore query with default config params', () =>
+            factory.query(defaultQueryConfig)
+                .then(() => {
+                    assert.calledWith(
+                        datastore.query,
+                        {
+                            table: 'base',
+                            queries: defaultQueryConfig.queries,
+                            rawResponse: false,
+                            replacements: {}
+                        });
+                })
+        );
+
+        it('calls datastore query without rawResponse and returns correct values', () =>
+            factory.query(queryConfig)
+                .then((arr) => {
+                    assert.isArray(arr);
+                    assert.equal(arr.length, 2);
+                    arr.forEach((model) => {
+                        assert.instanceOf(model, Base);
+                        assert.deepEqual(model.datastore, datastore);
+                        assert.deepEqual(model.scm, scm);
+                    });
+                })
+        );
+
+        it('calls datastore query with rawResponse and returns correct values', () => {
+            queryConfig.rawResponse = true;
+
+            return factory.query(queryConfig)
+                .then((arr) => {
+                    assert.isArray(arr);
+                    assert.equal(arr.length, 2);
+                    arr.forEach((value) => {
+                        assert.notInstanceOf(value, Base);
+                    });
+                    assert.deepEqual(arr[0], returnValue[0]);
+                    assert.deepEqual(arr[1], returnValue[1]);
+                });
+        });
+
+        it('rejects with a failure from the datastore query', () => {
+            const errorMessage = 'genericScanError';
+
+            datastore.query.rejects(new Error(errorMessage));
+
+            return factory.query()
+                .then(() => {
+                    assert.fail('this should not happen');
+                })
+                .catch((err) => {
+                    assert.strictEqual(err.message, errorMessage);
+                });
         });
     });
 });

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -519,52 +519,43 @@ describe('Base Factory', () => {
         });
 
         it('calls datastore query with given config params', () =>
-            factory.query(queryConfig)
-                .then(() => {
-                    assert.calledWith(datastore.query, queryConfig);
-                })
-        );
+            factory.query(queryConfig).then(() => {
+                assert.calledWith(datastore.query, queryConfig);
+            }));
 
         it('calls datastore query with default config params', () =>
-            factory.query(defaultQueryConfig)
-                .then(() => {
-                    assert.calledWith(
-                        datastore.query,
-                        {
-                            table: 'base',
-                            queries: defaultQueryConfig.queries,
-                            rawResponse: false,
-                            replacements: {}
-                        });
-                })
-        );
+            factory.query(defaultQueryConfig).then(() => {
+                assert.calledWith(datastore.query, {
+                    table: 'base',
+                    queries: defaultQueryConfig.queries,
+                    rawResponse: false,
+                    replacements: {}
+                });
+            }));
 
         it('calls datastore query without rawResponse and returns correct values', () =>
-            factory.query(queryConfig)
-                .then((arr) => {
-                    assert.isArray(arr);
-                    assert.equal(arr.length, 2);
-                    arr.forEach((model) => {
-                        assert.instanceOf(model, Base);
-                        assert.deepEqual(model.datastore, datastore);
-                        assert.deepEqual(model.scm, scm);
-                    });
-                })
-        );
+            factory.query(queryConfig).then(arr => {
+                assert.isArray(arr);
+                assert.equal(arr.length, 2);
+                arr.forEach(model => {
+                    assert.instanceOf(model, Base);
+                    assert.deepEqual(model.datastore, datastore);
+                    assert.deepEqual(model.scm, scm);
+                });
+            }));
 
         it('calls datastore query with rawResponse and returns correct values', () => {
             queryConfig.rawResponse = true;
 
-            return factory.query(queryConfig)
-                .then((arr) => {
-                    assert.isArray(arr);
-                    assert.equal(arr.length, 2);
-                    arr.forEach((value) => {
-                        assert.notInstanceOf(value, Base);
-                    });
-                    assert.deepEqual(arr[0], returnValue[0]);
-                    assert.deepEqual(arr[1], returnValue[1]);
+            return factory.query(queryConfig).then(arr => {
+                assert.isArray(arr);
+                assert.equal(arr.length, 2);
+                arr.forEach(value => {
+                    assert.notInstanceOf(value, Base);
                 });
+                assert.deepEqual(arr[0], returnValue[0]);
+                assert.deepEqual(arr[1], returnValue[1]);
+            });
         });
 
         it('rejects with a failure from the datastore query', () => {
@@ -572,11 +563,12 @@ describe('Base Factory', () => {
 
             datastore.query.rejects(new Error(errorMessage));
 
-            return factory.query()
+            return factory
+                .query()
                 .then(() => {
                     assert.fail('this should not happen');
                 })
-                .catch((err) => {
+                .catch(err => {
                     assert.strictEqual(err.message, errorMessage);
                 });
         });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -99,7 +99,8 @@ describe('Build Factory', () => {
         datastore = {
             get: sinon.stub(),
             save: sinon.stub(),
-            scan: sinon.stub()
+            scan: sinon.stub(),
+            query: sinon.stub()
         };
         jobFactoryMock = {
             get: sinon.stub()
@@ -894,6 +895,193 @@ describe('Build Factory', () => {
             assert.throw(() => {
                 BuildFactory.getInstance({ executor, scm: {}, datastore, uiUri });
             }, Error, 'No bookend plugin provided to BuildFactory');
+        });
+    });
+
+    describe('getBuildStatuses', () => {
+        let config;
+        let expected;
+        let returnValue;
+        let queryConfig;
+        let query;
+        let mysqlQuery;
+
+        beforeEach(() => {
+            sinon.stub(BuildFactory.prototype, 'query').returns();
+
+            config = {
+                jobIds: [1, 2, 3, 4],
+                offset: 1,
+                numBuilds: 5
+            };
+
+            returnValue = [
+                [
+                    {
+                        jobId: 1,
+                        jobName: 'name',
+                        Status: 'SUCCESS',
+                        id: 1
+                    },
+                    {
+                        jobId: 1,
+                        jobName: 'name',
+                        Status: 'ABORTED',
+                        id: 2
+                    },
+                    {
+                        jobId: 2,
+                        jobName: 'name',
+                        Status: 'SUCCESS',
+                        id: 3
+                    },
+                    {
+                        jobId: 3,
+                        jobName: 'name',
+                        Status: 'SUCCESS',
+                        id: 4
+                    },
+                    {
+                        jobId: 2,
+                        jobName: 'name',
+                        Status: 'SUCCESS',
+                        id: 5
+                    },
+                    {
+                        jobId: 1,
+                        jobName: 'name',
+                        Status: 'SUCCESS',
+                        id: 6
+                    }
+                ],
+                []];
+
+            expected = [
+                {
+                    jobId: 1,
+                    builds: [
+                        {
+                            jobId: 1,
+                            jobName: 'name',
+                            Status: 'SUCCESS',
+                            id: 1
+                        },
+                        {
+                            jobId: 1,
+                            jobName: 'name',
+                            Status: 'ABORTED',
+                            id: 2
+                        },
+                        {
+                            jobId: 1,
+                            jobName: 'name',
+                            Status: 'SUCCESS',
+                            id: 6
+                        }
+                    ]
+                },
+                {
+                    jobId: 2,
+                    builds: [
+                        {
+                            jobId: 2,
+                            jobName: 'name',
+                            Status: 'SUCCESS',
+                            id: 3
+                        },
+                        {
+                            jobId: 2,
+                            jobName: 'name',
+                            Status: 'SUCCESS',
+                            id: 5
+                        }
+                    ]
+                },
+                {
+                    jobId: 3,
+                    builds: [
+                        {
+                            jobId: 3,
+                            jobName: 'name',
+                            Status: 'SUCCESS',
+                            id: 4
+                        }
+                    ]
+                }
+            ];
+
+            query =
+            'SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", '
+            + 'r."endTime" '
+            + 'FROM (SELECT "id", "jobId", "status", "startTime", "endTime", '
+            + 'RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank '
+            + 'FROM builds WHERE "jobId" in (:jobIds)) r '
+            + 'INNER JOIN jobs as j ON j."id" = r."jobId" '
+            + 'WHERE rank > :offset AND rank <= :maxRank '
+            + 'ORDER BY r."jobId", r."id" DESC';
+
+            mysqlQuery =
+            'SELECT r.id, r.jobId, j.name as `jobName`, r.status, r.startTime, r.endTime FROM '
+            + '(SELECT id, jobId, status, startTime, endTime, '
+            + 'RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS `rank` '
+            + 'FROM builds WHERE jobId in (:jobIds)) r '
+            + 'INNER JOIN jobs as j ON j.id = r.jobId '
+            + 'WHERE `rank` > :offset AND `rank` <= :maxRank '
+            + 'ORDER BY r.jobId, r.id DESC';
+
+            queryConfig = {
+                queries: [
+                    { dbType: 'postgres', query },
+                    { dbType: 'sqlite', query },
+                    { dbType: 'mysql', query: mysqlQuery }
+                ],
+                replacements: {
+                    jobIds: config.jobIds,
+                    offset: 1,
+                    maxRank: 6
+                },
+                rawResponse: true,
+                table: 'builds'
+            };
+        });
+
+        it('return build statuses for jobs', () => {
+            datastore.query.resolves(returnValue);
+
+            return factory.getBuildStatuses(config).then((buildStatuses) => {
+                assert.calledWith(datastore.query, queryConfig);
+
+                let i = 0;
+
+                buildStatuses.forEach((b) => {
+                    let j = 0;
+
+                    assert.deepEqual(b.jobId, expected[i].jobId);
+                    assert.deepEqual(b.builds.length, expected[i].builds.length);
+
+                    b.builds.forEach((s) => {
+                        assert.deepEqual(s, expected[i].builds[j]);
+
+                        j += 1;
+                    });
+
+                    i += 1;
+                });
+            });
+        });
+
+        it('Query with default config params', () => {
+            datastore.query.resolves([[], []]);
+
+            delete config.numBuilds;
+            delete config.offset;
+
+            queryConfig.replacements.offset = 0;
+            queryConfig.replacements.maxRank = 1;
+
+            return factory.getBuildStatuses(config).then(() => {
+                assert.calledWith(datastore.query, queryConfig);
+            });
         });
     });
 });

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BuildQueries = require('../../lib/rawQueries.js').BuildFactoryQueries;
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
@@ -903,8 +904,6 @@ describe('Build Factory', () => {
         let expected;
         let returnValue;
         let queryConfig;
-        let query;
-        let mysqlQuery;
 
         beforeEach(() => {
             sinon.stub(BuildFactory.prototype, 'query').returns();
@@ -1010,30 +1009,11 @@ describe('Build Factory', () => {
                 }
             ];
 
-            query =
-            'SELECT r."id", r."jobId", j."name" as "jobName", r."status", r."startTime", '
-            + 'r."endTime" '
-            + 'FROM (SELECT "id", "jobId", "status", "startTime", "endTime", '
-            + 'RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank '
-            + 'FROM builds WHERE "jobId" in (:jobIds)) r '
-            + 'INNER JOIN jobs as j ON j."id" = r."jobId" '
-            + 'WHERE rank > :offset AND rank <= :maxRank '
-            + 'ORDER BY r."jobId", r."id" DESC';
-
-            mysqlQuery =
-            'SELECT r.id, r.jobId, j.name as `jobName`, r.status, r.startTime, r.endTime FROM '
-            + '(SELECT id, jobId, status, startTime, endTime, '
-            + 'RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS `rank` '
-            + 'FROM builds WHERE jobId in (:jobIds)) r '
-            + 'INNER JOIN jobs as j ON j.id = r.jobId '
-            + 'WHERE `rank` > :offset AND `rank` <= :maxRank '
-            + 'ORDER BY r.jobId, r.id DESC';
-
             queryConfig = {
                 queries: [
-                    { dbType: 'postgres', query },
-                    { dbType: 'sqlite', query },
-                    { dbType: 'mysql', query: mysqlQuery }
+                    { dbType: 'postgres', query: BuildQueries.statusesQuery },
+                    { dbType: 'sqlite', query: BuildQueries.statusesQuery },
+                    { dbType: 'mysql', query: BuildQueries.statusesQueryMySql }
                 ],
                 replacements: {
                     jobIds: config.jobIds,

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const BuildQueries = require('../../lib/rawQueries.js').BuildFactoryQueries;
 const { assert } = require('chai');
 const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 const sinon = require('sinon');
+const BuildQueries = require('../../lib/rawQueries.js').BuildFactoryQueries;
 let startStub;
 let getStepsStub;
 
@@ -1062,7 +1062,8 @@ describe('Build Factory', () => {
                         id: 6
                     }
                 ],
-                []];
+                []
+            ];
 
             expected = [
                 {
@@ -1115,6 +1116,10 @@ describe('Build Factory', () => {
                             id: 4
                         }
                     ]
+                },
+                {
+                    jobId: 4,
+                    builds: []
                 }
             ];
 
@@ -1137,18 +1142,18 @@ describe('Build Factory', () => {
         it('return build statuses for jobs', () => {
             datastore.query.resolves(returnValue);
 
-            return factory.getBuildStatuses(config).then((buildStatuses) => {
+            return factory.getBuildStatuses(config).then(buildStatuses => {
                 assert.calledWith(datastore.query, queryConfig);
 
                 let i = 0;
 
-                buildStatuses.forEach((b) => {
+                buildStatuses.forEach(b => {
                     let j = 0;
 
                     assert.deepEqual(b.jobId, expected[i].jobId);
                     assert.deepEqual(b.builds.length, expected[i].builds.length);
 
-                    b.builds.forEach((s) => {
+                    b.builds.forEach(s => {
                         assert.deepEqual(s, expected[i].builds[j]);
 
                         j += 1;

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -1028,37 +1028,37 @@ describe('Build Factory', () => {
                     {
                         jobId: 1,
                         jobName: 'name',
-                        Status: 'SUCCESS',
+                        status: 'SUCCESS',
                         id: 1
                     },
                     {
                         jobId: 1,
                         jobName: 'name',
-                        Status: 'ABORTED',
+                        status: 'ABORTED',
                         id: 2
                     },
                     {
                         jobId: 2,
                         jobName: 'name',
-                        Status: 'SUCCESS',
+                        status: 'SUCCESS',
                         id: 3
                     },
                     {
                         jobId: 3,
                         jobName: 'name',
-                        Status: 'SUCCESS',
+                        status: 'SUCCESS',
                         id: 4
                     },
                     {
                         jobId: 2,
                         jobName: 'name',
-                        Status: 'SUCCESS',
+                        status: 'SUCCESS',
                         id: 5
                     },
                     {
                         jobId: 1,
                         jobName: 'name',
-                        Status: 'SUCCESS',
+                        status: 'SUCCESS',
                         id: 6
                     }
                 ],
@@ -1072,19 +1072,19 @@ describe('Build Factory', () => {
                         {
                             jobId: 1,
                             jobName: 'name',
-                            Status: 'SUCCESS',
+                            status: 'SUCCESS',
                             id: 1
                         },
                         {
                             jobId: 1,
                             jobName: 'name',
-                            Status: 'ABORTED',
+                            status: 'ABORTED',
                             id: 2
                         },
                         {
                             jobId: 1,
                             jobName: 'name',
-                            Status: 'SUCCESS',
+                            status: 'SUCCESS',
                             id: 6
                         }
                     ]
@@ -1095,13 +1095,13 @@ describe('Build Factory', () => {
                         {
                             jobId: 2,
                             jobName: 'name',
-                            Status: 'SUCCESS',
+                            status: 'SUCCESS',
                             id: 3
                         },
                         {
                             jobId: 2,
                             jobName: 'name',
-                            Status: 'SUCCESS',
+                            status: 'SUCCESS',
                             id: 5
                         }
                     ]
@@ -1112,7 +1112,7 @@ describe('Build Factory', () => {
                         {
                             jobId: 3,
                             jobName: 'name',
-                            Status: 'SUCCESS',
+                            status: 'SUCCESS',
                             id: 4
                         }
                     ]


### PR DESCRIPTION
## Context

Need to add the ability to do raw queries to baseFactory so queries that are otherwise impossible to do through sequelize can be done. Need to add ability to get build status history for jobs in bulk so that they can be displayed in pipeline list view.

## Objective

Add query method to baseFactory. Add getBuildStatuses to buildFactory so build status history for jobs can be queried in bulk.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1967

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
