### PR TITLE
fix(1967): Switch build status query order to ASC

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ factory.get({ jobId, number }).then(model => {
 | config.number | Number | build number |
 
 #### Get Build Statuses
-Get the statuses of the newest builds of jobs based on job ids. Can specify the number of build statuses desired per job id, this defaults to 1. Can specify the number of build statuses to skip per job id, this defaults to 0.
+Get the statuses of the newest builds of jobs based on job ids (in ascending order). Can specify the number of build statuses desired per job id, this defaults to 1. 
+Can specify the number of build statuses to skip per job id, this defaults to 0.
 ```js
 factory.getBuildStatuses(config).then(statuses => {
     // do stuff with the statuses

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -308,12 +308,12 @@ class BuildFactory extends BaseFactory {
     }
 
     /**
-     * Get build statuses for jobs
+     * Get build statuses for jobs in ascending order
      * @method getBuildStatuses
      * @param  {Object}   config                  Config object
      * @param  {Array}    config.jobIds           Jobs to get build statuses for
-     * @param  {Number}   config.offset           Number of build statuses to skip
-     * @param  {Number}   config.numBuilds        Number of build statuses to return per job
+     * @param  {Number}   config.offset           Number of build statuses to skip (default 0)
+     * @param  {Number}   config.numBuilds        Number of build statuses to return per job (default 1)
      * @return {Promise}
      */
     getBuildStatuses(config) {

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -7,14 +7,14 @@ const BuildFactoryQueries = {
         RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
         FROM builds WHERE "jobId" in (:jobIds)) as R
         WHERE rank > :offset AND rank <= :maxRank
-        ORDER BY "jobId", "id" DESC`,
+        ORDER BY "jobId", "id" ASC`,
 
     statusesQueryMySql: `SELECT id, jobId, status, startTime, endTime
         FROM (SELECT id, jobId, status, startTime, endTime,
         RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
         FROM builds WHERE jobId in (:jobIds)) as R
         WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
-        ORDER BY jobId, id DESC`,
+        ORDER BY jobId, id ASC`,
 
     // getLatestBuilds()
     latestBuildQuery: `SELECT * FROM (

--- a/package.json
+++ b/package.json
@@ -49,14 +49,14 @@
     "async": "^2.6.3",
     "base64url": "^3.0.1",
     "compare-versions": "^3.6.0",
-    "dayjs": "^1.8.23",
+    "dayjs": "^1.8.27",
     "deepcopy": "^2.0.0",
     "docker-parse-image": "^3.0.1",
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.15",
-    "screwdriver-config-parser": "^5.2.0",
-    "screwdriver-data-schema": "^19.7.0",
+    "screwdriver-config-parser": "^5.3.3",
+    "screwdriver-data-schema": "^19.10.1",
     "screwdriver-logger": "^1.0.0",
     "screwdriver-workflow-parser": "^2.0.3"
   }

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -1164,7 +1164,7 @@ describe('Build Factory', () => {
             });
         });
 
-        it('Query with default config params', () => {
+        it('queries with default config params', () => {
             datastore.query.resolves([[], []]);
 
             delete config.numBuilds;


### PR DESCRIPTION
## Context

The latest builds per job are displayed in ascending order in the UI, and it would be easier to change the SQL query to match this requirement rather than reverse the order in the UI.

## Objective

This PR changes the SQL query to get build statuses for jobs to return results in ascending order.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1967

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
