### PR TITLE
fix: return 404 when steps does not exists

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const boom = require('boom');
 const dayjs = require('dayjs');
 const hoek = require('hoek');
 const deepcopy = require('deepcopy');
@@ -656,7 +657,7 @@ class BuildModel extends BaseModel {
             })
             .then(steps => {
                 if (!steps.length) {
-                    throw new Error('Steps do not exist');
+                    throw boom.notFound('Steps do not exist');
                 }
 
                 // This if statement should be removed after enough time has passed since build.steps removed.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "async": "^2.6.3",
     "base64url": "^3.0.1",
+    "boom": "^7.3.0",
     "compare-versions": "^3.6.0",
     "dayjs": "^1.8.27",
     "deepcopy": "^2.0.0",


### PR DESCRIPTION
## Context
API Server returns 500 response when we send request to get build information that does not have `steps` in `steps` table of DB.
In this case, it should be 404 and this PR fixes it.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Fix to return 404 response If `steps` does not exist in `models.toJsonWithSteps`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
