### PR TITLE
fix: pipeline sync to process 5 jobs in parallel

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -23,6 +23,11 @@ const SCM_NO_ACCESS_STATUSES = [401, 404];
 
 const { getAllRecords, getBuildClusterName } = require('./helper.js');
 
+const JOB_CHUNK_SIZE = process.env.JOBS_PARALLEL_COUNT || 5;
+
+// Process jobs JOB_CHUNK_SIZE at at time
+const getJobChunks = jobs => _.chunk(jobs || [], JOB_CHUNK_SIZE);
+
 // Calculate event duration by using max endTime - min startTime of builds
 // that belong this event
 const eventMetrics = async event => {
@@ -508,20 +513,24 @@ class PipelineModel extends BaseModel {
         });
 
         // Create missing PR jobs
-        for (const jobName of jobsToCreate) {
-            const jobModel = {
-                permutations: parsedConfig.jobs[jobName],
-                pipelineId: this.id,
-                name: `PR-${prNum}:${jobName}`
-            };
+        for (const jobNames of getJobChunks(jobsToCreate)) {
+            await Promise.all(
+                jobNames.map(jobName => {
+                    const jobModel = {
+                        permutations: parsedConfig.jobs[jobName],
+                        pipelineId: this.id,
+                        name: `PR-${prNum}:${jobName}`
+                    };
 
-            // If there is a pr parent
-            if (prParentJobIdMap[jobName]) {
-                jobModel.prParentJobId = prParentJobIdMap[jobName];
-            }
+                    // If there is a pr parent
+                    if (prParentJobIdMap[jobName]) {
+                        jobModel.prParentJobId = prParentJobIdMap[jobName];
+                    }
 
-            // Create jobs
-            await jobFactory.create(jobModel);
+                    // Create jobs
+                    return jobFactory.create(jobModel);
+                })
+            );
         }
 
         await this._updateJobArchive(jobsToArchive, true);
@@ -737,96 +746,104 @@ class PipelineModel extends BaseModel {
         const pipelineId = this.id;
 
         // Loop through all existing jobs
-        for (const job of existingJobs) {
-            const jobName = job.name;
-            let requiresList = [];
+        for (const jobChunks of getJobChunks(existingJobs)) {
+            await Promise.all(
+                jobChunks.map(async job => {
+                    const jobName = job.name;
+                    let requiresList = [];
 
-            // if it's in the yaml, update it
-            if (parsedConfigJobNames.includes(jobName)) {
-                const templateId = parsedConfig.jobs[jobName][0].templateId || null;
+                    // if it's in the yaml, update it
+                    if (parsedConfigJobNames.includes(jobName)) {
+                        const templateId = parsedConfig.jobs[jobName][0].templateId || null;
 
-                delete parsedConfig.jobs[jobName][0].templateId;
+                        delete parsedConfig.jobs[jobName][0].templateId;
 
-                const permutations = parsedConfig.jobs[jobName];
+                        const permutations = parsedConfig.jobs[jobName];
 
-                requiresList = permutations[0].requires || [];
-                job.permutations = permutations;
-                job.templateId = templateId;
-                job.archived = false;
-                updatedJobs.push(await job.update());
-            } else if (!job.isPR()) {
-                job.archived = true;
-                updatedJobs.push(await job.update());
-            }
+                        requiresList = permutations[0].requires || [];
+                        job.permutations = permutations;
+                        job.templateId = templateId;
+                        job.archived = false;
+                        updatedJobs.push(await job.update());
+                    } else if (!job.isPR()) {
+                        job.archived = true;
+                        updatedJobs.push(await job.update());
+                    }
 
-            // sync external triggers for existing jobs
-            await syncExternalTriggers({
-                pipelineId,
-                jobName,
-                requiresList
-            });
+                    // sync external triggers for existing jobs
+                    await syncExternalTriggers({
+                        pipelineId,
+                        jobName,
+                        requiresList
+                    });
 
-            // if it's a PR, leave it alone
-            jobsProcessed.push(job.name);
+                    // if it's a PR, leave it alone
+                    jobsProcessed.push(job.name);
+                })
+            );
         }
 
         // Loop through all defined jobs in the yaml
-        for (const jobName of Object.keys(parsedConfig.jobs)) {
-            const permutations = parsedConfig.jobs[jobName];
-            const jobConfig = {
-                pipelineId,
-                name: jobName,
-                permutations
-            };
-            const requiresList = permutations[0].requires || [];
+        for (const jobChunks of getJobChunks(parsedConfigJobNames)) {
+            await Promise.all(
+                jobChunks.map(async jobName => {
+                    console.log(jobName);
+                    const permutations = parsedConfig.jobs[jobName];
+                    const jobConfig = {
+                        pipelineId,
+                        name: jobName,
+                        permutations
+                    };
+                    const requiresList = permutations[0].requires || [];
 
-            // If the job has not been processed, create it (new jobs)
-            if (!jobsProcessed.includes(jobName)) {
-                updatedJobs.push(await factory.create(jobConfig));
+                    // If the job has not been processed, create it (new jobs)
+                    if (!jobsProcessed.includes(jobName)) {
+                        updatedJobs.push(await factory.create(jobConfig));
 
-                await syncExternalTriggers({
-                    pipelineId: this.id,
-                    jobName,
-                    requiresList
-                });
-            }
+                        await syncExternalTriggers({
+                            pipelineId: this.id,
+                            jobName,
+                            requiresList
+                        });
+                    }
+                })
+            );
         }
 
         const { nodes } = this.workflowGraph;
 
         // Add jobId to workflowGraph.nodes
         await Promise.all(
-            nodes.map(node => {
+            nodes.map(async node => {
                 // Handle external nodes
                 if (/sd@/.test(node.name)) {
                     const pipelineFactory = this._getPipelineFactory();
                     const [, externalPipelineId, externalJobName] = EXTERNAL_TRIGGER_ALL.exec(node.name);
 
-                    return pipelineFactory
-                        .get(externalPipelineId)
-                        .then(externalPipeline => {
-                            const externalWorkflow = externalPipeline.workflowGraph;
+                    try {
+                        const externalPipeline = await pipelineFactory.get(externalPipelineId);
+                        const externalWorkflow = externalPipeline.workflowGraph;
 
-                            if (externalWorkflow && Array.isArray(externalWorkflow.nodes)) {
-                                const externalJob = externalWorkflow.nodes.find(n => n.name === externalJobName);
+                        if (externalWorkflow && Array.isArray(externalWorkflow.nodes)) {
+                            const externalJob = externalWorkflow.nodes.find(n => n.name === externalJobName);
 
-                                if (externalJob) {
-                                    node.id = externalJob.id;
-                                } else {
-                                    logger.error(
-                                        `pipelineId:${externalPipelineId}: workflow has no job:${externalJobName}.`
-                                    );
-                                }
+                            if (externalJob) {
+                                node.id = externalJob.id;
                             } else {
-                                logger.error(`pipelineId:${externalPipelineId}: has no workflow.`);
+                                logger.error(
+                                    `pipelineId:${externalPipelineId}: workflow has no job:${externalJobName}.`
+                                );
                             }
+                        } else {
+                            logger.error(`pipelineId:${externalPipelineId}: has no workflow.`);
+                        }
+                    } catch (err) {
+                        logger.error(`pipelineId:${externalPipelineId}: does not exist.`, err);
+                    }
 
-                            return node;
-                        })
-                        .catch(() => {
-                            logger.error(`pipelineId:${externalPipelineId}: does not exist.`);
-                        });
+                    return node;
                 }
+
                 const job = updatedJobs.find(j => j.name === node.name);
 
                 // Handle internal nodes


### PR DESCRIPTION
## Context

In https://github.com/screwdriver-cd/models/pull/443 we made job processing sequential to prevent large pipelines from overwhelming our resources. But that had the side effect of increased API response times especially for the large pipelines we targeted. 

## Objective

1. Process chunks of jobs in parallel.
1. Number of jobs in configurable using env variable `JOBS_PARALLEL_COUNT`
1. No change to end result since it's just moving some flows around. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
