### PR TITLE
feat: fix for archived to unarchived transition

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -232,10 +232,17 @@ class Job extends BaseModel {
         try {
             const newPeriodic = getAnnotations(newJob.permutations[0], 'screwdriver.cd/buildPeriodically');
             const isJobEnabled = newJob.state === 'ENABLED';
+            const isJobArchived = newJob.archived;
             const isSettingUpdated = newPeriodic ? newPeriodic !== oldPeriodic : !!oldPeriodic;
             const wasJobDisabled = oldJob.state === 'DISABLED';
+            const wasJobArchived = oldJob.archived;
 
-            if (newPeriodic && (isSettingUpdated || wasJobDisabled) && isJobEnabled) {
+            if (
+                newPeriodic &&
+                (isSettingUpdated || wasJobDisabled || wasJobArchived) &&
+                isJobEnabled &&
+                !isJobArchived
+            ) {
                 await this[executor].startPeriodic({
                     pipeline,
                     job: newJob,
@@ -247,7 +254,7 @@ class Job extends BaseModel {
 
                 return this;
             }
-            if ((!newPeriodic && oldPeriodic) || !isJobEnabled || this.archived) {
+            if ((!newPeriodic && oldPeriodic) || !isJobEnabled || isJobArchived) {
                 await this[executor].stopPeriodic({
                     jobId: this.id,
                     pipelineId: pipeline.id,

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -617,6 +617,37 @@ describe('Job Model', () => {
                 assert.calledOnce(datastore.update);
             });
         });
+
+        it('state archived->unarchived should start periodic job', () => {
+            const oldJob = Object.assign({}, job);
+
+            oldJob.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H 9 * * *'
+                    }
+                }
+            ];
+            oldJob.state = 'ENABLED';
+            oldJob.archived = true;
+            jobFactoryMock.get.resolves(oldJob);
+
+            job.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H 9 * * *'
+                    }
+                }
+            ];
+            job.state = 'ENABLED';
+            job.archived = false;
+            datastore.update.resolves(job);
+
+            return job.update().then(() => {
+                assert.calledOnce(executorMock.startPeriodic);
+                assert.calledOnce(datastore.update);
+            });
+        });
     });
 
     describe('remove', () => {


### PR DESCRIPTION
## Context

Transition from archived to unarchived job doesn't add the periodic config back to queue.

## Objective

This PR fixes the issue for archived to unarchived transition.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
