### PR TITLE
fix: Add check for disabled and archived job

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -226,10 +226,10 @@ class Job extends BaseModel {
         try {
             const newPeriodic = getAnnotations(newJob.permutations[0], 'screwdriver.cd/buildPeriodically');
             const isJobEnabled = newJob.state === 'ENABLED';
-            const isSettingUpdated = newPeriodic && newPeriodic !== oldPeriodic;
-            const wasJobDisabled = newPeriodic === oldPeriodic && oldJob.state === 'DISABLED';
+            const isSettingUpdated = newPeriodic ? newPeriodic !== oldPeriodic : !!oldPeriodic;
+            const wasJobDisabled = oldJob.state === 'DISABLED';
 
-            if ((isSettingUpdated || wasJobDisabled) && isJobEnabled) {
+            if (newPeriodic && (isSettingUpdated || wasJobDisabled) && isJobEnabled) {
                 await this[executor].startPeriodic({
                     pipeline,
                     job: newJob,

--- a/lib/job.js
+++ b/lib/job.js
@@ -224,10 +224,12 @@ class Job extends BaseModel {
         const newJob = await super.update();
         const pipeline = await pipelineFactory.get(newJob.pipelineId);
 
+        const isDisabled = this.state === 'DISABLED';
+
         try {
             const newPeriodic = getAnnotations(this.permutations[0], 'screwdriver.cd/buildPeriodically');
 
-            if (newPeriodic && newPeriodic !== oldPeriodic) {
+            if (newPeriodic && newPeriodic !== oldPeriodic && !isDisabled) {
                 await this[executor].startPeriodic({
                     pipeline,
                     job: newJob,
@@ -236,7 +238,11 @@ class Job extends BaseModel {
                     apiUri: this[apiUri],
                     isUpdate: true
                 });
-            } else if (!newPeriodic && oldPeriodic) {
+
+                return this;
+            }
+
+            if ((!newPeriodic && oldPeriodic) || isDisabled || this.archived) {
                 await this[executor].stopPeriodic({
                     jobId: this.id,
                     pipelineId: pipeline.id,

--- a/lib/job.js
+++ b/lib/job.js
@@ -217,19 +217,19 @@ class Job extends BaseModel {
         const pipelineFactory = PipelineFactory.getInstance();
         const jobFactory = JobFactory.getInstance();
 
-        const oldPeriodic = await jobFactory
-            .get(this.id)
-            .then(job => getAnnotations(job.permutations[0], 'screwdriver.cd/buildPeriodically'));
+        const oldJob = await jobFactory.get(this.id);
+        const oldPeriodic = getAnnotations(oldJob.permutations[0], 'screwdriver.cd/buildPeriodically');
 
         const newJob = await super.update();
         const pipeline = await pipelineFactory.get(newJob.pipelineId);
 
-        const isDisabled = this.state === 'DISABLED';
-
         try {
-            const newPeriodic = getAnnotations(this.permutations[0], 'screwdriver.cd/buildPeriodically');
+            const newPeriodic = getAnnotations(newJob.permutations[0], 'screwdriver.cd/buildPeriodically');
+            const isJobEnabled = newJob.state === 'ENABLED';
+            const isSettingUpdated = newPeriodic && newPeriodic !== oldPeriodic;
+            const wasJobDisabled = newPeriodic === oldPeriodic && oldJob.state === 'DISABLED';
 
-            if (newPeriodic && newPeriodic !== oldPeriodic && !isDisabled) {
+            if ((isSettingUpdated || wasJobDisabled) && isJobEnabled) {
                 await this[executor].startPeriodic({
                     pipeline,
                     job: newJob,
@@ -241,8 +241,7 @@ class Job extends BaseModel {
 
                 return this;
             }
-
-            if ((!newPeriodic && oldPeriodic) || isDisabled || this.archived) {
+            if ((!newPeriodic && oldPeriodic) || !isJobEnabled || this.archived) {
                 await this[executor].stopPeriodic({
                     jobId: this.id,
                     pipelineId: pipeline.id,

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -528,6 +528,35 @@ describe('Job Model', () => {
                 assert.calledOnce(datastore.update);
             });
         });
+
+        it('state disabled->enabled should start periodic job', () => {
+            const oldJob = Object.assign({}, job);
+
+            oldJob.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H 9 * * *'
+                    }
+                }
+            ];
+            oldJob.state = 'DISABLED';
+            jobFactoryMock.get.resolves(oldJob);
+
+            job.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H 9 * * *'
+                    }
+                }
+            ];
+            job.state = 'ENABLED';
+            datastore.update.resolves(job);
+
+            return job.update().then(() => {
+                assert.calledOnce(executorMock.startPeriodic);
+                assert.calledOnce(datastore.update);
+            });
+        });
     });
 
     describe('remove', () => {


### PR DESCRIPTION
## Context

Change for removing settings of periodic builds misses certain cases where settings was removed but not cleared from queue before changes were pushed which leads to some jobs with empty events and some jobs not being added to queue unless settings are removed and re-added.

## Objective
This PR will fix the issue by adding additional checks for disabled or archived jobs.

## References

https://github.com/screwdriver-cd/models/pull/465#issuecomment-662623305
https://github.com/screwdriver-cd/models/pull/465#issuecomment-662647213
https://github.com/screwdriver-cd/screwdriver/issues/2138

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
