### PR TITLE
fix(2100): rank query for mysql5.7

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -9,7 +9,7 @@ const BuildFactoryQueries = {
         WHERE rank > :offset AND rank <= :maxRank
         ORDER BY "jobId", "id" ASC`,
 
-    statusesQueryMySql: `SELECT * FROM (
+    statusesQueryMySql: `SELECT a.id, a.jobId, a.status, a.startTime, a.endTime FROM (
 	    SELECT a.id, a.jobId, a.status, a.startTime,  a.endTime, count(b.id)+1 AS rank
 		FROM  builds a LEFT JOIN (SELECT id, jobId FROM builds WHERE jobId IN (:jobIds)) b
                 ON a.id>b.id AND a.jobId=b.jobId

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -10,9 +10,9 @@ const BuildFactoryQueries = {
         ORDER BY "jobId", "id" ASC`,
 
     statusesQueryMySql: `SELECT id, jobId, status, startTime, endTime FROM (
-	    SELECT a.id, a.jobId, a.status, a.startTime,  a.endTime, count(b.id)+1 AS rank
+	    SELECT a.id, a.jobId, a.status, a.startTime,  a.endTime, count(b.id) AS rank
 		FROM  builds a LEFT JOIN (SELECT id, jobId FROM builds WHERE jobId IN (:jobIds)) b
-                ON a.id>b.id AND a.jobId=b.jobId
+                ON a.id<=b.id AND a.jobId=b.jobId
             WHERE a.jobId IN (:jobIds)
             GROUP BY a.jobId, a.id) AS R
         WHERE rank > :offset AND rank <= :maxRank
@@ -31,10 +31,10 @@ const BuildFactoryQueries = {
                 buildClusterName, stats, parentBuilds, templateId FROM (
         SELECT a.id, a.environment, a.eventId, a.jobId, a.parentBuildId, a.number, a.container, a.cause, a.sha,
                 a.commit, a.createTime, a.startTime, a.endTime, a.parameters, a.meta, a.status, a.statusMessage,
-                a.buildClusterName, a.stats, a.parentBuilds, a.templateId, count(b.id)+1 AS rank
+                a.buildClusterName, a.stats, a.parentBuilds, a.templateId, count(b.id) AS rank
         FROM builds a LEFT JOIN (SELECT id, jobId FROM builds WHERE eventId IN
                                     (SELECT id FROM events WHERE groupEventId = :groupEventId)) b
-                ON a.id>b.id AND a.jobId=b.jobId
+                ON a.id<=b.id AND a.jobId=b.jobId
             WHERE a.eventId IN (SELECT id FROM events WHERE groupEventId = :groupEventId)
             GROUP BY a.jobId, a.id) as R
         WHERE rank=1

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -9,7 +9,7 @@ const BuildFactoryQueries = {
         WHERE rank > :offset AND rank <= :maxRank
         ORDER BY "jobId", "id" ASC`,
 
-    statusesQueryMySql: `SELECT a.id, a.jobId, a.status, a.startTime, a.endTime FROM (
+    statusesQueryMySql: `SELECT id, jobId, status, startTime, endTime FROM (
 	    SELECT a.id, a.jobId, a.status, a.startTime,  a.endTime, count(b.id)+1 AS rank
 		FROM  builds a LEFT JOIN (SELECT id, jobId FROM builds WHERE jobId IN (:jobIds)) b
                 ON a.id>b.id AND a.jobId=b.jobId
@@ -26,7 +26,9 @@ const BuildFactoryQueries = {
         WHERE rank = 1
         ORDER BY "jobId", "id" DESC`,
 
-    latestBuildQueryMySql: `SELECT * FROM (
+    latestBuildQueryMySql: `SELECT id, environment, eventId, jobId, parentBuildId, number, container, cause, sha,
+                commit, createTime, startTime, endTime, parameters, meta, status, statusMessage,
+                buildClusterName, stats, parentBuilds, templateId FROM (
         SELECT a.id, a.environment, a.eventId, a.jobId, a.parentBuildId, a.number, a.container, a.cause, a.sha,
                 a.commit, a.createTime, a.startTime, a.endTime, a.parameters, a.meta, a.status, a.statusMessage,
                 a.buildClusterName, a.stats, a.parentBuilds, a.templateId, count(b.id)+1 AS rank

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -9,12 +9,14 @@ const BuildFactoryQueries = {
         WHERE rank > :offset AND rank <= :maxRank
         ORDER BY "jobId", "id" ASC`,
 
-    statusesQueryMySql: `SELECT id, jobId, status, startTime, endTime
-        FROM (SELECT id, jobId, status, startTime, endTime,
-        RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
-        FROM builds WHERE jobId in (:jobIds)) as R
-        WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
-        ORDER BY jobId, id ASC`,
+    statusesQueryMySql: `SELECT * FROM (
+	    SELECT a.id, a.jobId, a.status, a.startTime,  a.endTime, count(b.id)+1 AS rank
+		FROM  builds a LEFT JOIN (SELECT id, jobId FROM builds WHERE jobId IN (:jobIds)) b
+                ON a.id>b.id AND a.jobId=b.jobId
+            WHERE a.jobId IN (:jobIds)
+            GROUP BY a.jobId, a.id) AS R
+        WHERE rank > :offset AND rank <= :maxRank
+            ORDER BY jobId, id ASC`,
 
     // getLatestBuilds()
     latestBuildQuery: `SELECT * FROM (
@@ -25,10 +27,15 @@ const BuildFactoryQueries = {
         ORDER BY "jobId", "id" DESC`,
 
     latestBuildQueryMySql: `SELECT * FROM (
-        SELECT *, RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
-        FROM builds WHERE eventId in
-        (SELECT id FROM events WHERE groupEventId = (:groupEventId))) AS \`events\`
-        WHERE \`rank\` = 1
+        SELECT a.id, a.environment, a.eventId, a.jobId, a.parentBuildId, a.number, a.container, a.cause, a.sha,
+                a.commit, a.createTime, a.startTime, a.endTime, a.parameters, a.meta, a.status, a.statusMessage,
+                a.buildClusterName, a.stats, a.parentBuilds, a.templateId, count(b.id)+1 AS rank
+        FROM builds a LEFT JOIN (SELECT id, jobId FROM builds WHERE eventId IN
+                                    (SELECT id FROM events WHERE groupEventId = :groupEventId)) b
+                ON a.id>b.id AND a.jobId=b.jobId
+            WHERE a.eventId IN (SELECT id FROM events WHERE groupEventId = :groupEventId)
+            GROUP BY a.jobId, a.id) as R
+        WHERE rank=1
         ORDER BY jobId, id DESC`
 };
 


### PR DESCRIPTION
## Context

The RANK() function is not supported in MySQL 5.7.

## Objective

Don't use the RANK() function for aggregate view raw queries in MySQL 5.7.

## References

[/v4/builds/statuses API error when using MySQL 5.7 #2100](https://github.com/screwdriver-cd/screwdriver/issues/2100)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
