### PR TITLE
fix: fix error handling when steps do not exist.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -505,7 +505,7 @@ class BuildModel extends BaseModel {
 
             return this.getSteps().then(steps => {
                 if (steps.length === 0) {
-                    throw new Error('Steps do not exist');
+                    return Promise.resolve();
                 }
 
                 return Promise.all(

--- a/lib/build.js
+++ b/lib/build.js
@@ -505,7 +505,7 @@ class BuildModel extends BaseModel {
 
             return this.getSteps().then(steps => {
                 if (steps.length === 0) {
-                    return new Promise();
+                    throw new Error('Steps do not exist');
                 }
 
                 return Promise.all(

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -467,6 +467,20 @@ describe('Build Model', () => {
             });
         });
 
+        it('throws error if steps missing', () => {
+            build.status = 'SUCCESS';
+            stepFactoryMock.list.resolves([]);
+
+            return build
+                .update()
+                .then(() => {
+                    assert.fail('nope');
+                })
+                .catch(err => {
+                    assert.equal('Steps do not exist', err.message);
+                });
+        });
+
         it('aborts running steps, and sets an endTime', () => {
             build.status = 'ABORTED';
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -467,20 +467,6 @@ describe('Build Model', () => {
             });
         });
 
-        it('throws error if steps missing', () => {
-            build.status = 'SUCCESS';
-            stepFactoryMock.list.resolves([]);
-
-            return build
-                .update()
-                .then(() => {
-                    assert.fail('nope');
-                })
-                .catch(err => {
-                    assert.equal('Steps do not exist', err.message);
-                });
-        });
-
         it('aborts running steps, and sets an endTime', () => {
             build.status = 'ABORTED';
 


### PR DESCRIPTION
## Context
`TypeError: Promise resolver undefined is not a function` happens if buildId does not have steps data.
```
data: TypeError: Promise resolver undefined is not a function
at new Promise (<anonymous>)
at /usr/src/app/node_modules/screwdriver-models/lib/build.js:490:28
```
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Fix error handling properly. (return promise.resolve())

<!-- What does this PR fix? What intentional changes will this PR make? -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
