### PR TITLE
fix: Logging template name used for build

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -191,9 +191,13 @@ class BuildFactory extends BaseFactory {
         /* eslint-disable global-require */
         const JobFactory = require('./jobFactory');
         const StepFactory = require('./stepFactory');
+        const TemplateFactory = require('./templateFactory');
+        const PipelineFactory = require('./pipelineFactory');
         /* eslint-enable global-require */
         const factory = JobFactory.getInstance();
         const stepFactory = StepFactory.getInstance();
+        const templateFactory = TemplateFactory.getInstance();
+        const pipelineFactory = PipelineFactory.getInstance();
 
         return factory.get(jobId).then(job => {
             if (!job) {
@@ -265,6 +269,16 @@ class BuildFactory extends BaseFactory {
                     ];
 
                     modelConfig.templateId = job.templateId;
+                    if (job.templateId !== undefined && job.templateId !== null) {
+                        Promise.all([
+                            templateFactory.get({ id: job.templateId }),
+                            pipelineFactory.get({ id: job.pipelineId })
+                        ]).then(([t, p]) =>
+                            logger.info(
+                                `pipelineId:${p.id}: ${p.name} uses template ${t.namespace}/${t.name}@${t.version}`
+                            )
+                        );
+                    }
 
                     modelConfig.stats = {};
 

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -34,11 +34,15 @@ describe('Build Factory', () => {
     let jobFactoryMock;
     let userFactoryMock;
     let stepFactoryMock;
+    let templateFactoryMock;
+    let pipelineFactoryMock;
     let buildClusterFactoryMock;
     let scmMock;
     let factory;
     let jobFactory;
     let stepFactory;
+    let templateFactory;
+    let pipelineFactory;
     let buildClusterFactory;
     const apiUri = 'https://notify.com/some/endpoint';
     const tokenGen = sinon.stub();
@@ -113,6 +117,12 @@ describe('Build Factory', () => {
         stepFactoryMock = {
             create: sinon.stub().resolves({})
         };
+        templateFactoryMock = {
+            get: sinon.stub()
+        };
+        pipelineFactoryMock = {
+            get: sinon.stub()
+        };
         buildClusterFactoryMock = {
             list: sinon.stub().resolves([]),
             get: sinon.stub().resolves(externalBuildCluster)
@@ -129,6 +139,12 @@ describe('Build Factory', () => {
         stepFactory = {
             getInstance: sinon.stub().returns(stepFactoryMock)
         };
+        templateFactory = {
+            getInstance: sinon.stub().returns(templateFactoryMock)
+        };
+        pipelineFactory = {
+            getInstance: sinon.stub().returns(pipelineFactoryMock)
+        };
         buildClusterFactory = {
             getInstance: sinon.stub().returns(buildClusterFactoryMock)
         };
@@ -143,6 +159,8 @@ describe('Build Factory', () => {
 
         mockery.registerMock('./jobFactory', jobFactory);
         mockery.registerMock('./stepFactory', stepFactory);
+        mockery.registerMock('./templateFactory', templateFactory);
+        mockery.registerMock('./pipelineFactory', pipelineFactory);
         mockery.registerMock('./userFactory', {
             getInstance: sinon.stub().returns(userFactoryMock)
         });
@@ -347,6 +365,8 @@ describe('Build Factory', () => {
                 })
                 .then(() => {
                     assert.callCount(stepFactoryMock.create, steps.length);
+                    assert.callCount(templateFactoryMock.get, 0);
+                    assert.callCount(pipelineFactoryMock.get, 0);
                     assert.calledWith(datastore.save, saveConfig);
                 });
         });


### PR DESCRIPTION
## Context
In order to measure the usage statistics of the template, I want to log the template name used at the timing when the build is executed. It may be possible to extract it from the DB by daily batch processing, but I don't think it's bad if drop it in the log. I would like to hear your opinion.

## Objective
If users use the template at build, it will be logged as follows.
```
{"message":"pipelineId:1: wahapo/test uses template wahapo/test@0.0.0","level":"info","timestamp":"2020-05-14T07:41:14.122Z"}
```
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
