### PR TITLE
feat(2087): Pass token to executor for qs api call

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -232,7 +232,7 @@ function getToken(self, job, pipeline) {
         tokenGenConfig.prParentJobId = job.prParentJobId;
     }
 
-    const token = self[tokenGen](self.id, tokenGenConfig, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT);
+    const token = self[tokenGen](self.id, tokenGenConfig, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT, ['sdapi']);
 
     return token;
 }
@@ -541,7 +541,8 @@ class BuildModel extends BaseModel {
                         startTime: this.startTime,
                         annotations: job.permutations[0].annotations,
                         buildStatus: this.status,
-                        pipelineId: pipeline.id
+                        pipelineId: pipeline.id,
+                        token: getToken(this, job, pipeline)
                     };
 
                     return this[executor].startTimer(config);
@@ -570,7 +571,8 @@ class BuildModel extends BaseModel {
                             blockedBy,
                             buildId: this.id,
                             jobId: job.id,
-                            pipelineId: pipeline.id
+                            pipelineId: pipeline.id,
+                            token: getToken(this, job, pipeline)
                         };
 
                         if (this.buildClusterName) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -205,9 +205,28 @@ async function getBuildClusterName({ annotations, pipeline, isPipelineUpdate = f
     return buildCluster.name;
 }
 
+/**
+ * @description Gets the token from token gen fn
+ * @param {Object} fn token gen
+ * @param {String} jobId
+ * @param {Object} pipeline
+ * @return {String} A jwt token
+ */
+function getToken(fn, pipeline, jobId) {
+    const tokenGenConfig = {
+        pipelineId: pipeline.id,
+        jobId
+    };
+
+    const token = fn(pipeline.username, tokenGenConfig, pipeline.scmContext, ['sdapi']);
+
+    return token;
+}
+
 module.exports = {
     getAnnotations,
     parseTemplateConfigName,
     getAllRecords,
-    getBuildClusterName
+    getBuildClusterName,
+    getToken
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -32,6 +32,24 @@ async function findMetrics(build, stepName, aggregateInterval) {
     return metrics;
 }
 
+/**
+ * @description Gets the token from token gen fn
+ * @param {Object} self -> this object
+ * @param {String} jobId
+ * @param {Object} pipeline
+ * @return {String} A jwt token
+ */
+function getToken(self, pipeline, jobId) {
+    const tokenGenConfig = {
+        pipelineId: pipeline.id,
+        jobId
+    };
+
+    const token = self[tokenGen](pipeline.username, tokenGenConfig, pipeline.scmContext, ['sdapi']);
+
+    return token;
+}
+
 class Job extends BaseModel {
     /**
      * Constructs a Job Model
@@ -220,13 +238,16 @@ class Job extends BaseModel {
 
         try {
             // FIXME:: Make this call only if buildCron config is updated
-            await this[executor].startPeriodic({
-                pipeline,
-                job: newJob,
-                tokenGen: this[tokenGen],
-                apiUri: this[apiUri],
-                isUpdate: true
-            });
+            if (getAnnotations(this.permutations[0], 'screwdriver.cd/buildPeriodically')) {
+                await this[executor].startPeriodic({
+                    pipeline,
+                    job: newJob,
+                    tokenGen: this[tokenGen],
+                    token: getToken(this, pipeline, newJob.id),
+                    apiUri: this[apiUri],
+                    isUpdate: true
+                });
+            }
         } catch (err) {
             logger.error(`job:${this.id}: failed to update queue status`, err);
         }
@@ -245,7 +266,7 @@ class Job extends BaseModel {
                 ([builds, pipeline]) => {
                     if (builds.length === 0) {
                         // Done removing builds
-                        return pipeline.id;
+                        return pipeline;
                     }
 
                     return Promise.all(
@@ -256,7 +277,8 @@ class Job extends BaseModel {
                                 this[executor].stop({
                                     buildId: build.id,
                                     pipelineId: pipeline.id,
-                                    jobId: this.id
+                                    jobId: this.id,
+                                    token: getToken(this, pipeline, this.id)
                                 });
                             }
 
@@ -264,18 +286,19 @@ class Job extends BaseModel {
                         })
                     )
                         .then(() => removeBuilds())
-                        .then(() => pipeline.id);
+                        .then(() => pipeline);
                 }
             );
 
         // Remove builds
         return removeBuilds()
-            .then(pipelineId => {
+            .then(pipeline => {
                 // Remove periodic job
                 if (getAnnotations(this.permutations[0], 'screwdriver.cd/buildPeriodically')) {
                     return this[executor].stopPeriodic({
                         jobId: this.id,
-                        pipelineId
+                        pipelineId: pipeline.id,
+                        token: getToken(this, pipeline, this.id)
                     });
                 }
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -4,7 +4,7 @@ const logger = require('screwdriver-logger');
 const dayjs = require('dayjs');
 const hoek = require('hoek');
 const BaseModel = require('./base');
-const { getAnnotations, getAllRecords } = require('./helper');
+const { getAnnotations, getAllRecords, getToken } = require('./helper');
 const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
@@ -30,24 +30,6 @@ async function findMetrics(build, stepName, aggregateInterval) {
     }
 
     return metrics;
-}
-
-/**
- * @description Gets the token from token gen fn
- * @param {Object} self -> this object
- * @param {String} jobId
- * @param {Object} pipeline
- * @return {String} A jwt token
- */
-function getToken(self, pipeline, jobId) {
-    const tokenGenConfig = {
-        pipelineId: pipeline.id,
-        jobId
-    };
-
-    const token = self[tokenGen](pipeline.username, tokenGenConfig, pipeline.scmContext, ['sdapi']);
-
-    return token;
 }
 
 class Job extends BaseModel {
@@ -243,7 +225,7 @@ class Job extends BaseModel {
                     pipeline,
                     job: newJob,
                     tokenGen: this[tokenGen],
-                    token: getToken(this, pipeline, newJob.id),
+                    token: getToken(this[tokenGen], pipeline, newJob.id),
                     apiUri: this[apiUri],
                     isUpdate: true
                 });
@@ -278,7 +260,7 @@ class Job extends BaseModel {
                                     buildId: build.id,
                                     pipelineId: pipeline.id,
                                     jobId: this.id,
-                                    token: getToken(this, pipeline, this.id)
+                                    token: getToken(this[tokenGen], pipeline, this.id)
                                 });
                             }
 
@@ -298,7 +280,7 @@ class Job extends BaseModel {
                     return this[executor].stopPeriodic({
                         jobId: this.id,
                         pipelineId: pipeline.id,
-                        token: getToken(this, pipeline, this.id)
+                        token: getToken(this[tokenGen], pipeline, this.id)
                     });
                 }
 

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -6,11 +6,12 @@ const Job = require('./job');
 let instance;
 
 /**
- * @description Gets the token from token gen fn
- * @param {Object} self -> this object
- * @param {String} jobId
- * @param {Object} pipeline
- * @return {String} A jwt token
+ * Gets the token from token gen fn
+ * @method getToken
+ * @param  {Object} self      This object
+ * @param  {String} jobId     Job ID
+ * @param  {Object} pipeline  Pipeline
+ * @return {String}           A JWT token
  */
 function getToken(self, pipeline, jobId) {
     const tokenGenConfig = {

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -5,6 +5,24 @@ const { getAnnotations } = require('./helper');
 const Job = require('./job');
 let instance;
 
+/**
+ * @description Gets the token from token gen fn
+ * @param {Object} self -> this object
+ * @param {String} jobId
+ * @param {Object} pipeline
+ * @return {String} A jwt token
+ */
+function getToken(self, pipeline, jobId) {
+    const tokenGenConfig = {
+        pipelineId: pipeline.id,
+        jobId
+    };
+
+    const token = self.tokenGen(pipeline.username, tokenGenConfig, pipeline.scmContext, ['sdapi']);
+
+    return token;
+}
+
 class JobFactory extends BaseFactory {
     /**
      * Construct a JobFactory object
@@ -72,6 +90,7 @@ class JobFactory extends BaseFactory {
                             pipeline,
                             job,
                             tokenGen: this.tokenGen,
+                            token: getToken(this, pipeline, job.id),
                             apiUri: this.apiUri
                         })
                     )

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -1,28 +1,9 @@
 'use strict';
 
 const BaseFactory = require('./baseFactory');
-const { getAnnotations } = require('./helper');
+const { getAnnotations, getToken } = require('./helper');
 const Job = require('./job');
 let instance;
-
-/**
- * Gets the token from token gen fn
- * @method getToken
- * @param  {Object} self      This object
- * @param  {String} jobId     Job ID
- * @param  {Object} pipeline  Pipeline
- * @return {String}           A JWT token
- */
-function getToken(self, pipeline, jobId) {
-    const tokenGenConfig = {
-        pipelineId: pipeline.id,
-        jobId
-    };
-
-    const token = self.tokenGen(pipeline.username, tokenGenConfig, pipeline.scmContext, ['sdapi']);
-
-    return token;
-}
 
 class JobFactory extends BaseFactory {
     /**
@@ -91,7 +72,7 @@ class JobFactory extends BaseFactory {
                             pipeline,
                             job,
                             tokenGen: this.tokenGen,
-                            token: getToken(this, pipeline, job.id),
+                            token: getToken(this.tokenGen, pipeline, job.id),
                             apiUri: this.apiUri
                         })
                     )

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -258,7 +258,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
                 delete stepsMock[0].update;
                 delete stepsMock[1].update;
@@ -332,7 +333,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
                 delete stepsMock[0].update;
                 delete stepsMock[1].update;
@@ -414,7 +416,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
 
                 delete stepsMock[0].update;
@@ -474,7 +477,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
 
                 delete stepsMock[0].update;
@@ -514,7 +518,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
 
                 delete stepsMock[0].update;
@@ -604,7 +609,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
             });
         });
@@ -635,7 +641,8 @@ describe('Build Model', () => {
                     annotations,
                     startTime: build.startTime,
                     buildStatus: build.status,
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
                 assert.notCalled(executorMock.stop);
             });
@@ -668,7 +675,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
 
                 // Completed step is not modified
@@ -814,7 +822,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
             }));
 
@@ -828,7 +837,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
                 assert.calledWith(executorMock.stopTimer, {
                     buildId,
@@ -836,7 +846,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
             });
         });
@@ -852,7 +863,8 @@ describe('Build Model', () => {
                     annotations,
                     freezeWindows,
                     blockedBy: [jobId],
-                    pipelineId
+                    pipelineId,
+                    token: 'equivalentToOneQuarter'
                 });
             });
         });

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -420,6 +420,13 @@ describe('Job Model', () => {
     describe('update', () => {
         it('Update a job', () => {
             job.state = 'DISABLED';
+            job.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H * * * *'
+                    }
+                }
+            ];
 
             datastore.update.resolves(null);
 
@@ -429,7 +436,8 @@ describe('Job Model', () => {
                     job,
                     tokenGen,
                     apiUri,
-                    isUpdate: true
+                    isUpdate: true,
+                    token: 'tokengenerated'
                 });
                 assert.calledOnce(datastore.update);
             });

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -174,6 +174,7 @@ describe('Job Factory', () => {
                         pipeline: { id: 9999 },
                         job: model,
                         tokenGen: tokenGenFunc,
+                        token: 'bar',
                         apiUri
                     });
                 });


### PR DESCRIPTION
## Context

All calls to queue service must be authenticated and have scope sdapi.

## Objective

This PR passes token for all executor functions with scope sdapi.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2087

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
