### PR TITLE
feat(1994): [1] Filtering for ~release and ~tag triggers

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -23,10 +23,12 @@ let instance;
  * @param  {Object}   config.pipelineConfig
  * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
  * @param  {String}   config.startFrom                      Startfrom (e.g. ~commit, ~pr, ~sd@123:main, etc)
+ * @param  {String}   config.releaseName                    SCM webhook releaseName
+ * @param  {String}   config.ref                            SCM webhook ref
  * @return {Array}                                          Array of commit jobs to start
  */
 function getJobsFromTrigger(config) {
-    const { jobs, pipelineConfig, startFrom, branch } = config;
+    const { jobs, pipelineConfig, startFrom, branch, releaseName, ref } = config;
     const shouldGetJobs = [
         EXTERNAL_TRIGGER.test(startFrom),
         COMMIT_TRIGGER.test(startFrom),
@@ -53,7 +55,7 @@ function getJobsFromTrigger(config) {
     if (startFrom.match(RELEASE_TRIGGER)) {
         nextJobs = nextJobs.concat(
             workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
-                trigger: `~release`
+                trigger: `~release:${releaseName}`
             })
         );
     }
@@ -61,7 +63,7 @@ function getJobsFromTrigger(config) {
     if (startFrom.match(TAG_TRIGGER)) {
         nextJobs = nextJobs.concat(
             workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
-                trigger: `~tag`
+                trigger: `~tag:${ref}`
             })
         );
     }
@@ -252,13 +254,26 @@ function startBuild(config) {
  * @param  {Object}   [config.pipelineConfig.workflowGraph]  Object with nodes and edges that represent the order of jobs
  * @param  {Array}    [config.changedFiles]                  Array of files that were changed
  * @param  {Boolean}  [config.webhooks]                      If the create came from a webhook (pr or push) or not
+ * @param  {String}   [config.releaseName]                   SCM webhook releaseName
+ * @param  {String}   [config.ref]                           SCM webhook ref
  * @param  {Boolean}  [config.isPR]                          Is it PR?
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
  * @param  {Object}   [config.pipeline]                      Default pipeline config from databse
  * @param  {Object}   [config.pipelineConfig]                Current Pipeline config
  */
 function createBuilds(config) {
-    const { decoratedCommit, eventConfig, eventId, pipeline, pipelineConfig, changedFiles, webhooks, isPR } = config;
+    const {
+        decoratedCommit,
+        eventConfig,
+        eventId,
+        pipeline,
+        pipelineConfig,
+        changedFiles,
+        webhooks,
+        isPR,
+        releaseName,
+        ref
+    } = config;
     const { startFrom } = eventConfig;
     let rootDir = '';
 
@@ -274,7 +289,9 @@ function createBuilds(config) {
                 jobs,
                 pipelineConfig,
                 startFrom,
-                branch
+                branch,
+                releaseName,
+                ref
             });
             // When startFrom is a job name
             const jobsFromJobName = getJobsFromJobName({
@@ -525,6 +542,8 @@ class EventFactory extends BaseFactory {
      * @param  {Array}   [config.changedFiles]      Array of files that were changed
      * @param  {Boolean} [config.webhooks]          If the create came from a webhook (pr or push) or not
      * @param  {Object}  [config.meta]              Metadata tied to this event
+     * @param  {String}  [config.releaseName]       SCM webhook release name
+     * @param  {String}  [config.ref]               SCM webhook ref
      * @param  {Object}  [config.prInfo]            PR info
      * @param  {String}  [config.skipMessage]       Message to skip starting builds
      * @param  {Boolean} [config.chainPR]           Chain PR flag
@@ -553,7 +572,9 @@ class EventFactory extends BaseFactory {
             prNum,
             skipMessage,
             chainPR,
-            groupEventId
+            groupEventId,
+            releaseName,
+            ref
         } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
@@ -742,7 +763,9 @@ class EventFactory extends BaseFactory {
                                         pipelineConfig: modelConfig,
                                         isPR: !!prInfo,
                                         changedFiles,
-                                        webhooks
+                                        webhooks,
+                                        releaseName,
+                                        ref
                                     });
                                 })
                                 .then(builds => {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -50,6 +50,22 @@ function getJobsFromTrigger(config) {
         );
     }
 
+    if (startFrom.match(RELEASE_TRIGGER)) {
+        nextJobs = nextJobs.concat(
+            workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+                trigger: `~release`
+            })
+        );
+    }
+
+    if (startFrom.match(TAG_TRIGGER)) {
+        nextJobs = nextJobs.concat(
+            workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+                trigger: `~tag`
+            })
+        );
+    }
+
     return jobs.filter(j => nextJobs.includes(j.name) && j.state === 'ENABLED' && !j.archived);
 }
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -874,8 +874,17 @@ describe('Event Factory', () => {
 
             it('should create build if startFrom is ~release', () => {
                 const releaseWorkflow = {
-                    nodes: [{ name: '~pr' }, { name: '~commit' }, { name: '~release' }, { name: 'release' }],
-                    edges: [{ src: '~release', dest: 'release' }]
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: '~release' },
+                        { name: 'release' },
+                        { name: '~release:releaseName' }
+                    ],
+                    edges: [
+                        { src: '~release', dest: 'release' },
+                        { src: '~release:releaseName', dest: 'release' }
+                    ]
                 };
 
                 jobsMock = [
@@ -886,6 +895,17 @@ describe('Event Factory', () => {
                         permutations: [
                             {
                                 requires: ['~release']
+                            }
+                        ],
+                        state: 'ENABLED'
+                    },
+                    {
+                        id: 2,
+                        pipelineId: 8765,
+                        name: 'release',
+                        permutations: [
+                            {
+                                requires: ['~release:releaseName']
                             }
                         ],
                         state: 'ENABLED'
@@ -905,13 +925,21 @@ describe('Event Factory', () => {
                     assert.notCalled(jobFactoryMock.create);
                     assert.notCalled(syncedPipelineMock.syncPR);
                     assert.calledOnce(pipelineMock.sync);
-                    assert.calledOnce(buildFactoryMock.create);
+                    assert.calledTwice(buildFactoryMock.create);
                     assert.calledWith(
                         buildFactoryMock.create,
                         sinon.match({
                             parentBuildId: 12345,
                             eventId: model.id,
                             jobId: 1
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 2
                         })
                     );
                 });
@@ -969,8 +997,17 @@ describe('Event Factory', () => {
 
             it('should create build if startFrom is ~tag', () => {
                 const tagWorkflow = {
-                    nodes: [{ name: '~pr' }, { name: '~commit' }, { name: '~tag' }, { name: 'tag' }],
-                    edges: [{ src: '~tag', dest: 'tag' }]
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: '~tag' },
+                        { name: 'tag' },
+                        { name: '~tag:tagName' }
+                    ],
+                    edges: [
+                        { src: '~tag', dest: 'tag' },
+                        { src: '~tag:tagName', dest: 'tag' }
+                    ]
                 };
 
                 jobsMock = [
@@ -981,6 +1018,17 @@ describe('Event Factory', () => {
                         permutations: [
                             {
                                 requires: ['~tag']
+                            }
+                        ],
+                        state: 'ENABLED'
+                    },
+                    {
+                        id: 2,
+                        pipelineId: 8765,
+                        name: 'tag',
+                        permutations: [
+                            {
+                                requires: ['~tag:tagName']
                             }
                         ],
                         state: 'ENABLED'
@@ -1000,13 +1048,21 @@ describe('Event Factory', () => {
                     assert.notCalled(jobFactoryMock.create);
                     assert.notCalled(syncedPipelineMock.syncPR);
                     assert.calledOnce(pipelineMock.sync);
-                    assert.calledOnce(buildFactoryMock.create);
+                    assert.calledTwice(buildFactoryMock.create);
                     assert.calledWith(
                         buildFactoryMock.create,
                         sinon.match({
                             parentBuildId: 12345,
                             eventId: model.id,
                             jobId: 1
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 2
                         })
                     );
                 });


### PR DESCRIPTION
## Context
feat https://github.com/screwdriver-cd/screwdriver/issues/1994
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR will allow you to filter by release triggers and tag triggers.
<img width="341" alt="スクリーンショット 2020-06-15 17 50 08" src="https://user-images.githubusercontent.com/17828065/84637567-cfee1880-af30-11ea-8dc1-d5177c8b222d.png">
Filter by 'releaseName' and 'ref' in the webhook in case of tag trigger and release trigger.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1994
[2]https://github.com/screwdriver-cd/screwdriver/pull/2110
[3] https://github.com/screwdriver-cd/guide/pull/386
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
