### PR TITLE
Configurable config file path and extending api

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -312,10 +312,7 @@ class PipelineModel extends BaseModel {
                             path,
                             scmRepo: this.scmRepo
                         };
-                        console.log({
-                            config,
-                            screwdriverConf
-                        })
+
                         return request({
                             followAllRedirects: true,
                             json: true,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -7,6 +7,7 @@ const parser = require('screwdriver-config-parser');
 const workflowParser = require('screwdriver-workflow-parser');
 const hoek = require('hoek');
 const dayjs = require('dayjs');
+const request = require('requestretry');
 const _ = require('lodash');
 const { PR_JOB_NAME, EXTERNAL_TRIGGER_ALL } = require('screwdriver-data-schema').config.regex;
 const logger = require('screwdriver-logger');
@@ -282,10 +283,11 @@ class PipelineModel extends BaseModel {
                 .then(user => user.unsealToken())
                 // fetch the screwdriver.yaml file
                 .then(token => {
+                    const path = pipelineFactory.getScrewdriverPath();
                     const config = {
                         scmUri: this.scmUri,
                         scmContext: this.scmContext,
-                        path: 'screwdriver.yaml',
+                        path,
                         token,
                         scmRepo: this.scmRepo
                     };
@@ -299,6 +301,50 @@ class PipelineModel extends BaseModel {
 
                         logger.error(message, err);
                         throw new Error(message);
+                    });
+                })
+                .then(screwdriverConf => {
+                    if (pipelineFactory.isExtendingEnabled()) {
+                        const path = pipelineFactory.getScrewdriverPath();
+                        const config = {
+                            scmUri: this.scmUri,
+                            scmContext: this.scmContext,
+                            path,
+                            scmRepo: this.scmRepo
+                        };
+                        console.log({
+                            config,
+                            screwdriverConf
+                        })
+                        return request({
+                            followAllRedirects: true,
+                            json: true,
+                            method: 'POST',
+                            body: {
+                                config,
+                                screwdriverConf
+                            },
+                            url: pipelineFactory.getScrewdriverExtendApi()
+                        })
+                            .then(response => {
+                                if (response.statusCode >= 200 || response.statusCode < 300) {
+                                    return response.body;
+                                }
+                                const message = `pipelineId:${this.id}: Failed to generate screwdriver.yaml. Error Code  ${response.statusCode}`;
+
+                                logger.error(message, response.body);
+                                throw new Error(message);
+                            })
+                            .catch(error => {
+                                const message = `pipelineId:${this.id}: Failed to generate screwdriver.yaml.`;
+
+                                logger.error(message, error);
+                                throw new Error(message);
+                            });
+                    }
+
+                    return new Promise(resolve => {
+                        resolve(screwdriverConf);
                     });
                 })
                 // parse the content of the yaml file

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -141,7 +141,7 @@ class PipelineFactory extends BaseFactory {
      * @return {Boolean}
      */
     getScrewdriverExtendApi() {
-        this.screwdriverConfig.defaultExtendApi.trim();
+        return this.screwdriverConfig.defaultExtendApi.trim();
     }
 
     /**

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -17,6 +17,9 @@ class PipelineFactory extends BaseFactory {
         super('pipeline', config);
         this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
         this.externalJoin = config.externalJoin || false;
+        this.screwdriverConfig = config.screwdriverConfig || {
+            defaultPath: 'screwdriver.yaml'
+        };
     }
 
     /**
@@ -115,6 +118,30 @@ class PipelineFactory extends BaseFactory {
      */
     getExternalJoinFlag() {
         return this.externalJoin;
+    }
+
+    /**
+     * Return Screwdriver file path
+     * @return {String}
+     */
+    getScrewdriverPath() {
+        return this.screwdriverConfig.defaultPath;
+    }
+
+    /**
+     * Return if extending scredriver is enabled
+     * @return {Boolean}
+     */
+    isExtendingEnabled() {
+        return this.screwdriverConfig.defaultExtendApi && this.screwdriverConfig.defaultExtendApi.trim() !== '';
+    }
+
+    /**
+     * Return Api for extending screwdriver config
+     * @return {Boolean}
+     */
+    getScrewdriverExtendApi() {
+        this.screwdriverConfig.defaultExtendApi.trim();
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "hoek": "^5.0.4",
     "iron": "^5.0.6",
     "lodash": "^4.17.15",
+    "request": "^2.88.2",
+    "requestretry": "^1.12.0",
     "screwdriver-config-parser": "^5.3.3",
     "screwdriver-data-schema": "^19.10.1",
     "screwdriver-logger": "^1.0.0",

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -237,6 +237,9 @@ describe('Pipeline Model', () => {
             remove: sinon.stub().resolves(null)
         };
         pipelineFactoryMock = {
+            getScrewdriverPath: sinon.stub(),
+            isExtendingEnabled: sinon.stub(),
+            getScrewdriverExtendApi: sinon.stub(),
             getExternalJoinFlag: sinon.stub(),
             get: sinon.stub().resolves(configPipelineMock),
             update: sinon.stub().resolves(null),
@@ -262,6 +265,9 @@ describe('Pipeline Model', () => {
         };
         parserMock = sinon.stub();
         pipelineFactoryMock.getExternalJoinFlag.returns(false);
+        pipelineFactoryMock.getScrewdriverPath.returns("screwdriver.yaml");
+        pipelineFactoryMock.isExtendingEnabled.returns(false);
+        pipelineFactoryMock.getScrewdriverExtendApi.returns("https://1c38f86164157b75ccbf618699cc0e60.m.pipedream.net");
 
         buildClusterFactoryMock = {
             list: sinon.stub().resolves([]),
@@ -2136,8 +2142,8 @@ describe('Pipeline Model', () => {
 
         it(
             'multipleBuildClusterEnabled - without annotation - ' +
-                'updates a pipelines scm repository and branch - ' +
-                'pick screwdriver build cluster',
+            'updates a pipelines scm repository and branch - ' +
+            'pick screwdriver build cluster',
             () => {
                 const expected = {
                     params: {
@@ -2193,8 +2199,8 @@ describe('Pipeline Model', () => {
 
         it(
             'multipleBuildClusterEnabled - without cluster annotation - ' +
-                'updates a pipelines scm repository and branch - ' +
-                'pick screwdriver build cluster',
+            'updates a pipelines scm repository and branch - ' +
+            'pick screwdriver build cluster',
             () => {
                 const expected = {
                     params: {
@@ -2254,7 +2260,7 @@ describe('Pipeline Model', () => {
 
         it(
             'multipleBuildClusterEnabled - with cluster annotation - ' +
-                'updates a pipelines scm repository and branch',
+            'updates a pipelines scm repository and branch',
             () => {
                 const expected = {
                     params: {
@@ -2364,7 +2370,7 @@ describe('Pipeline Model', () => {
                 assert.strictEqual(
                     err.message,
                     'Cluster specified in screwdriver.cd/buildCluster iOS ' +
-                        `for scmContext ${pipeline.scmContext} does not exist.`
+                    `for scmContext ${pipeline.scmContext} does not exist.`
                 );
             });
         });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -265,9 +265,9 @@ describe('Pipeline Model', () => {
         };
         parserMock = sinon.stub();
         pipelineFactoryMock.getExternalJoinFlag.returns(false);
-        pipelineFactoryMock.getScrewdriverPath.returns("screwdriver.yaml");
+        pipelineFactoryMock.getScrewdriverPath.returns('screwdriver.yaml');
         pipelineFactoryMock.isExtendingEnabled.returns(false);
-        pipelineFactoryMock.getScrewdriverExtendApi.returns("https://1c38f86164157b75ccbf618699cc0e60.m.pipedream.net");
+        pipelineFactoryMock.getScrewdriverExtendApi.returns('https://1c38f86164157b75ccbf618699cc0e60.m.pipedream.net');
 
         buildClusterFactoryMock = {
             list: sinon.stub().resolves([]),
@@ -2142,8 +2142,8 @@ describe('Pipeline Model', () => {
 
         it(
             'multipleBuildClusterEnabled - without annotation - ' +
-            'updates a pipelines scm repository and branch - ' +
-            'pick screwdriver build cluster',
+                'updates a pipelines scm repository and branch - ' +
+                'pick screwdriver build cluster',
             () => {
                 const expected = {
                     params: {
@@ -2199,8 +2199,8 @@ describe('Pipeline Model', () => {
 
         it(
             'multipleBuildClusterEnabled - without cluster annotation - ' +
-            'updates a pipelines scm repository and branch - ' +
-            'pick screwdriver build cluster',
+                'updates a pipelines scm repository and branch - ' +
+                'pick screwdriver build cluster',
             () => {
                 const expected = {
                     params: {
@@ -2260,7 +2260,7 @@ describe('Pipeline Model', () => {
 
         it(
             'multipleBuildClusterEnabled - with cluster annotation - ' +
-            'updates a pipelines scm repository and branch',
+                'updates a pipelines scm repository and branch',
             () => {
                 const expected = {
                     params: {
@@ -2370,7 +2370,7 @@ describe('Pipeline Model', () => {
                 assert.strictEqual(
                     err.message,
                     'Cluster specified in screwdriver.cd/buildCluster iOS ' +
-                    `for scmContext ${pipeline.scmContext} does not exist.`
+                        `for scmContext ${pipeline.scmContext} does not exist.`
                 );
             });
         });

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -5,7 +5,9 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 const schema = require('screwdriver-data-schema');
 
-class Pipeline {}
+class Pipeline {
+    // TestPipeline class
+}
 
 sinon.assert.expose(assert, { prefix: '' });
 


### PR DESCRIPTION
## Context

There is no way to modify the screwdriver.yaml config file for a pipeline. And along with that there are no way to extend or dynamically create screwdriver.yaml file from external apis. Which is more generic way to pipeline templating.

## Objective
1. Give an option to Set global screwdriver.yaml path, the name can be changed to some other name using this feature.
2. No pipeline level config file override is possible in this PR, after the review of this we can provide per pipeline override for the config file.
3. Ability to extend the scredriver.yaml from an external API as configured in the screwdriver installation.
4. No pipeline level extension apis supported in this PR, can be provided in the subsequent PR based on the feedback.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2145

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
