### PR TITLE
feat(2339): [2] Pass in notificationsValidationErr flag to config parser

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -321,11 +321,20 @@ class PipelineModel extends BaseModel {
                 })
                 // parse the content of the yaml file
                 .then(config => {
+                    let parserConfig = {
+                        yaml: config,
+                        templateFactory,
+                        buildClusterFactory,
+                        notificationsValidationErr: pipelineFactory.getNotificationsValidationErrFlag()
+                    };
+
                     if (pipelineFactory.getExternalJoinFlag()) {
-                        return parser(config, templateFactory, buildClusterFactory, triggerFactory, id);
+                        const joinConfig = { triggerFactory, pipelineId: id };
+
+                        parserConfig = { ...parserConfig, ...joinConfig };
                     }
 
-                    return parser(config, templateFactory, buildClusterFactory);
+                    return parser(parserConfig);
                 })
         );
     }

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -9,14 +9,16 @@ class PipelineFactory extends BaseFactory {
      * Construct a JobFactory object
      * @method constructor
      * @param  {Object}    config
-     * @param  {Object}    config.datastore         Object that will perform operations on the datastore
-     * @param  {Boolean}   config.multiBuildClusterEnabled  Enable multiple build cluster feature or not
-     * @param  {Boolean}   config.externalJoin      Flag to allow external join
+     * @param  {Object}    config.datastore                     Object that will perform operations on the datastore
+     * @param  {Boolean}   config.multiBuildClusterEnabled      Enable multiple build cluster feature or not
+     * @param  {Boolean}   config.externalJoin                  Flag to allow external join
+     * @param  {Boolean}   config.notificationsValidationErr    Flag to throw error for notification validation or not
      */
     constructor(config) {
         super('pipeline', config);
         this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
         this.externalJoin = config.externalJoin || false;
+        this.notificationsValidationErr = config.notificationsValidationErr;
     }
 
     /**
@@ -115,6 +117,14 @@ class PipelineFactory extends BaseFactory {
      */
     getExternalJoinFlag() {
         return this.externalJoin;
+    }
+
+    /**
+     * Return notification validation error flag
+     * @return {Boolean}
+     */
+    getNotificationsValidationErrFlag() {
+        return this.notificationsValidationErr;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "deepcopy": "^2.0.0",
     "docker-parse-image": "^3.0.1",
     "lodash": "^4.17.20",
-    "screwdriver-config-parser": "^6.1.1",
+    "screwdriver-config-parser": "^7.0.0",
     "screwdriver-data-schema": "^21.0.0",
     "screwdriver-logger": "^1.0.0",
     "screwdriver-workflow-parser": "^3.1.1"

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -266,4 +266,26 @@ describe('Pipeline Factory', () => {
             assert.isFalse(factory.getExternalJoinFlag());
         });
     });
+
+    describe('getNotificationsValidationErr', () => {
+        beforeEach(() => {
+            // eslint-disable-next-line global-require
+            PipelineFactory = require('../../lib/pipelineFactory');
+            factory = new PipelineFactory(pipelineConfig);
+        });
+
+        it('getNotificationsValidationErr returns undefined', () => {
+            assert.isUndefined(factory.getNotificationsValidationErrFlag());
+        });
+
+        it('getNotificationsValidationErr returns false', () => {
+            factory.notificationsValidationErr = false;
+            assert.isFalse(factory.getNotificationsValidationErrFlag());
+        });
+
+        it('getNotificationsValidationErr returns true', () => {
+            factory.notificationsValidationErr = true;
+            assert.isTrue(factory.getNotificationsValidationErrFlag());
+        });
+    });
 });


### PR DESCRIPTION
## Context

It would be nice if there was an option to have invalid notifications not throw errors.

## Objective

This PR passes in the `notificationsValidationErr` flag to config parser, also uses latest config-parser.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2339
Blocked by https://github.com/screwdriver-cd/config-parser/pull/120

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
