### PR TITLE
fix: pass jobId and pipelineId

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -223,6 +223,8 @@ class Job extends BaseModel {
                         job: newJob,
                         tokenGen: this[tokenGen],
                         apiUri: this[apiUri],
+                        jobId: newJob.id,
+                        pipelineId: pipeline.id,
                         isUpdate: true
                     });
                 })

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -72,7 +72,9 @@ class JobFactory extends BaseFactory {
                             pipeline,
                             job,
                             tokenGen: this.tokenGen,
-                            apiUri: this.apiUri
+                            apiUri: this.apiUri,
+                            jobId: job.id,
+                            pipelineId: pipeline.id
                         })
                     )
                     .then(() => job);

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -109,7 +109,8 @@ describe('Job Model', () => {
                 value: '3',
                 allowInPR: true
             }
-        ])
+        ]),
+        id: 123
     };
 
     before(() => {
@@ -427,6 +428,8 @@ describe('Job Model', () => {
                 assert.calledWith(executorMock.startPeriodic, {
                     pipeline: pipelineMock,
                     job,
+                    jobId: job.id,
+                    pipelineId: 123,
                     tokenGen,
                     apiUri,
                     isUpdate: true

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -173,6 +173,8 @@ describe('Job Factory', () => {
                     assert.calledWith(executor.startPeriodic, {
                         pipeline: { id: 9999 },
                         job: model,
+                        jobId: model.id,
+                        pipelineId: 9999,
                         tokenGen: tokenGenFunc,
                         apiUri
                     });


### PR DESCRIPTION
## Context

JobId and PipelineId were undefined in case of periodic builds in log message

## Objective

This PR passes jobId and pipelineId in function to log correctly

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
