### PR TITLE
fix(1044): support blanket exclusions

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -238,6 +238,13 @@ function startBuild(config) {
                 return isMatchExclude;
             });
 
+            // sourcePath is only exclude
+            const notOnlyExclude = paths.some(source => source.startsWith('!') === false);
+
+            if (!notOnlyExclude && isFileExclude === false) {
+                return true;
+            }
+
             return isFileMatch && !isFileExclude;
         });
     }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -239,9 +239,9 @@ function startBuild(config) {
             });
 
             // sourcePath is only exclude
-            const notOnlyExclude = paths.some(source => source.startsWith('!') === false);
+            const onlyExclude = paths.every(source => source.startsWith('!') === true);
 
-            if (!notOnlyExclude && isFileExclude === false) {
+            if (onlyExclude && !isFileExclude) {
                 return true;
             }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Now sourcePaths will not start the build if exclude only sourcePaths is set.
For example, `screwdriver.yaml` like the following
```
jobs:
  build1:
    image: node12
    requires: [ ~commit  ]
    sourcePaths: ["!README.md"]
    steps:
      - echo "this is build1"
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add a step so that the build will start when sourcePaths is exclude only.

## References

issue: https://github.com/screwdriver-cd/screwdriver/issues/1044
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
