### PR TITLE
fix: Step order is broken

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -275,7 +275,7 @@ class BuildFactory extends BaseFactory {
                             // eslint-disable-next-line no-await-in-loop
                             await stepFactory.create({ buildId: build.id, ...step });
                         } catch (err) {
-                            logger.error(`Error in steps -BuildId:${build.id}-step:${step}`, err);
+                            logger.error(`Error in BuildFactory create -buildId:${build.id}-step:${step}`, err);
                         }
                     }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -275,7 +275,7 @@ class BuildFactory extends BaseFactory {
                             // eslint-disable-next-line no-await-in-loop
                             await stepFactory.create({ buildId: build.id, ...step });
                         } catch (err) {
-                            logger.error(`Error in BuildFactory create -buildId:${build.id}-step:${step}`, err);
+                            logger.error(`Error in BuildFactory create - buildId:${build.id}-step:${step}`, err);
                         }
                     }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -274,8 +274,8 @@ class BuildFactory extends BaseFactory {
                             // eslint-disable-next-line no-await-in-loop
                             await stepFactory.create({ buildId: build.id, ...step });
                         } catch (err) {
-                            throw new Error(
-                                `Error in steps -BuildId:${build.id}-step:${step}`, err);
+                            // eslint-disable-next-line max-len
+                            throw new Error(`Error in steps -BuildId:${build.id}-step:${step}`, err);
                         }
                     }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -263,13 +263,16 @@ class BuildFactory extends BaseFactory {
 
                     const build = await super.create(modelConfig);
 
-                    await steps.reduce(async (p, step) =>
-                        // eslint-disable-next-line no-return-await
-                        await p.then(() => stepFactory.create(Object.assign(
-                            { buildId: build.id },
-                            step
-                        )))
-                        , Promise.resolve());
+                    // eslint-disable-next-line no-restricted-syntax
+                    for (const step of steps) {
+                        try {
+                            // eslint-disable-next-line no-await-in-loop
+                            await stepFactory.create({ buildId: build.id, ...step });
+                        } catch (err) {
+                            throw new Error(
+                                `Error in steps -BuildId:${build.id}-step:${step}`, err);
+                        }
+                    }
 
                     if (start === false) {
                         return build;

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -263,8 +263,9 @@ class BuildFactory extends BaseFactory {
 
                     const build = await super.create(modelConfig);
 
-                    await steps.reduce((p, step) =>
-                        p.then(() => stepFactory.create(Object.assign(
+                    await steps.reduce(async (p, step) =>
+                        // eslint-disable-next-line no-return-await
+                        await p.then(() => stepFactory.create(Object.assign(
                             { buildId: build.id },
                             step
                         )))

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -5,6 +5,7 @@ const hoek = require('hoek');
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const helper = require('./helper');
+const logger = require('screwdriver-logger');
 let instance;
 
 /**
@@ -274,8 +275,7 @@ class BuildFactory extends BaseFactory {
                             // eslint-disable-next-line no-await-in-loop
                             await stepFactory.create({ buildId: build.id, ...step });
                         } catch (err) {
-                            // eslint-disable-next-line max-len
-                            throw new Error(`Error in steps -BuildId:${build.id}-step:${step}`, err);
+                            logger.error(`Error in steps -BuildId:${build.id}-step:${step}`, err);
                         }
                     }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -2,10 +2,10 @@
 
 const imageParser = require('docker-parse-image');
 const hoek = require('hoek');
+const logger = require('screwdriver-logger');
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const helper = require('./helper');
-const logger = require('screwdriver-logger');
 let instance;
 
 /**


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I found a build where the order of the steps was broken.
It happens several times a day.

<img width="392" alt="image" src="https://user-images.githubusercontent.com/17828065/77022480-0d441800-69cd-11ea-8f4e-e1bfe7d36c3d.png">

The expected steps order are: `1 2 3 .... 5 6 7`.
The cause probably occurs when `stepFactory.create` is delayed.

## Objective
In this PR, modify to wait for `stepFactory.create`.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://stackoverflow.com/questions/41243468/javascript-array-reduce-with-async-await

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
