### PR TITLE
fix(2258): allow buildCluster to use weightage 0

### DIFF
--- a/lib/buildClusterFactory.js
+++ b/lib/buildClusterFactory.js
@@ -43,7 +43,7 @@ class BuildClusterFactory extends BaseFactory {
             config.isActive = true;
         }
 
-        if (!config.weightage) {
+        if (!config.weightage && config.weightage !== 0) {
             config.weightage = 100;
         }
 


### PR DESCRIPTION
## Context
We want to create a build cluster that can be used by anyone with annotation but will not be randomly selected if the annotation is not specified.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
The buildClusterFactory be able to set weightage 0.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2258

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
