### PR TITLE
fix: sync child pipelines when sync parent pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -625,7 +625,7 @@ class PipelineModel extends BaseModel {
 
                 logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with pipelineId:${pipeline.id}.`);
 
-                return pipeline.update();
+                return pipeline.sync();
             }
 
             // Child pipeline does not belong to this parent, return

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -234,7 +234,8 @@ describe('Pipeline Model', () => {
             },
             configPipelineId: testId,
             update: sinon.stub().resolves(null),
-            remove: sinon.stub().resolves(null)
+            remove: sinon.stub().resolves(null),
+            sync: sinon.stub().resolves(null)
         };
         pipelineFactoryMock = {
             getExternalJoinFlag: sinon.stub(),
@@ -860,7 +861,7 @@ describe('Pipeline Model', () => {
                 assert.deepEqual(p.childPipelines.scmUrls, ['foo.git', 'bar.git']);
                 assert.calledWith(parserMock, 'yamlcontentwithscmurls', templateFactoryMock);
                 assert.calledOnce(pipelineFactoryMock.create);
-                assert.calledOnce(childPipelineMock.update);
+                assert.calledOnce(childPipelineMock.sync);
                 assert.calledOnce(childPipelineMock.remove);
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, when sync parent pipeline, child pipelines are updated and not synced.
However, `update()` not call `syncExternalTrigger` method. (e.g. in sync method https://github.com/screwdriver-cd/models/blob/4f0d1f9b54927222f47840ae8ede18d815c4b66b/lib/pipeline.js#L811 )
Therefore, if child pipeline's external triggers are updated, that change is not applied to child pipeline's config until child pipeline is synced.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Sync child pipelines when sync parent pipeline

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
