### PR TITLE
fix: Fix job remove

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -590,7 +590,8 @@ class BuildModel extends BaseModel {
      */
     isDone() {
         return (
-            ['ABORTED', 'FAILURE', 'SUCCESS'].includes(this.status) || (this.status === 'UNSTABLE' && !!this.endTime)
+            ['ABORTED', 'FAILURE', 'SUCCESS', 'COLLAPSED'].includes(this.status) ||
+            (this.status === 'UNSTABLE' && !!this.endTime)
         );
     }
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -244,17 +244,22 @@ class Job extends BaseModel {
                         return pipeline.id;
                     }
 
-                    return Promise.all(
-                        builds.map(build => {
-                            this[executor].stop({
-                                buildId: build.id,
-                                pipelineId: pipeline.id,
-                                jobId: this.id
-                            });
+                    return Promise.all([
+                        builds
+                            .filter(build => {
+                                const stoppedStatuses = ['ABORTED', 'FAILURE', 'SUCCESS'];
 
-                            return build.remove();
-                        })
-                    )
+                                return !stoppedStatuses.includes(build.status);
+                            })
+                            .map(build =>
+                                this[executor].stop({
+                                    buildId: build.id,
+                                    pipelineId: pipeline.id,
+                                    jobId: this.id
+                                })
+                            ),
+                        builds.map(build => build.remove())
+                    ])
                         .then(() => removeBuilds())
                         .then(() => pipeline.id);
                 }

--- a/lib/job.js
+++ b/lib/job.js
@@ -246,7 +246,7 @@ class Job extends BaseModel {
 
                     return Promise.all(
                         builds.map(build => {
-                            const stoppedStatuses = ['ABORTED', 'FAILURE', 'SUCCESS'];
+                            const stoppedStatuses = ['ABORTED', 'FAILURE', 'SUCCESS', 'COLLAPSED'];
 
                             if (!stoppedStatuses.includes(build.status)) {
                                 this[executor].stop({

--- a/lib/job.js
+++ b/lib/job.js
@@ -244,22 +244,21 @@ class Job extends BaseModel {
                         return pipeline.id;
                     }
 
-                    return Promise.all([
-                        builds
-                            .filter(build => {
-                                const stoppedStatuses = ['ABORTED', 'FAILURE', 'SUCCESS'];
+                    return Promise.all(
+                        builds.map(build => {
+                            const stoppedStatuses = ['ABORTED', 'FAILURE', 'SUCCESS'];
 
-                                return !stoppedStatuses.includes(build.status);
-                            })
-                            .map(build =>
+                            if (!stoppedStatuses.includes(build.status)) {
                                 this[executor].stop({
                                     buildId: build.id,
                                     pipelineId: pipeline.id,
                                     jobId: this.id
-                                })
-                            ),
-                        builds.map(build => build.remove())
-                    ])
+                                });
+                            }
+
+                            return build.remove();
+                        })
+                    )
                         .then(() => removeBuilds())
                         .then(() => pipeline.id);
                 }

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -441,13 +441,14 @@ describe('Job Model', () => {
             buildFactoryMock.list.reset();
             build1.remove.reset();
             build2.remove.reset();
+            build3.remove.reset();
         });
 
         it('remove builds recursively', () => {
             let i;
 
             for (i = 0; i < 4; i += 1) {
-                buildFactoryMock.list.onCall(i).resolves([build1, build2]);
+                buildFactoryMock.list.onCall(i).resolves([build1, build2, build3]);
             }
 
             buildFactoryMock.list.onCall(i).resolves([]);
@@ -456,6 +457,7 @@ describe('Job Model', () => {
                 assert.callCount(buildFactoryMock.list, 5);
                 assert.callCount(build1.remove, 4); // remove builds recursively
                 assert.callCount(build2.remove, 4);
+                assert.callCount(build3.remove, 4);
                 assert.calledOnce(datastore.remove); // remove the job
                 assert.callCount(executorMock.stop, 8);
                 assert.notCalled(executorMock.stopPeriodic);


### PR DESCRIPTION
## Context
Recently, the screwdriver which we operate got the situation that worker get busy when big pipelines have been deleted.
Now `job.remove` call `executor.stop` to all builds, even if the build was finished and it will make worker busy.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
`job.remove` will not call `executor.stop` to builds which have 'ABORTED', 'FAILURE' or 'SUCCESS' status.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
