### PR TITLE
fix(2356): if executor is not queue use temporal scope for build token

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -10,7 +10,6 @@ const BaseModel = require('./base');
 
 // Symbols for private members
 const executor = Symbol('executor');
-const executorName = Symbol('executorName');
 const apiUri = Symbol('apiUri');
 const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
@@ -235,7 +234,7 @@ function getToken(self, job, pipeline) {
     }
 
     // use temporal scope unless executor is queue
-    const tokenSkope = self[executorName] === 'queue' ? 'sdapi' : 'temporal';
+    const tokenSkope = self[executor].name === 'queue' ? 'sdapi' : 'temporal';
 
     const token = self[tokenGen](self.id, tokenGenConfig, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT, [tokenSkope]);
 
@@ -259,7 +258,6 @@ class BuildModel extends BaseModel {
     constructor(config) {
         super('build', config);
         this[executor] = config.executor;
-        this[executorName] = config.executorName;
         this[apiUri] = config.apiUri;
         this[tokenGen] = config.tokenGen;
         this[uiUri] = config.uiUri;

--- a/lib/build.js
+++ b/lib/build.js
@@ -10,6 +10,7 @@ const BaseModel = require('./base');
 
 // Symbols for private members
 const executor = Symbol('executor');
+const executorName = Symbol('executorName');
 const apiUri = Symbol('apiUri');
 const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
@@ -233,7 +234,10 @@ function getToken(self, job, pipeline) {
         tokenGenConfig.prParentJobId = job.prParentJobId;
     }
 
-    const token = self[tokenGen](self.id, tokenGenConfig, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT, ['sdapi']);
+    // use temporal scope unless executor is queue
+    const tokenSkope = self[executorName] === 'queue' ? 'sdapi' : 'temporal';
+
+    const token = self[tokenGen](self.id, tokenGenConfig, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT, [tokenSkope]);
 
     return token;
 }
@@ -255,6 +259,7 @@ class BuildModel extends BaseModel {
     constructor(config) {
         super('build', config);
         this[executor] = config.executor;
+        this[executorName] = config.executorName;
         this[apiUri] = config.apiUri;
         this[tokenGen] = config.tokenGen;
         this[uiUri] = config.uiUri;

--- a/lib/build.js
+++ b/lib/build.js
@@ -234,9 +234,9 @@ function getToken(self, job, pipeline) {
     }
 
     // use temporal scope unless executor is queue
-    const tokenSkope = self[executor].name === 'queue' ? 'sdapi' : 'temporal';
+    const tokenScope = self[executor].name === 'queue' ? 'sdapi' : 'temporal';
 
-    const token = self[tokenGen](self.id, tokenGenConfig, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT, [tokenSkope]);
+    const token = self[tokenGen](self.id, tokenGenConfig, pipeline.scmContext, TEMPORAL_JWT_TIMEOUT, [tokenScope]);
 
     return token;
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     }
   },
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.0",
     "eslint": "^7.11.0",
-    "eslint-config-screwdriver": "^5.0.3",
+    "eslint-config-screwdriver": "^5.0.6",
     "mocha": "^8.2.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
@@ -48,7 +48,7 @@
     "sinon": "^9.2.0"
   },
   "dependencies": {
-    "@hapi/boom": "^9.1.0",
+    "@hapi/boom": "^9.1.1",
     "@hapi/hoek": "^9.1.0",
     "@hapi/iron": "^6.0.0",
     "async": "^2.6.3",
@@ -60,7 +60,7 @@
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.0.0",
     "screwdriver-data-schema": "^21.0.0",
-    "screwdriver-logger": "^1.0.0",
+    "screwdriver-logger": "^1.0.2",
     "screwdriver-workflow-parser": "^3.1.1"
   }
 }


### PR DESCRIPTION
## Context

To have local development work, generate temporal scope token of executor is not queue

## Objective

https://github.com/screwdriver-cd/screwdriver/issues/2356

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
