### PR TITLE
fix: do not ignore failure to fetch screwdriver.yaml

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -295,9 +295,10 @@ class PipelineModel extends BaseModel {
                     }
 
                     return this.scm.getFile(config).catch(err => {
-                        logger.error(`pipelineId:${this.id}: Failed to fetch screwdriver.yaml.`, err);
+                        const message = `pipelineId:${this.id}: Failed to fetch screwdriver.yaml.`;
 
-                        return '';
+                        logger.error(message, err);
+                        throw new Error(message);
                     });
                 })
                 // parse the content of the yaml file


### PR DESCRIPTION
## Context

Error fetching `screwdriver.yaml` is currently ignored. This leads to a situation where during `pipeline.sync` generic error configuration is returned by `parser` and overwrites jobs for the pipeline. 

## Objective

Errors when fetching `screwdriver.yaml` should not be ignored. This lets caller handle the error and eventually fail any  API call in progress, rather than causing pipeline config to be overwritten 

## References

https://github.com/screwdriver-cd/models/blob/master/lib/pipeline.js#L721-L722


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
