### PR TITLE
[1]fix(1815): Change _getFullNameAndVersion method to getFullNameAndVersion

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -10,6 +10,7 @@ const TEMPLATE_NAME_REGEX = schema.config.regex.FULL_TEMPLATE_NAME;
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const EXACT_VERSION_REGEX = schema.config.regex.EXACT_VERSION;
 const VERSION_REGEX = schema.config.regex.VERSION;
+const TAG_REGEX = schema.config.regex.TEMPLATE_TAG_NAME;
 let instance;
 
 class TemplateFactory extends BaseFactory {
@@ -45,20 +46,22 @@ class TemplateFactory extends BaseFactory {
     /**
      * Parses full template name to return an object with
      * full template name, versionOrTag, isExactVersion, and isVersion
-     * @method _getFullNameAndVersion
+     * @method getFullNameAndVersion
      * @param  {String} fullTemplateName Full template name (e.g.: chefdk/knife@1.2.3 or chefdk/knife@stable)
      * @return {Object}                  Object with template metadata
      */
-    _getFullNameAndVersion(fullTemplateName) {
+    getFullNameAndVersion(fullTemplateName) {
         const [, templateName, versionOrTag] = TEMPLATE_NAME_REGEX.exec(fullTemplateName);
         const isExactVersion = EXACT_VERSION_REGEX.exec(versionOrTag);
         const isVersion = VERSION_REGEX.exec(versionOrTag);
+        const isTag = versionOrTag ? versionOrTag.match(TAG_REGEX) : null;
 
         return {
             templateName, // not yet parsed for namespace
             versionOrTag,
             isExactVersion,
-            isVersion
+            isVersion,
+            isTag
         };
     }
 
@@ -276,7 +279,7 @@ class TemplateFactory extends BaseFactory {
      */
     getTemplate(fullTemplateName) {
         // eslint-disable-next-line max-len, no-underscore-dangle
-        const { templateName, versionOrTag, isExactVersion, isVersion } = this._getFullNameAndVersion(fullTemplateName);
+        const { templateName, versionOrTag, isExactVersion, isVersion } = this.getFullNameAndVersion(fullTemplateName);
 
         if (isExactVersion) {
             // Get a template using the exact template version

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -91,6 +91,48 @@ describe('Template Factory', () => {
         });
     });
 
+    describe('getFullNameAndVersion', () => {
+        it('versionOrTag is exact version', () => {
+            const template = factory.getFullNameAndVersion('foo/bar@1.2.3');
+
+            assert.equal(template.templateName, 'foo/bar');
+            assert.equal(template.versionOrTag, '1.2.3');
+            assert.isOk(template.isExactVersion);
+            assert.isOk(template.isVersion);
+            assert.isNotOk(template.isTag);
+        });
+
+        it('versionOrTag is not exact version', () => {
+            const template = factory.getFullNameAndVersion('foo/bar@1.2');
+
+            assert.equal(template.templateName, 'foo/bar');
+            assert.equal(template.versionOrTag, '1.2');
+            assert.isNotOk(template.isExactVersion);
+            assert.isOk(template.isVersion);
+            assert.isNotOk(template.isTag);
+        });
+
+        it('versionOrTag is tag', () => {
+            const template = factory.getFullNameAndVersion('foo/bar@stable');
+
+            assert.equal(template.templateName, 'foo/bar');
+            assert.equal(template.versionOrTag, 'stable');
+            assert.isNotOk(template.isExactVersion);
+            assert.isNotOk(template.isVersion);
+            assert.isOk(template.isTag);
+        });
+
+        it('versionOrTag is empty', () => {
+            const template = factory.getFullNameAndVersion('foo/bar');
+
+            assert.equal(template.templateName, 'foo/bar');
+            assert.isUndefined(template.versionOrTag);
+            assert.isNotOk(template.isExactVersion);
+            assert.isNotOk(template.isVersion);
+            assert.isNotOk(template.isTag);
+        });
+    });
+
     describe('create', () => {
         const generatedId = 1234135;
         let expected;


### PR DESCRIPTION
## Context
If versionOrTag is not specified with the template, the validator will output a warning.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Enables config-parser(<https://github.com/screwdriver-cd/config-parser/pull/116>)  to use `isVersion` and `isTag`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1815

[1] : https://github.com/screwdriver-cd/models/pull/484  (This PR)
[2] : https://github.com/screwdriver-cd/config-parser/pull/116
[3] : https://github.com/screwdriver-cd/ui/pull/650
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
