### PR TITLE
fix(2194): trigger from external trigger in child pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -275,7 +275,7 @@ class PipelineModel extends BaseModel {
                     return configPipeline.getConfiguration({});
                 }
 
-                return configPipeline.getConfiguration({ ref, id: this.id });
+                return configPipeline.getConfiguration({ ref, id });
             });
         }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -248,11 +248,13 @@ class PipelineModel extends BaseModel {
      * @param  {Object}  [configuration]       Config object
      * @param  {String}  [configuration.ref]   Reference to get screwdriver.yaml, e.g.sha, prRef, branch
      * @param  {String}  [configuration.isPR]  Flag to indicate if it is getting config for PR
+     * @param  {Number}  [configuration.id]    Id of child pipeline, if the pipeline to be parsed is a child pipeline
      * @return {Promise} Resolves to parsed and flattened configuration
      */
     getConfiguration(configuration) {
         const ref = hoek.reach(configuration, 'ref');
         const isPR = hoek.reach(configuration, 'isPR') || false;
+        const id = hoek.reach(configuration, 'id') || this.id;
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -273,7 +275,7 @@ class PipelineModel extends BaseModel {
                     return configPipeline.getConfiguration({});
                 }
 
-                return configPipeline.getConfiguration({ ref });
+                return configPipeline.getConfiguration({ ref, id: this.id });
             });
         }
 
@@ -304,7 +306,7 @@ class PipelineModel extends BaseModel {
                 // parse the content of the yaml file
                 .then(config => {
                     if (pipelineFactory.getExternalJoinFlag()) {
-                        return parser(config, templateFactory, buildClusterFactory, triggerFactory, this.id);
+                        return parser(config, templateFactory, buildClusterFactory, triggerFactory, id);
                     }
 
                     return parser(config, templateFactory, buildClusterFactory);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1975,7 +1975,7 @@ describe('Pipeline Model', () => {
             pipeline.configPipelineId = 1;
 
             return pipeline.getConfiguration().then(config => {
-                assert.calledWith(configPipelineMock.getConfiguration, { ref: undefined });
+                assert.calledWith(configPipelineMock.getConfiguration, { id: 123, ref: undefined });
                 assert.equal(config, EXTERNAL_PARSED_YAML);
             });
         });
@@ -1989,6 +1989,7 @@ describe('Pipeline Model', () => {
                 })
                 .then(config => {
                     assert.calledWith(configPipelineMock.getConfiguration, {
+                        id: 123,
                         ref: 'bar'
                     });
                     assert.equal(config, EXTERNAL_PARSED_YAML);


### PR DESCRIPTION
## Context
Fix issue https://github.com/screwdriver-cd/screwdriver/issues/2194.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
As shown in the screenshot below, the child pipeline can trigger external triggers on other pipelines.
<img width="1000" src="https://user-images.githubusercontent.com/24538326/92683064-dd1e7600-f36c-11ea-975b-f7230e6d3a5f.png">

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
