### PR TITLE
feat(1044): Add exclude expression in SourcePath

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -152,8 +152,13 @@ function startBuild(config) {
             paths.push(`${rootDir}/`);
         }
 
-        hasChangeInSourcePaths = changedFiles.some(file =>
-            paths.some(source => {
+        hasChangeInSourcePaths = changedFiles.some(file => {
+            const isFileMatch = paths.some(source => {
+                // source path is exclude expression
+                if (source.startsWith('!')) {
+                    return false;
+                }
+
                 let isMatch = false;
 
                 // source path is a file
@@ -170,8 +175,28 @@ function startBuild(config) {
                 }
 
                 return isMatch;
-            })
-        );
+            });
+            const isFileExclude = paths.some(source => {
+                // source path is not exclude expression
+                if (!source.startsWith('!')) {
+                    return false;
+                }
+
+                let isMatchExclude = false;
+
+                // source path is a file
+                if (source.slice(-1) !== '/') {
+                    isMatchExclude = '!'.concat(file) === source;
+                    // source path is a directory
+                } else {
+                    isMatchExclude = '!'.concat(file).startsWith(source);
+                }
+
+                return isMatchExclude;
+            });
+
+            return isFileMatch && !isFileExclude;
+        });
     }
 
     buildConfig.meta = {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1463,6 +1463,36 @@ describe('Event Factory', () => {
             });
         });
 
+        it('should not start build if changed file is in exclude soucePath', () => {
+            jobsMock = [
+                {
+                    id: 1,
+                    pipelineId: 8765,
+                    name: 'main',
+                    permutations: [
+                        {
+                            requires: ['~pr'],
+                            sourcePaths: ['src/test/', '!src/test/foo']
+                        }
+                    ],
+                    state: 'ENABLED'
+                }
+            ];
+            syncedPipelineMock.update = sinon.stub().resolves({
+                getJobs: sinon.stub().resolves(jobsMock),
+                branch: Promise.resolve('branch')
+            });
+
+            config.startFrom = 'main';
+            config.webhooks = true;
+            config.changedFiles = ['README.md', 'src/test/foo'];
+
+            return eventFactory.create(config).then(event => {
+                assert.notCalled(buildFactoryMock.create);
+                assert.equal(event.builds, null);
+            });
+        });
+
         it('should start build if changed file is in rootDir', () => {
             jobsMock = [
                 {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1463,7 +1463,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should not start build if changed file is in exclude soucePath', () => {
+        it('should not start build if changed file is in exclude sourcePath', () => {
             jobsMock = [
                 {
                     id: 1,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If sourcePath parameter starts with `!`, that path treated as exclude path.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Even if source path is matched, a build does not start if exclude path is matched.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#1044

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
