### PR TITLE
fix(2232): remove custom step sorting logic

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -660,13 +660,6 @@ class BuildModel extends BaseModel {
                     throw boom.notFound('Steps do not exist');
                 }
 
-                // This if statement should be removed after enough time has passed since build.steps removed.
-                // Make orders of steps in completed builds sure,
-                // because steps in old builds in DB have the order not sorted.
-                if (this.endTime) {
-                    steps.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
-                }
-
                 return Object.assign(deepcopy(this.toJson()), { steps });
             });
     }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1693,14 +1693,14 @@ describe('Build Model', () => {
                 assert.deepStrictEqual(json, expected);
             }));
 
-        it('returns the JSON with steps sorted by step.createTime', () => {
+        it('always returns the JSON with steps sorted by step.id', () => {
             const configWithEndTime = { ...config };
 
             configWithEndTime.endTime = '2019-01-22T22:30: 00.000Z';
             build = new BuildModel(configWithEndTime);
 
             return build.toJsonWithSteps().then(json => {
-                const expected = { ...build.toJson(), steps: [step2, step3, step1] };
+                const expected = { ...build.toJson(), steps: [step1, step2, step3] };
 
                 assert.deepStrictEqual(json, expected);
             });


### PR DESCRIPTION
## Context

To address https://github.com/screwdriver-cd/screwdriver/issues/2232 this PR will start showing steps in order. While the actual fix for this issue should be a problem with the build cluster, we can start with making sure steps are displayed in order. 

## Objective

Remove custom step sorting logic. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/2232

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
