### PR TITLE
fix: make sync jobs sequential

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const logger = require('screwdriver-logger');
 const dayjs = require('dayjs');
 const hoek = require('hoek');
 const BaseModel = require('./base');
@@ -206,7 +207,7 @@ class Job extends BaseModel {
      * @method update
      * @return {Promise}
      */
-    update() {
+    async update() {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -214,20 +215,23 @@ class Job extends BaseModel {
         /* eslint-enable global-require */
         const pipelineFactory = PipelineFactory.getInstance();
 
-        return super.update().then(newJob =>
-            pipelineFactory
-                .get(newJob.pipelineId)
-                .then(pipeline => {
-                    this[executor].startPeriodic({
-                        pipeline,
-                        job: newJob,
-                        tokenGen: this[tokenGen],
-                        apiUri: this[apiUri],
-                        isUpdate: true
-                    });
-                })
-                .then(() => this)
-        );
+        const newJob = await super.update();
+        const pipeline = await pipelineFactory.get(newJob.pipelineId);
+
+        try {
+            // FIXME:: Make this call only if buildCron config is updated
+            await this[executor].startPeriodic({
+                pipeline,
+                job: newJob,
+                tokenGen: this[tokenGen],
+                apiUri: this[apiUri],
+                isUpdate: true
+            });
+        } catch (err) {
+            logger.error(`job:${this.id}: failed to update queue status`, err);
+        }
+
+        return this;
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -528,6 +528,8 @@ class PipelineModel extends BaseModel {
         await this._updateJobArchive(jobsToUnarchive, false, parsedConfig);
 
         delete this.jobs; // so that next time it will not get the cached version of this.jobs
+
+        return this;
     }
 
     /**
@@ -796,7 +798,7 @@ class PipelineModel extends BaseModel {
         await Promise.all(
             nodes.map(node => {
                 // Handle external nodes
-                if (/sd@/.test(node.name)) {
+                if (EXTERNAL_TRIGGER_ALL.test(node.name)) {
                     const pipelineFactory = this._getPipelineFactory();
                     const [, externalPipelineId, externalJobName] = /sd@(\d+):([\w-]+)$/.exec(node.name);
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -703,7 +703,7 @@ class PipelineModel extends BaseModel {
      * @param {Boolean} [chainPR] Chain PR flag
      * @return {Promise}
      */
-    sync(ref, chainPR = false) {
+    async sync(ref, chainPR = false) {
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -753,6 +753,7 @@ class PipelineModel extends BaseModel {
 
                     return this.jobs.then(existingJobs => {
                         const jobsProcessed = [];
+                        const updatedJobs = [];
                         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
                         const pipelineId = this.id;
 
@@ -773,11 +774,12 @@ class PipelineModel extends BaseModel {
                                 job.permutations = permutations;
                                 job.templateId = templateId;
                                 job.archived = false;
-                                await job.update();
                             } else if (!job.isPR()) {
                                 job.archived = true;
-                                await job.update();
                             }
+
+                            await job.update();
+                            updatedJobs.push(await job.update());
 
                             // sync external triggers for existing jobs
                             await syncExternalTriggers({
@@ -803,7 +805,7 @@ class PipelineModel extends BaseModel {
                             // If the job has not been processed, create it (new jobs)
                             if (!jobsProcessed.includes(jobName)) {
 
-                                await factory.create(jobConfig);
+                                updatedJobs.push(await factory.create(jobConfig));
 
                                 await syncExternalTriggers({
                                     pipelineId: this.id,
@@ -812,6 +814,8 @@ class PipelineModel extends BaseModel {
                                 })
                             }
                         }
+
+                        return updatedJobs;
                     });
                 })
                 // wait until all promises have resolved

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -751,14 +751,14 @@ class PipelineModel extends BaseModel {
                     this.annotations = parsedConfig.annotations;
                     this.parameters = parsedConfig.parameters;
 
-                    return this.jobs.then(existingJobs => {
+                    return this.jobs.then(async existingJobs => {
                         const jobsProcessed = [];
                         const updatedJobs = [];
                         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
                         const pipelineId = this.id;
 
                         // Loop through all existing jobs
-                        for (const job in existingJobs) {
+                        for (const job of existingJobs) {
                             const jobName = job.name;
                             let requiresList = [];
 
@@ -778,7 +778,6 @@ class PipelineModel extends BaseModel {
                                 job.archived = true;
                             }
 
-                            await job.update();
                             updatedJobs.push(await job.update());
 
                             // sync external triggers for existing jobs
@@ -793,7 +792,7 @@ class PipelineModel extends BaseModel {
                         }
 
                         // Loop through all defined jobs in the yaml
-                        for (const jobName in Object.keys(parsedConfig.jobs)) {
+                        for (const jobName of Object.keys(parsedConfig.jobs)) {
                             const permutations = parsedConfig.jobs[jobName];
                             const jobConfig = {
                                 pipelineId,
@@ -811,7 +810,7 @@ class PipelineModel extends BaseModel {
                                     pipelineId: this.id,
                                     jobName,
                                     requiresList
-                                })
+                                });
                             }
                         }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -798,9 +798,9 @@ class PipelineModel extends BaseModel {
         await Promise.all(
             nodes.map(node => {
                 // Handle external nodes
-                if (EXTERNAL_TRIGGER_ALL.test(node.name)) {
+                if (/sd@/.test(node.name)) {
                     const pipelineFactory = this._getPipelineFactory();
-                    const [, externalPipelineId, externalJobName] = /sd@(\d+):([\w-]+)$/.exec(node.name);
+                    const [, externalPipelineId, externalJobName] = EXTERNAL_TRIGGER_ALL.exec(node.name);
 
                     return pipelineFactory
                         .get(externalPipelineId)

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -752,14 +752,12 @@ class PipelineModel extends BaseModel {
                     this.parameters = parsedConfig.parameters;
 
                     return this.jobs.then(existingJobs => {
-                        const jobsToSync = [];
                         const jobsProcessed = [];
-                        const triggersToSync = [];
                         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
                         const pipelineId = this.id;
 
                         // Loop through all existing jobs
-                        existingJobs.forEach(job => {
+                        for (const job in existingJobs) {
                             const jobName = job.name;
                             let requiresList = [];
 
@@ -775,28 +773,25 @@ class PipelineModel extends BaseModel {
                                 job.permutations = permutations;
                                 job.templateId = templateId;
                                 job.archived = false;
-                                jobsToSync.push(job.update());
-                                // if it's not in the yaml then archive it
+                                await job.update();
                             } else if (!job.isPR()) {
                                 job.archived = true;
-                                jobsToSync.push(job.update());
+                                await job.update();
                             }
 
                             // sync external triggers for existing jobs
-                            triggersToSync.push(
-                                syncExternalTriggers({
-                                    pipelineId,
-                                    jobName,
-                                    requiresList
-                                })
-                            );
+                            await syncExternalTriggers({
+                                pipelineId,
+                                jobName,
+                                requiresList
+                            });
 
                             // if it's a PR, leave it alone
                             jobsProcessed.push(job.name);
-                        });
+                        }
 
                         // Loop through all defined jobs in the yaml
-                        Object.keys(parsedConfig.jobs).forEach(jobName => {
+                        for (const jobName in Object.keys(parsedConfig.jobs)) {
                             const permutations = parsedConfig.jobs[jobName];
                             const jobConfig = {
                                 pipelineId,
@@ -807,20 +802,16 @@ class PipelineModel extends BaseModel {
 
                             // If the job has not been processed, create it (new jobs)
                             if (!jobsProcessed.includes(jobName)) {
-                                jobsToSync.push(factory.create(jobConfig));
 
-                                // sync external triggers for new jobs
-                                triggersToSync.push(
-                                    syncExternalTriggers({
-                                        pipelineId: this.id,
-                                        jobName,
-                                        requiresList
-                                    })
-                                );
+                                await factory.create(jobConfig);
+
+                                await syncExternalTriggers({
+                                    pipelineId: this.id,
+                                    jobName,
+                                    requiresList
+                                })
                             }
-                        });
-
-                        return Promise.all(triggersToSync).then(() => Promise.all(jobsToSync));
+                        }
                     });
                 })
                 // wait until all promises have resolved

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -803,7 +803,6 @@ class PipelineModel extends BaseModel {
 
                             // If the job has not been processed, create it (new jobs)
                             if (!jobsProcessed.includes(jobName)) {
-
                                 updatedJobs.push(await factory.create(jobConfig));
 
                                 await syncExternalTriggers({

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -421,124 +421,113 @@ class PipelineModel extends BaseModel {
      * @method  syncPR
      * @return  {Promise}
      */
-    syncPR(prNum) {
-        return this.admin
-            .then(user => user.unsealToken())
-            .then(token =>
-                this.scm.getPrInfo({
-                    scmUri: this.scmUri,
-                    scmContext: this.scmContext,
-                    token,
-                    prNum,
-                    scmRepo: this.scmRepo
-                })
-            )
-            .then(prInfo =>
-                Promise.all([
-                    this.getConfiguration({
-                        ref: prInfo.ref,
-                        isPR: true
-                    }),
-                    this.jobs,
-                    prInfo.baseBranch
-                ])
-            )
-            .then(([parsedConfig, jobs, branch]) => {
-                logger.info(`pipelineId:${this.id}: chainPR flag is ${this.chainPR}.`);
+    async syncPR(prNum) {
+        const user = await this.admin;
+        const token = await user.unsealToken();
+        const prInfo = await this.scm.getPrInfo({
+            scmUri: this.scmUri,
+            scmContext: this.scmContext,
+            token,
+            prNum,
+            scmRepo: this.scmRepo
+        });
+        const jobs = await this.jobs;
+        const parsedConfig = await this.getConfiguration({
+            ref: prInfo.ref,
+            isPR: true
+        });
+        const branch = await prInfo.baseBranch;
 
-                const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
-                const { workflowGraph } = parsedConfig;
+        logger.info(`pipelineId:${this.id}: chainPR flag is ${this.chainPR}.`);
 
-                // Get next jobs for when startFrom is ~pr
-                let nextJobNames = workflowParser.getNextJobs(workflowGraph, {
-                    trigger: '~pr',
-                    prNum,
+        const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
+        const { workflowGraph } = parsedConfig;
+
+        // Get next jobs for when startFrom is ~pr
+        let nextJobNames = workflowParser.getNextJobs(workflowGraph, {
+            trigger: '~pr',
+            prNum,
+            chainPR: this.chainPR
+        });
+
+        // Get next jobs for when startFrom is ~pr:branchName
+        nextJobNames = nextJobNames.concat(
+            workflowParser.getNextJobs(workflowGraph, {
+                trigger: `~pr:${branch}`,
+                prNum,
+                chainPR: this.chainPR
+            })
+        );
+
+        // Get all chained jobs if chainPR is true
+        if (this.chainPR) {
+            let triggerJobs = nextJobNames.concat();
+
+            while (triggerJobs.length > 0) {
+                const chainedJobs = workflowParser.getNextJobs(workflowGraph, {
+                    trigger: triggerJobs[0],
                     chainPR: this.chainPR
                 });
 
-                // Get next jobs for when startFrom is ~pr:branchName
-                nextJobNames = nextJobNames.concat(
-                    workflowParser.getNextJobs(workflowGraph, {
-                        trigger: `~pr:${branch}`,
-                        prNum,
-                        chainPR: this.chainPR
-                    })
-                );
+                triggerJobs.splice(0, 1);
+                triggerJobs = triggerJobs.concat(chainedJobs);
+                nextJobNames = nextJobNames.concat(chainedJobs);
+            }
+        }
 
-                // Get all chained jobs if chainPR is true
-                if (this.chainPR) {
-                    let triggerJobs = nextJobNames.concat();
+        // PR jobs which requires ~pr or ~pr:branch are both same job name (like PR-1:test),
+        // so it needs to remove a duplicated PR job.
+        nextJobNames = _.uniq(nextJobNames);
 
-                    while (triggerJobs.length > 0) {
-                        const chainedJobs = workflowParser.getNextJobs(workflowGraph, {
-                            trigger: triggerJobs[0],
-                            chainPR: this.chainPR
-                        });
+        // Get all the missing PR- job names
+        const existingPRJobNames = prJobs.map(prJob => prJob.name);
+        const missingPRJobNames = nextJobNames.filter(nextJob => !existingPRJobNames.includes(nextJob));
 
-                        triggerJobs.splice(0, 1);
-                        triggerJobs = triggerJobs.concat(chainedJobs);
-                        nextJobNames = nextJobNames.concat(chainedJobs);
-                    }
-                }
+        // Get the job name part, e.g. main from PR-1:main to create job
+        const jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
+        const jobsToArchive = prJobs.filter(prJob => !nextJobNames.includes(prJob.name));
+        const jobsToUnarchive = prJobs.filter(prJob => nextJobNames.includes(prJob.name));
 
-                // PR jobs which requires ~pr or ~pr:branch are both same job name (like PR-1:test),
-                // so it needs to remove a duplicated PR job.
-                nextJobNames = _.uniq(nextJobNames);
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const JobFactory = require('./jobFactory');
+        /* eslint-enable global-require */
+        const jobFactory = JobFactory.getInstance();
 
-                // Get all the missing PR- job names
-                const existingPRJobNames = prJobs.map(prJob => prJob.name);
-                const missingPRJobNames = nextJobNames.filter(nextJob => !existingPRJobNames.includes(nextJob));
+        // filter to keep only the pipeline jobs that include in the jobsToCreate list
+        const prFromPipelineJobs = jobs.filter(
+            j => !j.name.startsWith(`PR-${prNum}:`) && jobsToCreate.includes(j.name)
+        );
 
-                // Get the job name part, e.g. main from PR-1:main to create job
-                const jobsToCreate = missingPRJobNames.map(name => name.split(':')[1]);
-                const jobsToArchive = prJobs.filter(prJob => !nextJobNames.includes(prJob.name));
-                const jobsToUnarchive = prJobs.filter(prJob => nextJobNames.includes(prJob.name));
+        // create a map for PR Parent Jobs like: {main: 1, publish: 2}
+        const prParentJobIdMap = {};
 
-                // Lazy load factory dependency to prevent circular dependency issues
-                // https://nodejs.org/api/modules.html#modules_cycles
-                /* eslint-disable global-require */
-                const JobFactory = require('./jobFactory');
-                /* eslint-enable global-require */
-                const jobFactory = JobFactory.getInstance();
+        prFromPipelineJobs.forEach(j => {
+            prParentJobIdMap[j.name] = j.id;
+        });
 
-                // filter to keep only the pipeline jobs that include in the jobsToCreate list
-                const prFromPipelineJobs = jobs.filter(
-                    j => !j.name.startsWith(`PR-${prNum}:`) && jobsToCreate.includes(j.name)
-                );
+        // Create missing PR jobs
+        for (const jobName of jobsToCreate) {
+            const jobModel = {
+                permutations: parsedConfig.jobs[jobName],
+                pipelineId: this.id,
+                name: `PR-${prNum}:${jobName}`
+            };
 
-                // create a map for PR Parent Jobs like: {main: 1, publish: 2}
-                const prParentJobIdMap = {};
+            // If there is a pr parent
+            if (prParentJobIdMap[jobName]) {
+                jobModel.prParentJobId = prParentJobIdMap[jobName];
+            }
 
-                prFromPipelineJobs.forEach(j => {
-                    prParentJobIdMap[j.name] = j.id;
-                });
+            // Create jobs
+            await jobFactory.create(jobModel);
+        }
 
-                // Create missing PR jobs
-                return Promise.all(
-                    jobsToCreate.map(jobName => {
-                        const jobModel = {
-                            permutations: parsedConfig.jobs[jobName],
-                            pipelineId: this.id,
-                            name: `PR-${prNum}:${jobName}`
-                        };
+        await this._updateJobArchive(jobsToArchive, true);
+        await this._updateJobArchive(jobsToUnarchive, false, parsedConfig);
 
-                        // If there is a pr parent
-                        if (prParentJobIdMap[jobName]) {
-                            jobModel.prParentJobId = prParentJobIdMap[jobName];
-                        }
-
-                        // Create jobs
-                        return jobFactory.create(jobModel);
-                    })
-                ).then(() =>
-                    Promise.all([
-                        this._updateJobArchive(jobsToArchive, true),
-                        this._updateJobArchive(jobsToUnarchive, false, parsedConfig)
-                    ])
-                );
-            })
-            .then(() => delete this.jobs) // so that next time it will not get the cached version of this.jobs
-            .then(() => this);
+        delete this.jobs; // so that next time it will not get the cached version of this.jobs
     }
 
     /**
@@ -712,162 +701,148 @@ class PipelineModel extends BaseModel {
         const factory = JobFactory.getInstance();
 
         // get the pipeline configuration
-        return (
-            this.getConfiguration({ ref })
-                .then(parsedConfig => {
-                    const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
-                    const parsedConfigAnnotations = hoek.reach(parsedConfig, 'annotations', { default: {} });
-                    const buildCluster = parsedConfigAnnotations[buildClusterAnnotation] || '';
+        const parsedConfig = await this.getConfiguration({ ref });
+        const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+        const parsedConfigAnnotations = hoek.reach(parsedConfig, 'annotations', { default: {} });
+        const buildCluster = parsedConfigAnnotations[buildClusterAnnotation] || '';
 
-                    if (!buildCluster) {
-                        const dbClusterAnnotations = hoek.reach(this, 'annotations', { default: {} });
+        if (!buildCluster) {
+            const dbClusterAnnotations = hoek.reach(this, 'annotations', { default: {} });
 
-                        if (dbClusterAnnotations) {
-                            parsedConfig.annotations[buildClusterAnnotation] =
-                                dbClusterAnnotations[buildClusterAnnotation];
-                        }
-                    }
+            if (dbClusterAnnotations) {
+                parsedConfig.annotations[buildClusterAnnotation] = dbClusterAnnotations[buildClusterAnnotation];
+            }
+        }
 
-                    // If it is an external config pipeline, sync all children
-                    if (
-                        (this.childPipelines || parsedConfig.childPipelines) &&
-                        !this.configPipelineId &&
-                        !parsedConfig.errors
-                    ) {
-                        return this._syncChildPipelines(hoek.reach(parsedConfig, 'childPipelines.scmUrls')).then(() => {
-                            this.childPipelines = parsedConfig.childPipelines || null;
+        // If it is an external config pipeline, sync all children
+        if ((this.childPipelines || parsedConfig.childPipelines) && !this.configPipelineId && !parsedConfig.errors) {
+            await this._syncChildPipelines(hoek.reach(parsedConfig, 'childPipelines.scmUrls'));
+            this.childPipelines = parsedConfig.childPipelines || null;
+        }
 
-                            return parsedConfig;
-                        });
-                    }
+        const annotChainPR = parsedConfig.annotations['screwdriver.cd/chainPR'];
 
-                    return parsedConfig;
-                })
-                .then(async parsedConfig => {
-                    const annotChainPR = parsedConfig.annotations['screwdriver.cd/chainPR'];
+        this.chainPR = typeof annotChainPR === 'undefined' ? chainPR : annotChainPR;
+        this.workflowGraph = parsedConfig.workflowGraph;
+        this.annotations = parsedConfig.annotations;
+        this.parameters = parsedConfig.parameters;
 
-                    this.chainPR = typeof annotChainPR === 'undefined' ? chainPR : annotChainPR;
-                    this.workflowGraph = parsedConfig.workflowGraph;
-                    this.annotations = parsedConfig.annotations;
-                    this.parameters = parsedConfig.parameters;
+        const existingJobs = await this.jobs;
 
-                    const existingJobs = await this.jobs;
+        const jobsProcessed = [];
+        const updatedJobs = [];
+        const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
+        const pipelineId = this.id;
 
-                    const jobsProcessed = [];
-                    const updatedJobs = [];
-                    const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
-                    const pipelineId = this.id;
+        // Loop through all existing jobs
+        for (const job of existingJobs) {
+            const jobName = job.name;
+            let requiresList = [];
 
-                    // Loop through all existing jobs
-                    for (const job of existingJobs) {
-                        const jobName = job.name;
-                        let requiresList = [];
+            // if it's in the yaml, update it
+            if (parsedConfigJobNames.includes(jobName)) {
+                const templateId = parsedConfig.jobs[jobName][0].templateId || null;
 
-                        // if it's in the yaml, update it
-                        if (parsedConfigJobNames.includes(jobName)) {
-                            const templateId = parsedConfig.jobs[jobName][0].templateId || null;
+                delete parsedConfig.jobs[jobName][0].templateId;
 
-                            delete parsedConfig.jobs[jobName][0].templateId;
+                const permutations = parsedConfig.jobs[jobName];
 
-                            const permutations = parsedConfig.jobs[jobName];
+                requiresList = permutations[0].requires || [];
+                job.permutations = permutations;
+                job.templateId = templateId;
+                job.archived = false;
+                updatedJobs.push(await job.update());
+            } else if (!job.isPR()) {
+                job.archived = true;
+                updatedJobs.push(await job.update());
+            }
 
-                            requiresList = permutations[0].requires || [];
-                            job.permutations = permutations;
-                            job.templateId = templateId;
-                            job.archived = false;
-                            updatedJobs.push(await job.update());
-                        } else if (!job.isPR()) {
-                            job.archived = true;
-                            updatedJobs.push(await job.update());
-                        }
+            // sync external triggers for existing jobs
+            await syncExternalTriggers({
+                pipelineId,
+                jobName,
+                requiresList
+            });
 
-                        // sync external triggers for existing jobs
-                        await syncExternalTriggers({
-                            pipelineId,
-                            jobName,
-                            requiresList
-                        });
+            // if it's a PR, leave it alone
+            jobsProcessed.push(job.name);
+        }
 
-                        // if it's a PR, leave it alone
-                        jobsProcessed.push(job.name);
-                    }
+        // Loop through all defined jobs in the yaml
+        for (const jobName of Object.keys(parsedConfig.jobs)) {
+            const permutations = parsedConfig.jobs[jobName];
+            const jobConfig = {
+                pipelineId,
+                name: jobName,
+                permutations
+            };
+            const requiresList = permutations[0].requires || [];
 
-                    // Loop through all defined jobs in the yaml
-                    for (const jobName of Object.keys(parsedConfig.jobs)) {
-                        const permutations = parsedConfig.jobs[jobName];
-                        const jobConfig = {
-                            pipelineId,
-                            name: jobName,
-                            permutations
-                        };
-                        const requiresList = permutations[0].requires || [];
+            // If the job has not been processed, create it (new jobs)
+            if (!jobsProcessed.includes(jobName)) {
+                updatedJobs.push(await factory.create(jobConfig));
 
-                        // If the job has not been processed, create it (new jobs)
-                        if (!jobsProcessed.includes(jobName)) {
-                            updatedJobs.push(await factory.create(jobConfig));
+                await syncExternalTriggers({
+                    pipelineId: this.id,
+                    jobName,
+                    requiresList
+                });
+            }
+        }
 
-                            await syncExternalTriggers({
-                                pipelineId: this.id,
-                                jobName,
-                                requiresList
-                            });
-                        }
-                    }
+        const { nodes } = this.workflowGraph;
 
-                    return updatedJobs;
-                })
-                // wait until all promises have resolved
-                .then(updatedJobs => {
-                    const { nodes } = this.workflowGraph;
+        // Add jobId to workflowGraph.nodes
+        await Promise.all(
+            nodes.map(node => {
+                // Handle external nodes
+                if (/sd@/.test(node.name)) {
+                    const pipelineFactory = this._getPipelineFactory();
+                    const [, externalPipelineId, externalJobName] = /sd@(\d+):([\w-]+)$/.exec(node.name);
 
-                    // Add jobId to workflowGraph.nodes
-                    return Promise.all(
-                        nodes.map(node => {
-                            // Handle external nodes
-                            if (/sd@/.test(node.name)) {
-                                const pipelineFactory = this._getPipelineFactory();
-                                const [, externalPipelineId, externalJobName] = /sd@(\d+):([\w-]+)$/.exec(node.name);
+                    return pipelineFactory
+                        .get(externalPipelineId)
+                        .then(externalPipeline => {
+                            const externalWorkflow = externalPipeline.workflowGraph;
 
-                                return pipelineFactory
-                                    .get(externalPipelineId)
-                                    .then(externalPipeline => {
-                                        const externalWorkflow = externalPipeline.workflowGraph;
+                            if (externalWorkflow && Array.isArray(externalWorkflow.nodes)) {
+                                const externalJob = externalWorkflow.nodes.find(n => n.name === externalJobName);
 
-                                        if (externalWorkflow && Array.isArray(externalWorkflow.nodes)) {
-                                            const externalJobId = externalWorkflow.nodes.find(
-                                                n => n.name === externalJobName
-                                            ).id;
-
-                                            node.id = externalJobId;
-                                        } else {
-                                            logger.error(`pipelineId:${externalPipelineId}: has no workflow.`);
-                                        }
-
-                                        return node;
-                                    })
-                                    .catch(() => {
-                                        logger.error(`pipelineId:${externalPipelineId}: does not exist.`);
-                                    });
-                            }
-                            const job = updatedJobs.find(j => j.name === node.name);
-
-                            // Handle internal nodes
-                            if (job) {
-                                node.id = job.id;
+                                if (externalJob) {
+                                    node.id = externalJob.id;
+                                } else {
+                                    logger.error(
+                                        `pipelineId:${externalPipelineId}: workflow has no job:${externalJobName}.`
+                                    );
+                                }
+                            } else {
+                                logger.error(`pipelineId:${externalPipelineId}: has no workflow.`);
                             }
 
                             return node;
                         })
-                    ).then(() => {
-                        // jobs updated or new jobs created during sync
-                        // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
-                        delete this.jobs;
+                        .catch(() => {
+                            logger.error(`pipelineId:${externalPipelineId}: does not exist.`);
+                        });
+                }
+                const job = updatedJobs.find(j => j.name === node.name);
 
-                        return this.update();
-                    });
-                })
-                .then(() => this)
+                // Handle internal nodes
+                if (job) {
+                    node.id = job.id;
+                }
+
+                return node;
+            })
         );
+
+        // jobs updated or new jobs created during sync
+        // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
+        delete this.jobs;
+
+        await this.update();
+
+        return this;
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -743,7 +743,7 @@ class PipelineModel extends BaseModel {
 
                     return parsedConfig;
                 })
-                .then(parsedConfig => {
+                .then(async parsedConfig => {
                     const annotChainPR = parsedConfig.annotations['screwdriver.cd/chainPR'];
 
                     this.chainPR = typeof annotChainPR === 'undefined' ? chainPR : annotChainPR;
@@ -751,70 +751,70 @@ class PipelineModel extends BaseModel {
                     this.annotations = parsedConfig.annotations;
                     this.parameters = parsedConfig.parameters;
 
-                    return this.jobs.then(async existingJobs => {
-                        const jobsProcessed = [];
-                        const updatedJobs = [];
-                        const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
-                        const pipelineId = this.id;
+                    const existingJobs = await this.jobs;
 
-                        // Loop through all existing jobs
-                        for (const job of existingJobs) {
-                            const jobName = job.name;
-                            let requiresList = [];
+                    const jobsProcessed = [];
+                    const updatedJobs = [];
+                    const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
+                    const pipelineId = this.id;
 
-                            // if it's in the yaml, update it
-                            if (parsedConfigJobNames.includes(jobName)) {
-                                const templateId = parsedConfig.jobs[jobName][0].templateId || null;
+                    // Loop through all existing jobs
+                    for (const job of existingJobs) {
+                        const jobName = job.name;
+                        let requiresList = [];
 
-                                delete parsedConfig.jobs[jobName][0].templateId;
+                        // if it's in the yaml, update it
+                        if (parsedConfigJobNames.includes(jobName)) {
+                            const templateId = parsedConfig.jobs[jobName][0].templateId || null;
 
-                                const permutations = parsedConfig.jobs[jobName];
+                            delete parsedConfig.jobs[jobName][0].templateId;
 
-                                requiresList = permutations[0].requires || [];
-                                job.permutations = permutations;
-                                job.templateId = templateId;
-                                job.archived = false;
-                            } else if (!job.isPR()) {
-                                job.archived = true;
-                            }
+                            const permutations = parsedConfig.jobs[jobName];
 
+                            requiresList = permutations[0].requires || [];
+                            job.permutations = permutations;
+                            job.templateId = templateId;
+                            job.archived = false;
                             updatedJobs.push(await job.update());
+                        } else if (!job.isPR()) {
+                            job.archived = true;
+                            updatedJobs.push(await job.update());
+                        }
 
-                            // sync external triggers for existing jobs
+                        // sync external triggers for existing jobs
+                        await syncExternalTriggers({
+                            pipelineId,
+                            jobName,
+                            requiresList
+                        });
+
+                        // if it's a PR, leave it alone
+                        jobsProcessed.push(job.name);
+                    }
+
+                    // Loop through all defined jobs in the yaml
+                    for (const jobName of Object.keys(parsedConfig.jobs)) {
+                        const permutations = parsedConfig.jobs[jobName];
+                        const jobConfig = {
+                            pipelineId,
+                            name: jobName,
+                            permutations
+                        };
+                        const requiresList = permutations[0].requires || [];
+
+                        // If the job has not been processed, create it (new jobs)
+                        if (!jobsProcessed.includes(jobName)) {
+                            updatedJobs.push(await factory.create(jobConfig));
+
                             await syncExternalTriggers({
-                                pipelineId,
+                                pipelineId: this.id,
                                 jobName,
                                 requiresList
                             });
-
-                            // if it's a PR, leave it alone
-                            jobsProcessed.push(job.name);
                         }
+                    }
 
-                        // Loop through all defined jobs in the yaml
-                        for (const jobName of Object.keys(parsedConfig.jobs)) {
-                            const permutations = parsedConfig.jobs[jobName];
-                            const jobConfig = {
-                                pipelineId,
-                                name: jobName,
-                                permutations
-                            };
-                            const requiresList = permutations[0].requires || [];
-
-                            // If the job has not been processed, create it (new jobs)
-                            if (!jobsProcessed.includes(jobName)) {
-                                updatedJobs.push(await factory.create(jobConfig));
-
-                                await syncExternalTriggers({
-                                    pipelineId: this.id,
-                                    jobName,
-                                    requiresList
-                                });
-                            }
-                        }
-
-                        return updatedJobs;
-                    });
+                    return updatedJobs;
                 })
                 // wait until all promises have resolved
                 .then(updatedJobs => {


### PR DESCRIPTION
## Context

For pipelines with large number of jobs, sync process can fail. This is because models does `job.update` in parallel for all jobs and overwhelms underlying resources

## Objective

Process jobs sequentially.

## References

https://github.com/screwdriver-cd/models/blob/98011ec83236ecab0bb49d0f4482f96459410929/lib/job.js#L220

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
