### PR TITLE
fix(2074): Use admin permission to sync hook

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -378,8 +378,11 @@ class PipelineModel extends BaseModel {
      * @method  addWebhook
      * @return  {Promise}
      */
-    addWebhook(webhookUrl) {
-        return this.token.then(token =>
+    async addWebhook(webhookUrl) {
+        const admin = await this.getFirstRepoAdmin();
+
+        // return this.token.then(token =>
+        return admin.unsealToken().then(token =>
             this.scm.addWebhook({
                 scmUri: this.scmUri,
                 scmContext: this.scmContext,
@@ -980,6 +983,50 @@ class PipelineModel extends BaseModel {
 
             return result;
         }
+    }
+
+    /**
+     * This function gets a repository admin.
+     * @method getFirstRepoAdmin
+     * @return {Promise}
+     */
+    async getFirstRepoAdmin() {
+        /* eslint-disable global-require */
+        const UserFactory = require('./userFactory');
+        /* eslint-enable global-require */
+        const factory = UserFactory.getInstance();
+
+        /* eslint-disable no-restricted-syntax */
+        for (const username of Object.keys(this.admins)) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            // eslint-disable-next-line no-await-in-loop
+            const user = await factory.get({
+                username,
+                scmContext: this.scmContext
+            });
+            let permission = {};
+
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                permission = await user.getPermissions(this.scmUri);
+            } catch (err) {
+                if (SCM_NO_ACCESS_STATUSES.includes(err.status)) {
+                    permission.push = false;
+                } else {
+                    throw err;
+                }
+            }
+
+            if ('admin' in permission && permission.admin) {
+                return user;
+            }
+        }
+        /* eslint-enable no-restricted-syntax */
+
+        // There is no repository admins
+        logger.error(`pipelineId:${this.id}: Pipeline has no repository admin.`);
+        throw new Error('Pipeline has no repository admins');
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -381,7 +381,6 @@ class PipelineModel extends BaseModel {
     async addWebhook(webhookUrl) {
         const admin = await this.getFirstRepoAdmin();
 
-        // return this.token.then(token =>
         return admin.unsealToken().then(token =>
             this.scm.addWebhook({
                 scmUri: this.scmUri,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -378,17 +378,17 @@ class PipelineModel extends BaseModel {
      * @method  addWebhook
      * @return  {Promise}
      */
-    async addWebhook(webhookUrl) {
-        const admin = await this.getFirstRepoAdmin();
-
-        return admin.unsealToken().then(token =>
-            this.scm.addWebhook({
-                scmUri: this.scmUri,
-                scmContext: this.scmContext,
-                token,
-                webhookUrl
-            })
-        );
+    addWebhook(webhookUrl) {
+        return this.getFirstRepoAdmin()
+            .then(admin => admin.unsealToken())
+            .then(token =>
+                this.scm.addWebhook({
+                    scmUri: this.scmUri,
+                    scmContext: this.scmContext,
+                    token,
+                    webhookUrl
+                })
+            );
     }
 
     /**

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -381,7 +381,6 @@ describe('Pipeline Model', () => {
         });
 
         it('rejects if there is no admins', () => {
-            // scmMock.addWebhook.rejects(new Error('error adding webhooks'));
             getUserPermissionMocks({ username: 'batman', push: true });
 
             return pipeline.addWebhook('https://api.screwdriver.cd/v4/webhooks').then(

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -361,7 +361,7 @@ describe('Pipeline Model', () => {
 
     describe('addWebhook', () => {
         beforeEach(() => {
-            getUserPermissionMocks({ username: 'batman', push: true });
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
             getUserPermissionMocks({ username: 'robin', push: true });
             pipeline.admins = { batman: true, robin: true };
             pipeline.update = sinon.stub().resolves('foo');
@@ -378,6 +378,19 @@ describe('Pipeline Model', () => {
                     webhookUrl: 'https://api.screwdriver.cd/v4/webhooks'
                 });
             });
+        });
+
+        it('rejects if there is no admins', () => {
+            // scmMock.addWebhook.rejects(new Error('error adding webhooks'));
+            getUserPermissionMocks({ username: 'batman', push: true });
+
+            return pipeline.addWebhook('https://api.screwdriver.cd/v4/webhooks').then(
+                () => assert.fail('should not get here'),
+                err => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.message, 'Pipeline has no repository admins');
+                }
+            );
         });
 
         it('rejects if there is a failure to update the webhook', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix https://github.com/screwdriver-cd/screwdriver/issues/2074

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR uses admin permission to sync hook, so the `Not Found` error doesn't occur anymore.

For the case there is no admin permission, it shows error message like below.
![Screen Shot 2020-06-11 at 16 42 19](https://user-images.githubusercontent.com/32473622/84358781-9a7cbe80-ac02-11ea-8564-17dde8267e08.jpg)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2074

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
