### PR TITLE
fix(2350): new template/command should inherit trusted property

### DIFF
--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -85,9 +85,7 @@ class CommandFactory extends BaseFactory {
                     const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
                     config.version = `${latestMajor}${latestMinor}.${patch}`;
-
-                    // eslint-disable-next-line no-unneeded-ternary
-                    config.trusted = latestCommand.trusted ? true : false;
+                    config.trusted = latestCommand.trusted || false;
                 }
 
                 config.createTime = new Date().toISOString();

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -78,13 +78,16 @@ class CommandFactory extends BaseFactory {
             .then(latestCommand => {
                 if (!latestCommand) {
                     config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
+                    config.trusted = false;
                 } else {
                     // eslint-disable-next-line max-len
                     const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestCommand.version);
                     const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
                     config.version = `${latestMajor}${latestMinor}.${patch}`;
-                    config.trusted = latestCommand.trusted;
+
+                    // eslint-disable-next-line no-unneeded-ternary
+                    config.trusted = latestCommand.trusted ? true : false;
                 }
 
                 config.createTime = new Date().toISOString();

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -70,20 +70,21 @@ class CommandFactory extends BaseFactory {
                 if (latestCommand) {
                     latestCommand.latest = false;
 
-                    return latestCommand.update().then(() => latestCommand.version);
+                    return latestCommand.update().then(() => latestCommand);
                 }
 
                 return null;
             })
-            .then(latestVersion => {
-                if (!latestVersion) {
+            .then(latestCommand => {
+                if (!latestCommand) {
                     config.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
                 } else {
                     // eslint-disable-next-line max-len
-                    const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestVersion);
+                    const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestCommand.version);
                     const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
                     config.version = `${latestMajor}${latestMinor}.${patch}`;
+                    config.trusted = latestCommand.trusted;
                 }
 
                 config.createTime = new Date().toISOString();

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -152,20 +152,21 @@ class TemplateFactory extends BaseFactory {
                 if (latestTemplate) {
                     latestTemplate.latest = false;
 
-                    return latestTemplate.update().then(() => latestTemplate.version);
+                    return latestTemplate.update().then(() => latestTemplate);
                 }
 
                 return null;
             })
-            .then(latestVersion => {
-                if (!latestVersion) {
+            .then(latestTemplate => {
+                if (!latestTemplate) {
                     result.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
                 } else {
                     // eslint-disable-next-line max-len
-                    const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestVersion);
+                    const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestTemplate.version);
                     const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
                     result.version = `${latestMajor}${latestMinor}.${patch}`;
+                    result.trusted = latestTemplate.trusted;
                 }
 
                 result.createTime = new Date().toISOString();

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -160,13 +160,16 @@ class TemplateFactory extends BaseFactory {
             .then(latestTemplate => {
                 if (!latestTemplate) {
                     result.version = minor ? `${major}${minor}.0` : `${major}.0.0`;
+                    result.trusted = false;
                 } else {
                     // eslint-disable-next-line max-len
                     const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestTemplate.version);
                     const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
                     result.version = `${latestMajor}${latestMinor}.${patch}`;
-                    result.trusted = latestTemplate.trusted;
+
+                    // eslint-disable-next-line no-unneeded-ternary
+                    result.trusted = latestTemplate.trusted ? true : false;
                 }
 
                 result.createTime = new Date().toISOString();

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -167,9 +167,7 @@ class TemplateFactory extends BaseFactory {
                     const patch = parseInt(latestPatch.slice(1), 10) + 1;
 
                     result.version = `${latestMajor}${latestMinor}.${patch}`;
-
-                    // eslint-disable-next-line no-unneeded-ternary
-                    result.trusted = latestTemplate.trusted ? true : false;
+                    result.trusted = latestTemplate.trusted || false;
                 }
 
                 result.createTime = new Date().toISOString();

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -99,7 +99,8 @@ describe('Command Factory', () => {
                 format,
                 habitat,
                 id: generatedId,
-                pipelineId
+                pipelineId,
+                trusted: false
             };
         });
 

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -197,6 +197,53 @@ describe('Command Factory', () => {
                     });
                 });
         });
+
+        it('creates a trusted Command if latest Command was trusted', () => {
+            const latest = {
+                namespace,
+                name,
+                version: `${version}.0`,
+                maintainer,
+                description,
+                format,
+                habitat,
+                id: generatedId,
+                pipelineId,
+                trusted: true
+            };
+
+            expected.version = `${version}.1`;
+            expected.trusted = true;
+
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([latest]);
+            datastore.update.resolves(latest);
+
+            return factory
+                .create({
+                    namespace,
+                    name,
+                    version,
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    pipelineId
+                })
+                .then(model => {
+                    assert.instanceOf(model, Command);
+                    assert.calledWith(datastore.update, {
+                        table: 'commands',
+                        params: {
+                            id: 1234135,
+                            latest: false
+                        }
+                    });
+                    Object.keys(expected).forEach(key => {
+                        assert.strictEqual(model[key], expected[key]);
+                    });
+                });
+        });
     });
 
     describe('getInstance', () => {

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -147,7 +147,8 @@ describe('Template Factory', () => {
                 labels,
                 config: templateConfig,
                 pipelineId,
-                id: generatedId
+                id: generatedId,
+                trusted: false
             };
         });
 

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -320,6 +320,51 @@ describe('Template Factory', () => {
                     });
                 });
         });
+
+        it('creates a trusted Template if latest Template was trusted', () => {
+            const latest = {
+                name,
+                version: `${version}.0`,
+                maintainer,
+                description,
+                labels,
+                config: templateConfig,
+                pipelineId,
+                id: generatedId,
+                trusted: true
+            };
+
+            expected.version = `${version}.1`;
+            expected.trusted = true;
+
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([latest]);
+            datastore.update.resolves(latest);
+
+            return factory
+                .create({
+                    name,
+                    version,
+                    maintainer,
+                    description,
+                    labels,
+                    config: templateConfig,
+                    pipelineId
+                })
+                .then(model => {
+                    assert.instanceOf(model, Template);
+                    assert.calledWith(datastore.update, {
+                        table: 'templates',
+                        params: {
+                            id: 1234135,
+                            latest: false
+                        }
+                    });
+                    Object.keys(expected).forEach(key => {
+                        assert.deepEqual(model[key], expected[key]);
+                    });
+                });
+        });
     });
 
     describe('getInstance', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
creating new template/command does not inherit trusted property
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
new template/command should inherit trusted property
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2350
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
