### PR TITLE
feat(1785): Add query to get latest builds for groupEventId [3.5]

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ factory.get({ jobId, number }).then(model => {
 });
 ```
 
-| Parameter        | Type  |  Description |
-| :-------------   | :---- | :-------------|
+| Parameter      | Type  |  Description   |
+| :------------- | :---- | :------------- |
 | id | Number | The unique ID for the build |
 | config.jobId | Number | The unique ID for a job |
 | config.number | Number | build number |
@@ -361,8 +361,8 @@ factory.getBuildStatuses(config).then(statuses => {
 });
 ```
 
-| Parameter        | Type  |  Required | Description |
-| :-------------   | :---- | :-------------|  :-------------|
+| Parameter       | Type  |  Required | Description |
+| :-------------  | :---- | :-------- | :---------- |
 | config        | Object | Yes | Configuration Object |
 | config.jobIds | Array | Yes | Ids of the jobs to get build statuses for |
 | config.numBuilds | Number | No | Number of build statuses to return per job |
@@ -376,8 +376,8 @@ factory.getLatestBuilds(config).then(latestBuilds => {
 });
 ```
 
-| Parameter        | Type  |  Required | Description |
-| :-------------   | :---- | :-------------|  :-------------|
+| Parameter      | Type  |  Required | Description |
+| :------------- | :---- | :-------- | :---------- |
 | config        | Object | Yes | Configuration Object |
 | config.groupEventId | Number | Yes | Group event ID to get latest builds for |
 
@@ -416,7 +416,7 @@ Update  a commit status
 model.updateCommitStatus(pipeline)
 ```
 | Parameter        | Type  |  Description |
-| :-------------   | :---- | :-------------|
+| :-------------   | :---- | :----------- |
 | pipeline        | Pipeline | The pipeline that this build belongs to |
 
 #### Start a build

--- a/README.md
+++ b/README.md
@@ -368,6 +368,19 @@ factory.getBuildStatuses(config).then(statuses => {
 | config.numBuilds | Number | No | Number of build statuses to return per job |
 | config.offset | Number | No | Number of build statuses to skip per job|
 
+#### Get Latest Builds
+Get the latest builds for each job in corresponding groupEventId.
+```js
+factory.getLatestBuilds(config).then(latestBuilds => {
+    // do stuff with the latest builds
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.groupEventId | Number | Yes | Group event ID to get latest builds for |
+
 ### Build Model
 ```js
 'use strict';

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -353,6 +353,29 @@ class BuildFactory extends BaseFactory {
     }
 
     /**
+     * Get latest build status for each job in events with matching groupEventId
+     * @method getLatestBuilds
+     * @param  {Object}     config                  Config object
+     * @param  {Number}     config.groupEventId     Group event ID to get build statuses for
+     * @return {Promise}
+     */
+    getLatestBuilds(config) {
+        const queryConfig = {
+            queries: [
+                { dbType: 'postgres', query: BuildQueries.latestBuildQuery },
+                { dbType: 'sqlite', query: BuildQueries.latestBuildQuery },
+                { dbType: 'mysql', query: BuildQueries.latestBuildQueryMySql }
+            ],
+            readOnly: true,
+            replacements: {
+                groupEventId: config.groupEventId
+            }
+        };
+
+        return super.query(queryConfig);
+    }
+
+    /**
      * Get an instance of the BuildFactory
      * @method getInstance
      * @param  {Object}     [config]            Configuration required for first call

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -13,6 +13,20 @@ const BuildFactoryQueries = {
         RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
         FROM builds WHERE jobId in (:jobIds)) as R
         WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
+        ORDER BY jobId, id DESC`,
+
+    latestBuildQuery: `SELECT * FROM (
+        SELECT *, RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
+        FROM builds WHERE "eventId" in
+        (SELECT "id" FROM events WHERE "groupEventId" = (:groupEventId))) AS events
+        WHERE rank = 1
+        ORDER BY "jobId", "id" DESC`,
+
+    latestBuildQueryMySql: `SELECT * FROM (
+        SELECT *, RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
+        FROM builds WHERE eventId in
+        (SELECT id FROM events WHERE groupEventId = (:groupEventId))) AS \`events\`
+        WHERE \`rank\` = 1
         ORDER BY jobId, id DESC`
 };
 

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BuildFactoryQueries = {
+    // getBuildStatuses()
     statusesQuery: `SELECT "id", "jobId", "status", "startTime", "endTime"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime",
         RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
@@ -15,6 +16,7 @@ const BuildFactoryQueries = {
         WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
         ORDER BY jobId, id DESC`,
 
+    // getLatestBuilds()
     latestBuildQuery: `SELECT * FROM (
         SELECT *, RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
         FROM builds WHERE "eventId" in

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -1178,4 +1178,55 @@ describe('Build Factory', () => {
             });
         });
     });
+
+    describe('getLatestBuilds', () => {
+        let config;
+        let returnValue;
+        let queryConfig;
+
+        beforeEach(() => {
+            sinon.stub(BuildFactory.prototype, 'query').returns();
+
+            config = {
+                groupEventId: '12345'
+            };
+
+            returnValue = [
+                {
+                    jobId: 1,
+                    status: 'SUCCESS',
+                    id: 1
+                },
+                {
+                    jobId: 1,
+                    status: 'ABORTED',
+                    id: 2
+                }
+            ];
+
+            queryConfig = {
+                queries: [
+                    { dbType: 'postgres', query: BuildQueries.latestBuildQuery },
+                    { dbType: 'sqlite', query: BuildQueries.latestBuildQuery },
+                    { dbType: 'mysql', query: BuildQueries.latestBuildQueryMySql }
+                ],
+                replacements: {
+                    groupEventId: config.groupEventId
+                },
+                rawResponse: false,
+                table: 'builds'
+            };
+        });
+
+        it('returns latest builds for groupEventId', () => {
+            datastore.query.resolves(returnValue);
+
+            return factory.getLatestBuilds(config).then(latestBuilds => {
+                assert.calledWith(datastore.query, queryConfig);
+                latestBuilds.forEach(b => {
+                    assert.instanceOf(b, Build);
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Context

We will want to get the latest build for each job in an event that has a matching `groupEventId`. It would be nice to have a sql query to get the data directly instead of making multiple calls to get the latestBuilds for each event, then processing each event's builds to get the desired data.

## Objective

This PR adds raw SQL queries to get the desired data.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1785

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
