### PR TITLE
[2] feat(2092): Allow multiple default parameters

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -455,7 +455,14 @@ function updateEventParameters(config) {
         let defaultParameterValue = val;
 
         if (typeof val === 'object') {
-            defaultParameterValue = val.value;
+            if (Array.isArray(val)) {
+                defaultParameterValue = val[0];
+            } else {
+                defaultParameterValue = val.value;
+                if (Array.isArray(val.value)) {
+                    defaultParameterValue = val.value[0];
+                }
+            }
         }
 
         allowedParameters[name] = { value: defaultParameterValue };

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2105,6 +2105,23 @@ describe('Event Factory', () => {
                 assert.equal(config.meta.parameters.user.value, 'adong');
             });
         });
+
+        it('should have first default parameters if it has multiple paramter', () => {
+            const pipelineWithParameter = {
+                parameters: {
+                    user: ['adong', 'batman']
+                },
+                ...syncedPipelineMock
+            };
+
+            pipelineMock.sync = sinon.stub().resolves(pipelineWithParameter);
+            config.startFrom = 'main';
+
+            return eventFactory.create(config).then(model => {
+                assert.equal(model.meta.parameters.user.value, 'adong');
+                assert.equal(config.meta.parameters.user.value, 'adong');
+            });
+        });
     });
 
     describe('getInstance', () => {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2126,7 +2126,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should have first default parameters if it has multiple parameter', () => {
+        it('should have first default parameters if it has multiple parameters', () => {
             const pipelineWithParameter = {
                 parameters: {
                     user: ['adong', 'batman']

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2143,7 +2143,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should have first default parameters if it has multiple parameter with description', () => {
+        it('should have first default parameters if it has multiple parameters with description', () => {
             const pipelineWithParameter = {
                 parameters: {
                     user: {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2106,10 +2106,50 @@ describe('Event Factory', () => {
             });
         });
 
+        it('should have default parameters if parameter with description enabled', () => {
+            const pipelineWithParameter = {
+                parameters: {
+                    user: {
+                        value: 'adong',
+                        description: 'User name'
+                    }
+                },
+                ...syncedPipelineMock
+            };
+
+            pipelineMock.sync = sinon.stub().resolves(pipelineWithParameter);
+            config.startFrom = 'main';
+
+            return eventFactory.create(config).then(model => {
+                assert.equal(model.meta.parameters.user.value, 'adong');
+                assert.equal(config.meta.parameters.user.value, 'adong');
+            });
+        });
+
         it('should have first default parameters if it has multiple parameter', () => {
             const pipelineWithParameter = {
                 parameters: {
                     user: ['adong', 'batman']
+                },
+                ...syncedPipelineMock
+            };
+
+            pipelineMock.sync = sinon.stub().resolves(pipelineWithParameter);
+            config.startFrom = 'main';
+
+            return eventFactory.create(config).then(model => {
+                assert.equal(model.meta.parameters.user.value, 'adong');
+                assert.equal(config.meta.parameters.user.value, 'adong');
+            });
+        });
+
+        it('should have first default parameters if it has multiple parameter with description', () => {
+            const pipelineWithParameter = {
+                parameters: {
+                    user: {
+                        value: ['adong', 'batman'],
+                        description: 'User name'
+                    }
                 },
                 ...syncedPipelineMock
             };

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2106,7 +2106,7 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should have first default parameters if it has multiple paramter', () => {
+        it('should have first default parameters if it has multiple parameter', () => {
             const pipelineWithParameter = {
                 parameters: {
                     user: ['adong', 'batman']


### PR DESCRIPTION
## Context
Even if multiple parameters are set, an event should be created with a single parameter.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
First parameter is chosen when an event is created with multiple parameters.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2092

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
