### PR TITLE
fix(2138): Remove scheduler when deleted from buildPeriodically

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -212,15 +212,22 @@ class Job extends BaseModel {
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
         const PipelineFactory = require('./pipelineFactory');
+        const JobFactory = require('./jobFactory');
         /* eslint-enable global-require */
         const pipelineFactory = PipelineFactory.getInstance();
+        const jobFactory = JobFactory.getInstance();
+
+        const oldPeriodic = await jobFactory
+            .get(this.id)
+            .then(job => getAnnotations(job.permutations[0], 'screwdriver.cd/buildPeriodically'));
 
         const newJob = await super.update();
         const pipeline = await pipelineFactory.get(newJob.pipelineId);
 
         try {
-            // FIXME:: Make this call only if buildCron config is updated
-            if (getAnnotations(this.permutations[0], 'screwdriver.cd/buildPeriodically')) {
+            const newPeriodic = getAnnotations(this.permutations[0], 'screwdriver.cd/buildPeriodically');
+
+            if (newPeriodic && newPeriodic !== oldPeriodic) {
                 await this[executor].startPeriodic({
                     pipeline,
                     job: newJob,
@@ -229,7 +236,7 @@ class Job extends BaseModel {
                     apiUri: this[apiUri],
                     isUpdate: true
                 });
-            } else {
+            } else if (!newPeriodic && oldPeriodic) {
                 await this[executor].stopPeriodic({
                     jobId: this.id,
                     pipelineId: pipeline.id,

--- a/lib/job.js
+++ b/lib/job.js
@@ -229,6 +229,12 @@ class Job extends BaseModel {
                     apiUri: this[apiUri],
                     isUpdate: true
                 });
+            } else {
+                await this[executor].stopPeriodic({
+                    jobId: this.id,
+                    pipelineId: pipeline.id,
+                    token: getToken(this[tokenGen], pipeline, this.id)
+                });
             }
         } catch (err) {
             logger.error(`job:${this.id}: failed to update queue status`, err);

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -16,6 +16,7 @@ describe('Job Model', () => {
     const token = 'tokengenerated';
     const apiUri = 'https://notify.com/some/endpoint';
     let pipelineFactoryMock;
+    let jobFactoryMock;
     let buildFactoryMock;
     let JobModel;
     let datastore;
@@ -111,6 +112,14 @@ describe('Job Model', () => {
             }
         ])
     };
+    const jobMock = Promise.resolve({
+        name: 'job',
+        permutations: [
+            {
+                annotations: { 'screwdriver.cd/buildPeriodically': 'H 9 * * *' }
+            }
+        ]
+    });
 
     before(() => {
         mockery.enable({
@@ -128,6 +137,10 @@ describe('Job Model', () => {
             get: sinon.stub().resolves(pipelineMock)
         };
 
+        jobFactoryMock = {
+            get: sinon.stub().resolves(jobMock)
+        };
+
         buildFactoryMock = {
             list: sinon.stub().resolves(null)
         };
@@ -142,6 +155,10 @@ describe('Job Model', () => {
 
         mockery.registerMock('./pipelineFactory', {
             getInstance: sinon.stub().returns(pipelineFactoryMock)
+        });
+
+        mockery.registerMock('./jobFactory', {
+            getInstance: sinon.stub().returns(jobFactoryMock)
         });
 
         mockery.registerMock('./buildFactory', {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -444,7 +444,6 @@ describe('Job Model', () => {
         });
 
         it('remove periodic job', () => {
-            job.state = 'DISABLED';
             job.permutations = [{}];
 
             datastore.update.resolves(null);

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -442,6 +442,17 @@ describe('Job Model', () => {
                 assert.calledOnce(datastore.update);
             });
         });
+
+        it('remove periodic job', () => {
+            job.state = 'DISABLED';
+            job.permutations = [{}];
+
+            datastore.update.resolves(null);
+
+            return job.update().then(() => {
+                assert.calledOnce(executorMock.stopPeriodic);
+            });
+        });
     });
 
     describe('remove', () => {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -460,6 +460,25 @@ describe('Job Model', () => {
             });
         });
 
+        it('no change of buildPeriodically', () => {
+            job.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H 9 * * *'
+                    }
+                }
+            ];
+
+            datastore.update.resolves(null);
+
+            return job.update().then(() => {
+                assert.notCalled(executorMock.startPeriodic);
+                assert.notCalled(executorMock.stopPeriodic);
+                assert.calledOnce(datastore.update);
+                assert.notCalled(datastore.remove);
+            });
+        });
+
         it('remove periodic job', () => {
             job.permutations = [{}];
 
@@ -467,6 +486,7 @@ describe('Job Model', () => {
 
             return job.update().then(() => {
                 assert.calledOnce(executorMock.stopPeriodic);
+                assert.calledOnce(datastore.update);
             });
         });
     });


### PR DESCRIPTION
## Context
Fix issue https://github.com/screwdriver-cd/screwdriver/issues/2138.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
If the setting of buildPeriodically removed, the schedule should also be deleted.

`screwdriver.yaml`:
```diff
 jobs:
   main:
-    annotations:
-      screwdriver.cd/buildPeriodically: H * * * *
   image: node:12
   steps:
    - ls
```

It is not necessary to call the API to check if buildPeriodically existed before update. Even if it call stopPeriodic when there is no scheduled task, sdqueue-service(`DELETE /v1/queue/message?type=periodic`) responds with 200, so I think this modification is sufficient.

```
IncomingMessage {
  statusCode: 200,
  statusMessage: 'OK',
  request: Request {
    path: '/v1/queue/message?type=periodic',
    method: 'DELETE',
    body: '{"jobId":1,"pipelineId":1,"token":"***"}',
(snip)
```

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2138

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
