### PR TITLE
fix(2311): Make /v4/events performance better

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -231,8 +231,10 @@ class Job extends BaseModel {
 
         try {
             const newPeriodic = getAnnotations(newJob.permutations[0], 'screwdriver.cd/buildPeriodically');
-            const isJobEnabled = newJob.state === 'ENABLED';
-            const isJobArchived = newJob.archived;
+            const newIsJobEnabled = newJob.state === 'ENABLED';
+            const oldIsJobEnabled = oldJob.state === 'ENABLED';
+            const newIsJobArchived = newJob.archived;
+            const oldIsJobArchived = oldJob.archived;
             const isSettingUpdated = newPeriodic ? newPeriodic !== oldPeriodic : !!oldPeriodic;
             const wasJobDisabled = oldJob.state === 'DISABLED';
             const wasJobArchived = oldJob.archived;
@@ -240,8 +242,8 @@ class Job extends BaseModel {
             if (
                 newPeriodic &&
                 (isSettingUpdated || wasJobDisabled || wasJobArchived) &&
-                isJobEnabled &&
-                !isJobArchived
+                newIsJobEnabled &&
+                !newIsJobArchived
             ) {
                 await this[executor].startPeriodic({
                     pipeline,
@@ -254,7 +256,11 @@ class Job extends BaseModel {
 
                 return this;
             }
-            if ((!newPeriodic && oldPeriodic) || !isJobEnabled || isJobArchived) {
+            if (
+                (!newPeriodic && oldPeriodic) ||
+                (!newIsJobEnabled && oldIsJobEnabled) ||
+                (newIsJobArchived && !oldIsJobArchived)
+            ) {
                 await this[executor].stopPeriodic({
                     jobId: this.id,
                     pipelineId: pipeline.id,

--- a/lib/job.js
+++ b/lib/job.js
@@ -231,19 +231,17 @@ class Job extends BaseModel {
 
         try {
             const newPeriodic = getAnnotations(newJob.permutations[0], 'screwdriver.cd/buildPeriodically');
-            const newIsJobEnabled = newJob.state === 'ENABLED';
-            const oldIsJobEnabled = oldJob.state === 'ENABLED';
-            const newIsJobArchived = newJob.archived;
-            const oldIsJobArchived = oldJob.archived;
+            const isNewJobEnabled = newJob.state === 'ENABLED';
+            const isOldJobEnabled = oldJob.state === 'ENABLED';
+            const isNewJobArchived = newJob.archived;
+            const isOldJobArchived = oldJob.archived;
             const isSettingUpdated = newPeriodic ? newPeriodic !== oldPeriodic : !!oldPeriodic;
-            const wasJobDisabled = oldJob.state === 'DISABLED';
-            const wasJobArchived = oldJob.archived;
 
             if (
                 newPeriodic &&
-                (isSettingUpdated || wasJobDisabled || wasJobArchived) &&
-                newIsJobEnabled &&
-                !newIsJobArchived
+                (isSettingUpdated || !isOldJobEnabled || isOldJobArchived) &&
+                isNewJobEnabled &&
+                !isNewJobArchived
             ) {
                 await this[executor].startPeriodic({
                     pipeline,
@@ -258,8 +256,8 @@ class Job extends BaseModel {
             }
             if (
                 (!newPeriodic && oldPeriodic) ||
-                (!newIsJobEnabled && oldIsJobEnabled) ||
-                (newIsJobArchived && !oldIsJobArchived)
+                (!isNewJobEnabled && isOldJobEnabled) ||
+                (isNewJobArchived && !isOldJobArchived)
             ) {
                 await this[executor].stopPeriodic({
                     jobId: this.id,

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -436,6 +436,16 @@ describe('Job Model', () => {
 
     describe('update', () => {
         it('Update a job and remove periodic, when job is disabled', () => {
+            const oldJob = Object.assign({}, job);
+
+            oldJob.permutations = [
+                {
+                    annotations: {}
+                }
+            ];
+            oldJob.state = 'ENABLED';
+            jobFactoryMock.get.resolves(oldJob);
+
             job.state = 'DISABLED';
             job.permutations = [
                 {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -559,6 +559,18 @@ describe('Job Model', () => {
         });
 
         it('no change of buildPeriodically', () => {
+            const oldJob = Object.assign({}, job);
+
+            oldJob.state = 'ENABLED';
+            oldJob.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H 9 * * *'
+                    }
+                }
+            ];
+            jobFactoryMock.get.resolves(oldJob);
+
             job.permutations = [
                 {
                     annotations: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`v4/events` performance issue makes problem like https://github.com/screwdriver-cd/screwdriver/issues/2311
This PR make the performance better.

In my sandbox the performance becomes for 6500 archived jobs:
120028ms -> 82047ms
(still its too large)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Make `v4/events` performance better by reducing enormous `DELETE /v1/queue/message`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Please do **not** close these issues after this PR is merged. This is not complete solution.

https://github.com/screwdriver-cd/screwdriver/issues/2318
https://github.com/screwdriver-cd/screwdriver/issues/2311

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
