### PR TITLE
fix(2125): Pass configPipelineId when build starts

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -464,7 +464,8 @@ class BuildModel extends BaseModel {
                                 blockedBy,
                                 pipeline: {
                                     id: pipeline.id,
-                                    scmContext: pipeline.scmContext
+                                    scmContext: pipeline.scmContext,
+                                    configPipelineId: pipeline.configPipelineId
                                 },
                                 causeMessage: causeMessage || '',
                                 freezeWindows: hoek.reach(job.permutations[0], 'freezeWindows', { default: [] }),

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -962,7 +962,8 @@ describe('Build Model', () => {
                     token,
                     pipeline: {
                         id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext
+                        scmContext: pipelineMockB.scmContext,
+                        configPipelineId: pipelineMockB.configPipelineId
                     },
                     tokenGen,
                     pipelineId,
@@ -1020,7 +1021,8 @@ describe('Build Model', () => {
                     tokenGen,
                     pipeline: {
                         id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext
+                        scmContext: pipelineMockB.scmContext,
+                        configPipelineId: pipelineMockB.configPipelineId
                     },
                     pipelineId,
                     isPR: false,
@@ -1079,7 +1081,8 @@ describe('Build Model', () => {
                         tokenGen,
                         pipeline: {
                             id: pipelineMockB.id,
-                            scmContext: pipelineMockB.scmContext
+                            scmContext: pipelineMockB.scmContext,
+                            configPipelineId: pipelineMockB.configPipelineId
                         },
                         pipelineId,
                         isPR: false,
@@ -1184,7 +1187,8 @@ describe('Build Model', () => {
                     tokenGen,
                     pipeline: {
                         id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext
+                        scmContext: pipelineMockB.scmContext,
+                        configPipelineId: pipelineMockB.configPipelineId
                     },
                     pipelineId,
                     isPR: true,
@@ -1227,6 +1231,7 @@ describe('Build Model', () => {
                 id: pipelineId,
                 scmUri,
                 scmContext,
+                configPipelineId,
                 admin: Promise.resolve(adminUser),
                 token: Promise.resolve('foo'),
                 getJobs: sinon.stub().resolves([
@@ -1275,7 +1280,8 @@ describe('Build Model', () => {
                     tokenGen,
                     pipeline: {
                         id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext
+                        scmContext: pipelineMockB.scmContext,
+                        configPipelineId: pipelineMockB.configPipelineId
                     },
                     pipelineId: pipelineMockB.id,
                     isPR: false,
@@ -1309,6 +1315,7 @@ describe('Build Model', () => {
                 id: pipelineId,
                 scmUri,
                 scmContext,
+                configPipelineId,
                 admin: Promise.resolve(adminUser),
                 token: Promise.resolve('foo'),
                 getJobs: sinon.stub().resolves([
@@ -1357,7 +1364,8 @@ describe('Build Model', () => {
                     tokenGen,
                     pipeline: {
                         id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext
+                        scmContext: pipelineMockB.scmContext,
+                        configPipelineId: pipelineMockB.configPipelineId
                     },
                     pipelineId: pipelineMockB.id,
                     isPR: false,
@@ -1405,7 +1413,8 @@ describe('Build Model', () => {
                     tokenGen,
                     pipeline: {
                         id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext
+                        scmContext: pipelineMockB.scmContext,
+                        configPipelineId: pipelineMockB.configPipelineId
                     },
                     pipelineId: pipelineMockB.id,
                     isPR: false,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To get parent pipeline's secrets, credentials must contains `configPipelineId`.
https://github.com/screwdriver-cd/screwdriver/blob/c4a7a7a0341bab24fb77b184626b27c9b2b90468/plugins/secrets/index.js#L65
Queue-service adds `configPipelineId` to token from build config.
https://github.com/screwdriver-cd/queue-service/blob/938d3fc5b41c675257806812cac65ecd3e1d0c36/plugins/queue/scheduler.js#L301
However, this config does not have `configPipelineId`.
https://github.com/screwdriver-cd/models/blob/0a274c7d9891d699ca0a3b568bd237337354baaa/lib/build.js#L465-L468


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Adds `configPipeline` to startConfig.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2125

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
