### PR TITLE
fix: [1] Tag/Release trigger does not depend on changedFile

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -120,6 +120,7 @@ function getJobsFromPR(config) {
  * @method startBuild
  * @param  {Object}   config                    configuration object
  * @param  {Object}   config.buildConfig        Build Config to create the build with
+ * @param  {String}   config.startFrom          Startfrom (e.g. ~commit, ~pr, etc)
  * @param  {Array}    config.changedFiles       List of files that were changed
  * @param  {Array}    config.sourcePaths        List of soure paths
  * @param  {Boolean}  [config.webhooks]         If the create came from a webhook (pr or push) or not
@@ -133,14 +134,17 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, sourcePaths, webhooks, isPR, decoratedCommit, rootDir } = config;
+    const { buildConfig, changedFiles, startFrom, sourcePaths, webhooks, isPR, decoratedCommit, rootDir } = config;
+    const isReleaseTrigger = RELEASE_TRIGGER.test(startFrom);
+    const isTagTrigger = TAG_TRIGGER.test(startFrom);
     let hasChangeInSourcePaths = true;
 
     buildConfig.environment = {};
 
     // Only check if sourcePaths or rootDir is set
+    // and is not a releaseTrigger and is not a tagTrigger
     // and webhooks or is a PR
-    if ((webhooks || isPR) && (sourcePaths || rootDir)) {
+    if ((webhooks || isPR) && !(isReleaseTrigger || isTagTrigger) && (sourcePaths || rootDir)) {
         if (!changedFiles) {
             throw new Error('Your SCM does not support Source Paths');
         }
@@ -273,6 +277,7 @@ function createBuilds(config) {
                     return startBuild({
                         decoratedCommit,
                         buildConfig,
+                        startFrom,
                         changedFiles,
                         sourcePaths: j.permutations[0].sourcePaths, // TODO: support matrix job
                         webhooks,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -794,7 +794,6 @@ class PipelineModel extends BaseModel {
         for (const jobChunks of getJobChunks(parsedConfigJobNames)) {
             await Promise.all(
                 jobChunks.map(async jobName => {
-                    console.log(jobName);
                     const permutations = parsedConfig.jobs[jobName];
                     const jobConfig = {
                         pipelineId,


### PR DESCRIPTION
## Context
Currently, even if we create a tag, it does not start to build unless it matches changedFiles. Tag/Release triggers need to start built without depending on the changedFiles.

## Objective
Fixed to start build regardless of changedFile for tag/release triggers.

## References
https://github.com/screwdriver-cd/screwdriver/pull/2099
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
