### PR TITLE
feat(1415): Add alternate routes and handlers for subscribed repos

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -390,7 +390,7 @@ function createBuilds(config) {
  * @param  {Object}         config
  * @param  {Pipeline}       config.pipeline            Pipeline
  * @param  {Object}         config.eventConfig
- * @param  {Boolean}        config.subscribedEvent
+ * @param  {Boolean}        config.subscribedEvent     Flag specifying whether this is a subscribed event
  * @param  {String}         [config.eventConfig.prRef] PR ref
  * @resolves {Object}                                  Resolves with workflowGraph
  */

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -108,6 +108,9 @@ function getJobsFromPR(config) {
     const { jobs, prNum, pipelineConfig, startFrom, chainPR, branch } = config;
     const isPRTrigger = PR_TRIGGER.test(startFrom);
 
+    // console.log('here - pr - 1000');
+    // console.log(jobs);
+
     if (!isPRTrigger) {
         return [];
     }
@@ -131,6 +134,92 @@ function getJobsFromPR(config) {
     const jobsToStart = jobs.filter(j => nextJobs.includes(j.name));
 
     return jobsToStart.filter(j => j.state === 'ENABLED' && !j.archived);
+}
+
+/**
+ * Implementation of queue prototype
+ * @method Queue
+ */
+function Queue() {
+    this.elements = [];
+}
+
+Queue.prototype.enqueue = e => {
+    this.elements.push(e);
+};
+
+Queue.prototype.isEmpty = () => {
+    return this.elements.length === 0;
+};
+
+Queue.prototype.dequeue = () => {
+    if (this.isEmpty()) return null;
+
+    return this.items.shift();
+};
+
+/**
+ * Filter workflow graph by bfs traversal wrt the subscribed job
+ * @method filterSubscribedJobs
+ * @param  {Object}    workflowGraph
+ * @return {Object}                                         Filtered workflow graph
+ */
+function filterSubscribedJobs(workflowGraph) {
+    const adj = {};
+    const reachableNodes = [];
+    const visitedNode = {};
+    const queue = new Queue();
+
+    workflowGraph.nodes.forEach(node => {
+        adj[node.name] = [];
+        visitedNode[node.name] = false;
+    });
+
+    workflowGraph.edges.forEach(edge => {
+        adj[edge.src].push(edge.dest);
+        // Should be a directed graph so no reverse edge
+        // adj[edge.dest].push(edge.src);
+    });
+
+    const sourceNode = workflowGraph.edges.filter(edge => edge.src === '~subscribe')[0];
+
+    visitedNode[sourceNode.dest] = true;
+    queue.enqueue(sourceNode.dest);
+
+    // BFS in the workflow graph
+    while (!queue.isEmpty()) {
+        const visiting = queue.dequeue();
+        let node;
+
+        reachableNodes.push(visiting);
+
+        for (node of adj[visiting]) {
+            if (!visitedNode[node]) {
+                queue.enqueue(node);
+                visitedNode[node] = true;
+            }
+        }
+    }
+
+    const filteredEdges = workflowGraph.edges.filter(
+        edge =>
+            (reachableNodes.includes(edge.dest) && reachableNodes.includes(edge.src)) ||
+            (edge.src[0] === '~' && edge.src !== '~subscribe' && edge.dest === sourceNode.dest)
+    );
+
+    const filteredNodes = workflowGraph.nodes.filter(node => reachableNodes.includes(node.name));
+
+    filteredEdges.forEach(edge => {
+        if (edge.src[0] === '~')
+            filteredNodes.push({
+                name: edge.src
+            });
+    });
+
+    return {
+        edges: filteredEdges,
+        nodes: filteredNodes
+    };
 }
 
 /**
@@ -272,7 +361,8 @@ function createBuilds(config) {
         webhooks,
         isPR,
         releaseName,
-        ref
+        ref,
+        subscribedEvent
     } = config;
     const { startFrom } = eventConfig;
     let rootDir = '';
@@ -284,6 +374,11 @@ function createBuilds(config) {
     return Promise.all([pipeline.branch, pipeline.getJobs(), pipeline.rootDir])
         .then(([branch, jobs, root]) => {
             rootDir = root;
+
+            if (subscribedEvent) {
+                pipelineConfig.workflowGraph = filterSubscribedJobs(pipelineConfig.workflowGraph);
+            }
+
             // When startFrom is ~commit, ~release, ~tag, ~sd@
             const jobsFromTrigger = getJobsFromTrigger({
                 jobs,
@@ -368,6 +463,13 @@ function createBuilds(config) {
  */
 function getLatestWorkflowGraph(config) {
     const { pipeline, eventConfig } = config;
+
+    // Experimental feature turned off
+    if ('subscribedEvent' in config) {
+        if (config.subscribedEvent) {
+            eventConfig.prRef = false;
+        }
+    }
 
     if (eventConfig.prRef) {
         return pipeline
@@ -455,14 +557,7 @@ function updateEventParameters(config) {
         let defaultParameterValue = val;
 
         if (typeof val === 'object') {
-            if (Array.isArray(val)) {
-                defaultParameterValue = val[0];
-            } else {
-                defaultParameterValue = val.value;
-                if (Array.isArray(val.value)) {
-                    defaultParameterValue = val.value[0];
-                }
-            }
+            defaultParameterValue = val.value;
         }
 
         allowedParameters[name] = { value: defaultParameterValue };
@@ -581,7 +676,9 @@ class EventFactory extends BaseFactory {
             chainPR,
             groupEventId,
             releaseName,
-            ref
+            ref,
+            subscribedEvent,
+            subscribedScmConfig
         } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
@@ -640,6 +737,10 @@ class EventFactory extends BaseFactory {
                 .then(p => {
                     if (prevChainPR !== p.chainPR) {
                         // when chainPR was changed, sync PRs.
+                        if (subscribedEvent) {
+                            return p;
+                        }
+
                         return p.syncPRs();
                     }
 
@@ -667,7 +768,12 @@ class EventFactory extends BaseFactory {
                     if (prRef) {
                         modelConfig.pr.ref = prRef;
 
-                        return p.syncPR(prNum);
+                        // return p.syncPR(prNum);
+                        if (subscribedEvent) {
+                            return p;
+                        }
+
+                        return p.syncPRs();
                     }
 
                     return p;
@@ -686,8 +792,14 @@ class EventFactory extends BaseFactory {
                                     .then(creator => {
                                         modelConfig.creator = creator;
 
+                                        let adaptedScmUri = pipeline.scmUri;
+
+                                        if (subscribedEvent) {
+                                            adaptedScmUri = subscribedScmConfig.scmUri;
+                                        }
+
                                         return this.scm.decorateCommit({
-                                            scmUri: pipeline.scmUri,
+                                            scmUri: adaptedScmUri,
                                             scmContext,
                                             sha,
                                             token
@@ -695,8 +807,14 @@ class EventFactory extends BaseFactory {
                                     });
                             }
 
+                            let adaptedScmUri = pipeline.scmUri;
+
+                            if (subscribedEvent) {
+                                adaptedScmUri = subscribedScmConfig.scmUri;
+                            }
+
                             return this.scm.decorateCommit({
-                                scmUri: pipeline.scmUri,
+                                scmUri: adaptedScmUri,
                                 scmContext,
                                 sha,
                                 token
@@ -709,7 +827,8 @@ class EventFactory extends BaseFactory {
 
                             return getLatestWorkflowGraph({
                                 pipeline,
-                                eventConfig: config
+                                eventConfig: config,
+                                subscribedEvent
                             });
                         })
                         .then(workflowGraph =>
@@ -772,7 +891,8 @@ class EventFactory extends BaseFactory {
                                         changedFiles,
                                         webhooks,
                                         releaseName,
-                                        ref
+                                        ref,
+                                        subscribedEvent
                                     });
                                 })
                                 .then(builds => {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -108,9 +108,6 @@ function getJobsFromPR(config) {
     const { jobs, prNum, pipelineConfig, startFrom, chainPR, branch } = config;
     const isPRTrigger = PR_TRIGGER.test(startFrom);
 
-    // console.log('here - pr - 1000');
-    // console.log(jobs);
-
     if (!isPRTrigger) {
         return [];
     }
@@ -134,92 +131,6 @@ function getJobsFromPR(config) {
     const jobsToStart = jobs.filter(j => nextJobs.includes(j.name));
 
     return jobsToStart.filter(j => j.state === 'ENABLED' && !j.archived);
-}
-
-/**
- * Implementation of queue prototype
- * @method Queue
- */
-function Queue() {
-    this.elements = [];
-}
-
-Queue.prototype.enqueue = e => {
-    this.elements.push(e);
-};
-
-Queue.prototype.isEmpty = () => {
-    return this.elements.length === 0;
-};
-
-Queue.prototype.dequeue = () => {
-    if (this.isEmpty()) return null;
-
-    return this.items.shift();
-};
-
-/**
- * Filter workflow graph by bfs traversal wrt the subscribed job
- * @method filterSubscribedJobs
- * @param  {Object}    workflowGraph
- * @return {Object}                                         Filtered workflow graph
- */
-function filterSubscribedJobs(workflowGraph) {
-    const adj = {};
-    const reachableNodes = [];
-    const visitedNode = {};
-    const queue = new Queue();
-
-    workflowGraph.nodes.forEach(node => {
-        adj[node.name] = [];
-        visitedNode[node.name] = false;
-    });
-
-    workflowGraph.edges.forEach(edge => {
-        adj[edge.src].push(edge.dest);
-        // Should be a directed graph so no reverse edge
-        // adj[edge.dest].push(edge.src);
-    });
-
-    const sourceNode = workflowGraph.edges.filter(edge => edge.src === '~subscribe')[0];
-
-    visitedNode[sourceNode.dest] = true;
-    queue.enqueue(sourceNode.dest);
-
-    // BFS in the workflow graph
-    while (!queue.isEmpty()) {
-        const visiting = queue.dequeue();
-        let node;
-
-        reachableNodes.push(visiting);
-
-        for (node of adj[visiting]) {
-            if (!visitedNode[node]) {
-                queue.enqueue(node);
-                visitedNode[node] = true;
-            }
-        }
-    }
-
-    const filteredEdges = workflowGraph.edges.filter(
-        edge =>
-            (reachableNodes.includes(edge.dest) && reachableNodes.includes(edge.src)) ||
-            (edge.src[0] === '~' && edge.src !== '~subscribe' && edge.dest === sourceNode.dest)
-    );
-
-    const filteredNodes = workflowGraph.nodes.filter(node => reachableNodes.includes(node.name));
-
-    filteredEdges.forEach(edge => {
-        if (edge.src[0] === '~')
-            filteredNodes.push({
-                name: edge.src
-            });
-    });
-
-    return {
-        edges: filteredEdges,
-        nodes: filteredNodes
-    };
 }
 
 /**
@@ -361,8 +272,7 @@ function createBuilds(config) {
         webhooks,
         isPR,
         releaseName,
-        ref,
-        subscribedEvent
+        ref
     } = config;
     const { startFrom } = eventConfig;
     let rootDir = '';
@@ -374,11 +284,6 @@ function createBuilds(config) {
     return Promise.all([pipeline.branch, pipeline.getJobs(), pipeline.rootDir])
         .then(([branch, jobs, root]) => {
             rootDir = root;
-
-            if (subscribedEvent) {
-                pipelineConfig.workflowGraph = filterSubscribedJobs(pipelineConfig.workflowGraph);
-            }
-
             // When startFrom is ~commit, ~release, ~tag, ~sd@
             const jobsFromTrigger = getJobsFromTrigger({
                 jobs,
@@ -465,10 +370,8 @@ function getLatestWorkflowGraph(config) {
     const { pipeline, eventConfig } = config;
 
     // Experimental feature turned off
-    if ('subscribedEvent' in config) {
-        if (config.subscribedEvent) {
-            eventConfig.prRef = false;
-        }
+    if (config.subscribedEvent) {
+        eventConfig.prRef = false;
     }
 
     if (eventConfig.prRef) {
@@ -557,7 +460,14 @@ function updateEventParameters(config) {
         let defaultParameterValue = val;
 
         if (typeof val === 'object') {
-            defaultParameterValue = val.value;
+            if (Array.isArray(val)) {
+                defaultParameterValue = val[0];
+            } else {
+                defaultParameterValue = val.value;
+                if (Array.isArray(val.value)) {
+                    defaultParameterValue = val.value[0];
+                }
+            }
         }
 
         allowedParameters[name] = { value: defaultParameterValue };
@@ -735,12 +645,8 @@ class EventFactory extends BaseFactory {
                     return p.sync(null, chainPR);
                 })
                 .then(p => {
-                    if (prevChainPR !== p.chainPR) {
+                    if (prevChainPR !== p.chainPR && !subscribedEvent) {
                         // when chainPR was changed, sync PRs.
-                        if (subscribedEvent) {
-                            return p;
-                        }
-
                         return p.syncPRs();
                     }
 
@@ -768,12 +674,7 @@ class EventFactory extends BaseFactory {
                     if (prRef) {
                         modelConfig.pr.ref = prRef;
 
-                        // return p.syncPR(prNum);
-                        if (subscribedEvent) {
-                            return p;
-                        }
-
-                        return p.syncPRs();
+                        return subscribedEvent ? p : p.syncPR(prNum);
                     }
 
                     return p;
@@ -792,14 +693,8 @@ class EventFactory extends BaseFactory {
                                     .then(creator => {
                                         modelConfig.creator = creator;
 
-                                        let adaptedScmUri = pipeline.scmUri;
-
-                                        if (subscribedEvent) {
-                                            adaptedScmUri = subscribedScmConfig.scmUri;
-                                        }
-
                                         return this.scm.decorateCommit({
-                                            scmUri: adaptedScmUri,
+                                            scmUri: subscribedEvent ? subscribedScmConfig.scmUri : pipeline.scmUri,
                                             scmContext,
                                             sha,
                                             token
@@ -807,14 +702,8 @@ class EventFactory extends BaseFactory {
                                     });
                             }
 
-                            let adaptedScmUri = pipeline.scmUri;
-
-                            if (subscribedEvent) {
-                                adaptedScmUri = subscribedScmConfig.scmUri;
-                            }
-
                             return this.scm.decorateCommit({
-                                scmUri: adaptedScmUri,
+                                scmUri: subscribedEvent ? subscribedScmConfig.scmUri : pipeline.scmUri,
                                 scmContext,
                                 sha,
                                 token
@@ -891,8 +780,7 @@ class EventFactory extends BaseFactory {
                                         changedFiles,
                                         webhooks,
                                         releaseName,
-                                        ref,
-                                        subscribedEvent
+                                        ref
                                     });
                                 })
                                 .then(builds => {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -33,7 +33,8 @@ function getJobsFromTrigger(config) {
         EXTERNAL_TRIGGER.test(startFrom),
         COMMIT_TRIGGER.test(startFrom),
         RELEASE_TRIGGER.test(startFrom),
-        TAG_TRIGGER.test(startFrom)
+        TAG_TRIGGER.test(startFrom),
+        startFrom === '~subscribe'
     ];
 
     if (!shouldGetJobs.some(t => t === true)) {
@@ -64,6 +65,14 @@ function getJobsFromTrigger(config) {
         nextJobs = nextJobs.concat(
             workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
                 trigger: `~tag:${ref}`
+            })
+        );
+    }
+
+    if (startFrom === '~subscribe') {
+        nextJobs = nextJobs.concat(
+            workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+                trigger: '~subscribe'
             })
         );
     }
@@ -152,12 +161,24 @@ function startBuild(config) {
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
     /* eslint-enable global-require */
-    const { buildConfig, changedFiles, startFrom, sourcePaths, webhooks, isPR, decoratedCommit, rootDir } = config;
+    const {
+        buildConfig,
+        changedFiles,
+        startFrom,
+        sourcePaths,
+        webhooks,
+        isPR,
+        decoratedCommit,
+        subscribedConfigSha,
+        subscribedSourceUrl,
+        rootDir
+    } = config;
     const isReleaseTrigger = RELEASE_TRIGGER.test(startFrom);
     const isTagTrigger = TAG_TRIGGER.test(startFrom);
     let hasChangeInSourcePaths = true;
 
     buildConfig.environment = {};
+    buildConfig.subscribedConfigSha = subscribedConfigSha;
 
     // Only check if sourcePaths or rootDir is set
     // and is not a releaseTrigger and is not a tagTrigger
@@ -226,7 +247,9 @@ function startBuild(config) {
             ...decoratedCommit,
             changedFiles: changedFiles ? changedFiles.join(',') : ''
         },
-        ...buildConfig.meta
+        ...buildConfig.meta,
+        subscribedConfigSha,
+        subscribedSourceUrl: subscribedConfigSha ? subscribedSourceUrl : undefined
     };
 
     return hasChangeInSourcePaths ? buildFactory.create(buildConfig) : null;
@@ -264,6 +287,8 @@ function startBuild(config) {
 function createBuilds(config) {
     const {
         decoratedCommit,
+        subscribedConfigSha,
+        subscribedSourceUrl,
         eventConfig,
         eventId,
         pipeline,
@@ -334,6 +359,8 @@ function createBuilds(config) {
 
                     return startBuild({
                         decoratedCommit,
+                        subscribedConfigSha,
+                        subscribedSourceUrl,
                         buildConfig,
                         startFrom,
                         changedFiles,
@@ -588,7 +615,8 @@ class EventFactory extends BaseFactory {
             releaseName,
             ref,
             subscribedEvent,
-            subscribedScmConfig
+            subscribedConfigSha,
+            subscribedSourceUrl
         } = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
@@ -694,7 +722,7 @@ class EventFactory extends BaseFactory {
                                         modelConfig.creator = creator;
 
                                         return this.scm.decorateCommit({
-                                            scmUri: subscribedEvent ? subscribedScmConfig.scmUri : pipeline.scmUri,
+                                            scmUri: pipeline.scmUri,
                                             scmContext,
                                             sha,
                                             token
@@ -703,7 +731,7 @@ class EventFactory extends BaseFactory {
                             }
 
                             return this.scm.decorateCommit({
-                                scmUri: subscribedEvent ? subscribedScmConfig.scmUri : pipeline.scmUri,
+                                scmUri: pipeline.scmUri,
                                 scmContext,
                                 sha,
                                 token
@@ -772,6 +800,8 @@ class EventFactory extends BaseFactory {
                                     // Start builds
                                     return createBuilds({
                                         decoratedCommit,
+                                        subscribedConfigSha,
+                                        subscribedSourceUrl,
                                         eventConfig: config,
                                         eventId: event.id,
                                         pipeline: p,

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -390,6 +390,7 @@ function createBuilds(config) {
  * @param  {Object}         config
  * @param  {Pipeline}       config.pipeline            Pipeline
  * @param  {Object}         config.eventConfig
+ * @param  {Boolean}        config.subscribedEvent
  * @param  {String}         [config.eventConfig.prRef] PR ref
  * @resolves {Object}                                  Resolves with workflowGraph
  */

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -807,7 +807,6 @@ class PipelineModel extends BaseModel {
                 }
 
                 this.subscribedScmUrlsWithActions = urlWithActionsList;
-                this.subscribedScmUrls = this.subscribedScmUrlsWithActions.map(object => object.scmUri);
             }
         }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -376,15 +376,14 @@ class PipelineModel extends BaseModel {
 
     /**
      * Attach Screwdriver webhooks to the pipeline's repository
-     * @method addMultipleWebhooks
+     * @method addWebhooks
      * @param   {String}    webhookUrl    The webhook to be added
      * @method  addWebhook
      * @return  {Promise}
      */
-    async addMultipleWebhooks(webhookUrl) {
+    async addWebhooks(webhookUrl) {
         const webhookUrlsWithActionsList = [];
 
-        // Default repo actions
         const webhookUrlWithActions = {
             webhookUrl,
             actions: ['push', 'pull_request', 'create', 'release'],
@@ -393,33 +392,32 @@ class PipelineModel extends BaseModel {
 
         webhookUrlsWithActionsList.push(webhookUrlWithActions);
 
-        // check if subscribedScmUrlsWithActions is present
-        if ('subscribedScmUrlsWithActions' in this && this.subscribedScmUrlsWithActions !== undefined) {
-            this.subscribedScmUrlsWithActions.forEach(item => {
-                item.webhookUrl = webhookUrl;
+        if (Array.isArray(this.subscribedScmUrlsWithActions)) {
+            this.subscribedScmUrlsWithActions.forEach(urlObj => {
+                urlObj.webhookUrl = webhookUrl;
             });
             webhookUrlsWithActionsList.push(...this.subscribedScmUrlsWithActions);
         }
 
         return this.getFirstRepoAdmin()
             .then(admin => admin.unsealToken())
-            .then(token => {
-                const addWebhookPromiseList = [];
+            .then(async token => {
+                const addWebhookList = [];
 
-                // add webhook for all the scmUrls
-                webhookUrlsWithActionsList.forEach(async webhookUrlsWithActions => {
-                    const addWebhookPromise = await this.scm.addWebhook({
-                        scmUri: webhookUrlsWithActions.scmUri,
+                for (let i = 0; i < webhookUrlsWithActionsList.length; i += 1) {
+                    // eslint-disable-next-line no-await-in-loop
+                    const addWebhook = await this.scm.addWebhook({
+                        scmUri: webhookUrlsWithActionsList[i].scmUri,
                         scmContext: this.scmContext,
                         token,
-                        actions: webhookUrlsWithActions.actions,
-                        webhookUrl: webhookUrlsWithActions.webhookUrl
+                        actions: webhookUrlsWithActionsList[i].actions,
+                        webhookUrl: webhookUrlsWithActionsList[i].webhookUrl
                     });
 
-                    addWebhookPromiseList.push(addWebhookPromise);
-                });
+                    addWebhookList.push(addWebhook);
+                }
 
-                return Promise.all(addWebhookPromiseList);
+                return addWebhookList;
             });
     }
 
@@ -794,33 +792,21 @@ class PipelineModel extends BaseModel {
         this.annotations = parsedConfig.annotations;
         this.parameters = parsedConfig.parameters;
 
-        if ('subscribe' in parsedConfig) {
+        if (parsedConfig.subscribe) {
             if (Object.keys(parsedConfig.subscribe).length !== 0) {
                 const urlWithActionsList = [];
 
-                parsedConfig.subscribe.scmUrls.forEach(url => {
+                for (let i = 0; i < parsedConfig.subscribe.scmUrls.length; i += 1) {
+                    const urlObj = parsedConfig.subscribe.scmUrls[i];
+                    const scmUrl = Object.keys(urlObj)[0];
+
                     urlWithActionsList.push({
-                        scmUrl: Object.keys(url)[0],
-                        actions: Object.values(url)[0]
+                        actions: urlObj[scmUrl].map(action => (action[0] === '~' ? action.substring(1) : action)),
+                        scmUri: await this._getScmUri(scmUrl)
                     });
-                });
-                parsedConfig.subscribe.scmUrls = urlWithActionsList.map(urlObject =>
-                    this._formatUrlsWithActionsStruct(urlObject)
-                );
-                this.subscribedScmUrlsWithActions = await Promise.all(parsedConfig.subscribe.scmUrls);
-                this.subscribedScmUrlsWithActions.map(urlWithActions => {
-                    const formattedActions = urlWithActions.actions.map(action => {
-                        if (action[0] === '~') {
-                            return action.substring(1);
-                        }
+                }
 
-                        return action;
-                    });
-
-                    urlWithActions.actions = formattedActions;
-
-                    return urlWithActions;
-                });
+                this.subscribedScmUrlsWithActions = urlWithActionsList;
                 this.subscribedScmUrls = this.subscribedScmUrlsWithActions.map(object => object.scmUri);
             }
         }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -386,7 +386,7 @@ class PipelineModel extends BaseModel {
 
         const webhookUrlWithActions = {
             webhookUrl,
-            actions: ['push', 'pull_request', 'create', 'release'],
+            actions: [],
             scmUri: this.scmUri
         };
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -375,22 +375,52 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Attach Screwdriver webhook to the pipeline's repository
+     * Attach Screwdriver webhooks to the pipeline's repository
+     * @method addMultipleWebhooks
      * @param   {String}    webhookUrl    The webhook to be added
      * @method  addWebhook
      * @return  {Promise}
      */
-    addWebhook(webhookUrl) {
+    async addMultipleWebhooks(webhookUrl) {
+        const webhookUrlsWithActionsList = [];
+
+        // Default repo actions
+        const webhookUrlWithActions = {
+            webhookUrl,
+            actions: ['push', 'pull_request', 'create', 'release'],
+            scmUri: this.scmUri
+        };
+
+        webhookUrlsWithActionsList.push(webhookUrlWithActions);
+
+        // check if subscribedScmUrlsWithActions is present
+        if ('subscribedScmUrlsWithActions' in this && this.subscribedScmUrlsWithActions !== undefined) {
+            this.subscribedScmUrlsWithActions.forEach(item => {
+                item.webhookUrl = webhookUrl;
+            });
+            webhookUrlsWithActionsList.push(...this.subscribedScmUrlsWithActions);
+        }
+
         return this.getFirstRepoAdmin()
             .then(admin => admin.unsealToken())
-            .then(token =>
-                this.scm.addWebhook({
-                    scmUri: this.scmUri,
-                    scmContext: this.scmContext,
-                    token,
-                    webhookUrl
-                })
-            );
+            .then(token => {
+                const addWebhookPromiseList = [];
+
+                // add webhook for all the scmUrls
+                webhookUrlsWithActionsList.forEach(async webhookUrlsWithActions => {
+                    const addWebhookPromise = await this.scm.addWebhook({
+                        scmUri: webhookUrlsWithActions.scmUri,
+                        scmContext: this.scmContext,
+                        token,
+                        actions: webhookUrlsWithActions.actions,
+                        webhookUrl: webhookUrlsWithActions.webhookUrl
+                    });
+
+                    addWebhookPromiseList.push(addWebhookPromise);
+                });
+
+                return Promise.all(addWebhookPromiseList);
+            });
     }
 
     /**
@@ -435,6 +465,7 @@ class PipelineModel extends BaseModel {
     async syncPR(prNum) {
         const user = await this.admin;
         const token = await user.unsealToken();
+
         const prInfo = await this.scm.getPrInfo({
             scmUri: this.scmUri,
             scmContext: this.scmContext,
@@ -442,6 +473,7 @@ class PipelineModel extends BaseModel {
             prNum,
             scmRepo: this.scmRepo
         });
+
         const jobs = await this.jobs;
         const parsedConfig = await this.getConfiguration({
             ref: prInfo.ref,
@@ -599,6 +631,18 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Format scmUrlsWithActions object by converting scmUrl to scmUri
+     * @method _formatUrlsWithActionsStruct
+     * @param  {Object} scmUrlObject  object containing scmUrl and corresponding actions
+     * @return {Promise}
+     */
+    async _formatUrlsWithActionsStruct(scmUrlObject) {
+        scmUrlObject.scmUri = await this._getScmUri(scmUrlObject.scmUrl);
+
+        return scmUrlObject;
+    }
+
+    /**
      * Update or create a pipeline given a scmUrl
      * @method _createOrUpdatePipeline
      * @param {String} scmUrl  checkout url for a repository
@@ -724,6 +768,7 @@ class PipelineModel extends BaseModel {
 
         // get the pipeline configuration
         const parsedConfig = await this.getConfiguration({ ref });
+
         const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
         const parsedConfigAnnotations = hoek.reach(parsedConfig, 'annotations', { default: {} });
         const buildCluster = parsedConfigAnnotations[buildClusterAnnotation] || '';
@@ -748,6 +793,37 @@ class PipelineModel extends BaseModel {
         this.workflowGraph = parsedConfig.workflowGraph;
         this.annotations = parsedConfig.annotations;
         this.parameters = parsedConfig.parameters;
+
+        if ('subscribe' in parsedConfig) {
+            if (Object.keys(parsedConfig.subscribe).length !== 0) {
+                const urlWithActionsList = [];
+
+                parsedConfig.subscribe.scmUrls.forEach(url => {
+                    urlWithActionsList.push({
+                        scmUrl: Object.keys(url)[0],
+                        actions: Object.values(url)[0]
+                    });
+                });
+                parsedConfig.subscribe.scmUrls = urlWithActionsList.map(urlObject =>
+                    this._formatUrlsWithActionsStruct(urlObject)
+                );
+                this.subscribedScmUrlsWithActions = await Promise.all(parsedConfig.subscribe.scmUrls);
+                this.subscribedScmUrlsWithActions.map(urlWithActions => {
+                    const formattedActions = urlWithActions.actions.map(action => {
+                        if (action[0] === '~') {
+                            return action.substring(1);
+                        }
+
+                        return action;
+                    });
+
+                    urlWithActions.actions = formattedActions;
+
+                    return urlWithActions;
+                });
+                this.subscribedScmUrls = this.subscribedScmUrlsWithActions.map(object => object.scmUri);
+            }
+        }
 
         const existingJobs = await this.jobs;
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -629,18 +629,6 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Format scmUrlsWithActions object by converting scmUrl to scmUri
-     * @method _formatUrlsWithActionsStruct
-     * @param  {Object} scmUrlObject  object containing scmUrl and corresponding actions
-     * @return {Promise}
-     */
-    async _formatUrlsWithActionsStruct(scmUrlObject) {
-        scmUrlObject.scmUri = await this._getScmUri(scmUrlObject.scmUrl);
-
-        return scmUrlObject;
-    }
-
-    /**
      * Update or create a pipeline given a scmUrl
      * @method _createOrUpdatePipeline
      * @param {String} scmUrl  checkout url for a repository

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -403,14 +403,27 @@ class PipelineModel extends BaseModel {
             .then(admin => admin.unsealToken())
             .then(async token => {
                 const addWebhookList = [];
+                let mappedActions = [];
+
+                const scmActionMappings = this.scm.getWebhookEventsMapping({ scmContext: this.scmContext });
 
                 for (let i = 0; i < webhookUrlsWithActionsList.length; i += 1) {
+                    mappedActions = [];
+
+                    for (const action of webhookUrlsWithActionsList[i].actions) {
+                        if (scmActionMappings[action]) {
+                            if (Array.isArray(scmActionMappings[action]))
+                                mappedActions.concat(scmActionMappings[action]);
+                            else mappedActions.push(scmActionMappings[action]);
+                        }
+                    }
+
                     // eslint-disable-next-line no-await-in-loop
                     const addWebhook = await this.scm.addWebhook({
                         scmUri: webhookUrlsWithActionsList[i].scmUri,
                         scmContext: this.scmContext,
                         token,
-                        actions: webhookUrlsWithActionsList[i].actions,
+                        actions: mappedActions,
                         webhookUrl: webhookUrlsWithActionsList[i].webhookUrl
                     });
 

--- a/test/data/parserWithSubscribedScms.json
+++ b/test/data/parserWithSubscribedScms.json
@@ -1,0 +1,90 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "4"
+                }
+            },
+            {
+                "image": "node:5",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "5"
+                }
+            },
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "6"
+                }
+            }
+        ],
+        "publish": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "bump",
+                        "command": "npm run bump"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish --tag $NODE_TAG"
+                    },
+                    {
+                        "name": "tag",
+                        "command": "git push origin --tags"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_TAG": "latest"
+                }
+            }
+        ]
+    },
+    "workflowGraph": { "nodes": [{ "name": "~pr" }, { "name": "~commit" }, { "name": "main", "id": 3 }] },
+    "annotations": {
+        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm",
+        "screwdriver.cd/chainPR" : true
+    },
+    "subscribe": {
+        "scmUrls": [{
+            "foo.git": ["~commit", "~tags", "~release"]
+        }]
+    }
+}

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2162,6 +2162,25 @@ describe('Event Factory', () => {
                 assert.equal(config.meta.parameters.user.value, 'adong');
             });
         });
+
+        it('should should not call syncPRs and decorate commit with hook info', () => {
+            pipelineFactoryMock.get.withArgs(pipelineId).resolves(pipelineMock);
+            config.subscribedEvent = true;
+            config.subscribedScmConfig = {
+                scmUri: 'github.com:7893:branch'
+            };
+
+            return eventFactory.create(config).then(() => {
+                assert.notCalled(syncedPipelineMock.syncPRs);
+                assert.calledWith(scm.decorateCommit, {
+                    scmUri: 'github.com:7893:branch',
+                    scmContext,
+                    sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
+                    token: 'foo'
+                });
+                assert.notCalled(syncedPipelineMock.getConfiguration);
+            });
+        });
     });
 
     describe('getInstance', () => {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2163,18 +2163,15 @@ describe('Event Factory', () => {
             });
         });
 
-        it('should should not call syncPRs and decorate commit with hook info', () => {
+        it('should should not call syncPRs and decorate commit with subscribed hook event', () => {
             pipelineFactoryMock.get.withArgs(pipelineId).resolves(pipelineMock);
             config.subscribedEvent = true;
-            config.subscribedScmConfig = {
-                scmUri: 'github.com:7893:branch'
-            };
 
             return eventFactory.create(config).then(() => {
                 assert.notCalled(syncedPipelineMock.syncPRs);
                 assert.calledWith(scm.decorateCommit, {
-                    scmUri: 'github.com:7893:branch',
                     scmContext,
+                    scmUri: 'github.com:1234:branch',
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
                     token: 'foo'
                 });

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines-per-function */
-/* eslint-disable max-statements */
-
 'use strict';
 
 const { assert } = require('chai');

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -616,7 +616,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('subscribed pipelines from config gets added to the model', () => {
+        it('adds subscribed pipelines from config to the model', () => {
             jobs = [];
             sinon.spy(pipeline, 'update');
             jobFactoryMock.list.resolves(jobs);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -256,6 +256,7 @@ describe('Pipeline Model', () => {
         };
         scmMock = {
             addWebhook: sinon.stub(),
+            getWebhookEventsMapping: sinon.stub().returns({ pr: 'pull_request' }),
             getFile: sinon.stub(),
             decorateUrl: sinon.stub().resolves(scmRepo),
             annotations: sinon.stub(),

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -635,7 +635,6 @@ describe('Pipeline Model', () => {
                 .resolves(PARSED_YAML_WITH_SUBSCRIBE);
 
             return pipeline.sync().then(() => {
-                assert.deepEqual(pipeline.subscribedScmUrls, ['foo']);
                 assert.deepEqual(pipeline.subscribedScmUrlsWithActions, [
                     { actions: ['commit', 'tags', 'release'], scmUri: 'foo' }
                 ]);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -380,7 +380,7 @@ describe('Pipeline Model', () => {
                     scmUri,
                     scmContext,
                     token: 'foo',
-                    actions: ['push', 'pull_request', 'create', 'release'],
+                    actions: [],
                     webhookUrl: 'https://api.screwdriver.cd/v4/webhooks'
                 });
             });


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1415

## Objective

This PR adds handlers for using the subscribed config. If the parsed config contains the `subscribe` object it is formatted to convert scmUrl to scmUri mapped with their actions. This mapped array is used by the modified addWebhook() method (now addMultipleWebhooks()) to add the webhooks along with the corresponding actions.

Now when a webhook request arrives in the screwdriver API, it identifies it whether it is external and captures is `checkoutUrl`. The API filters the triggered pipelines based on the `checkoutUrl`. Further in the `eventFactory`, it needs to be figured whether the job(s) is(are) triggered or not. This is done by performing a `breadth-first-search` of the `workflowGraph` with `~subscribe` as the root node. This way all the dependant jobs are identified wrt the triggered jobs, `workflowGraph` updated and build started.

## References

screwdriver-cd/screwdriver#1415

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
