### PR TITLE
fix: Add isPR and prParentJobId to starts request

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -474,7 +474,9 @@ class BuildModel extends BaseModel {
                                 container: this.container,
                                 tokenGen: this[tokenGen],
                                 token: getToken(this, job, pipeline),
-                                pipelineId: pipeline.id
+                                pipelineId: pipeline.id,
+                                isPR: job.isPR(),
+                                prParentJobId: job.prParentJobId
                             };
 
                             if (this.buildClusterName) {

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -965,7 +965,9 @@ describe('Build Model', () => {
                         scmContext: pipelineMockB.scmContext
                     },
                     tokenGen,
-                    pipelineId
+                    pipelineId,
+                    isPR: false,
+                    prParentJobId
                 });
 
                 assert.calledWith(
@@ -1020,7 +1022,9 @@ describe('Build Model', () => {
                         id: pipelineMockB.id,
                         scmContext: pipelineMockB.scmContext
                     },
-                    pipelineId
+                    pipelineId,
+                    isPR: false,
+                    prParentJobId
                 });
 
                 assert.calledWith(
@@ -1077,7 +1081,9 @@ describe('Build Model', () => {
                             id: pipelineMockB.id,
                             scmContext: pipelineMockB.scmContext
                         },
-                        pipelineId
+                        pipelineId,
+                        isPR: false,
+                        prParentJobId
                     });
 
                     assert.calledWith(
@@ -1155,7 +1161,8 @@ describe('Build Model', () => {
                         blockedBy: [blocking1.name, blocking2.name]
                     }
                 ],
-                isPR: () => false
+                isPR: () => true,
+                prParentJobId
             });
 
             return build.start().then(() => {
@@ -1179,7 +1186,9 @@ describe('Build Model', () => {
                         id: pipelineMockB.id,
                         scmContext: pipelineMockB.scmContext
                     },
-                    pipelineId
+                    pipelineId,
+                    isPR: true,
+                    prParentJobId
                 });
             });
         });
@@ -1268,7 +1277,9 @@ describe('Build Model', () => {
                         id: pipelineMockB.id,
                         scmContext: pipelineMockB.scmContext
                     },
-                    pipelineId: pipelineMockB.id
+                    pipelineId: pipelineMockB.id,
+                    isPR: false,
+                    prParentJobId: undefined
                 });
             });
         });
@@ -1348,7 +1359,9 @@ describe('Build Model', () => {
                         id: pipelineMockB.id,
                         scmContext: pipelineMockB.scmContext
                     },
-                    pipelineId: pipelineMockB.id
+                    pipelineId: pipelineMockB.id,
+                    isPR: false,
+                    prParentJobId: undefined
                 });
             });
         });
@@ -1394,7 +1407,9 @@ describe('Build Model', () => {
                         id: pipelineMockB.id,
                         scmContext: pipelineMockB.scmContext
                     },
-                    pipelineId: pipelineMockB.id
+                    pipelineId: pipelineMockB.id,
+                    isPR: false,
+                    prParentJobId: undefined
                 });
 
                 assert.calledWith(


### PR DESCRIPTION
## Context

Executor start function needs to pass isPR and prParentJobId

## Objective

This PR passed the additional properties to start function used in token generation

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
