### PR TITLE
feat(1079): Check if scm deploy key secret is present or add it

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -11,6 +11,7 @@ const apiUri = Symbol('apiUri');
 const START_INDEX = 3;
 const MAX_COUNT = 1000;
 const DEFAULT_COUNT = 10;
+const DEPLOY_KEY_SECRET = 'SD_SCM_DEPLOY_KEY';
 
 /**
  * Find metrics and step metrics related to the build
@@ -87,6 +88,11 @@ class Job extends BaseModel {
         delete this.secrets;
 
         const secretNames = hoek.reach(this.permutations, '0.secrets', { default: [] });
+
+        if (!secretNames.includes(DEPLOY_KEY_SECRET)) {
+            secretNames.push(DEPLOY_KEY_SECRET);
+        }
+
         const secretList = this.pipeline.then(pipeline => {
             if (!pipeline) {
                 throw new Error('Pipeline does not exist');


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1079

## Objective

This PR checks whether SD_SCM_DEPLOY_KEY is present as a secret. If not, it adds it to the pipeline secrets.

## References

screwdriver-cd/screwdriver#1079

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
