### PR TITLE
fix(2318): POST /v4/events performance

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -843,7 +843,7 @@ class PipelineModel extends BaseModel {
         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
         const pipelineId = this.id;
 
-        // Loop through all existing jobs
+        // Loop through non-PR existing jobs
         for (const jobChunks of getJobChunks(existingJobs)) {
             await Promise.all(
                 jobChunks.map(async job => {
@@ -863,11 +863,9 @@ class PipelineModel extends BaseModel {
                         job.templateId = templateId;
                         job.archived = false;
                         updatedJobs.push(await job.update());
-                    } else if (!job.isPR()) {
-                        if (!job.archived) {
-                            job.archived = true;
-                            updatedJobs.push(await job.update());
-                        }
+                    } else if (!job.archived) {
+                        job.archived = true;
+                        updatedJobs.push(await job.update());
                     }
 
                     // sync external triggers for existing jobs

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -836,7 +836,7 @@ class PipelineModel extends BaseModel {
             }
         }
 
-        const existingJobs = await this.jobs;
+        const existingJobs = (await this.jobs).filter(j => !j.isPR());
 
         const jobsProcessed = [];
         const updatedJobs = [];


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix the following issue.
https://github.com/screwdriver-cd/screwdriver/issues/2318

`syncExternalTriggers` is being called for `PR-Job`, resulting in increased access to the database.
Since `PR-Jobs` are never specified as external triggers, we can improve the processing speed by removing `PR-Jobs`.

https://github.com/screwdriver-cd/models/blob/c56a23d6930c6767d2f6d8f3dd0e88bb8c79366f/lib/pipeline.js#L846-L885

[In this line](https://github.com/screwdriver-cd/models/blob/c56a23d6930c6767d2f6d8f3dd0e88bb8c79366f/lib/pipeline.js#L881) the PR job is added to `jobsProcessed` with the value `PR-xxx`. Therefore, `jobsProcessed` is used here ([i.e. line 897](https://github.com/screwdriver-cd/models/blob/c56a23d6930c6767d2f6d8f3dd0e88bb8c79366f/lib/pipeline.js#L899)), but at that stage, PR jobs are not eligible for matching even though they are in `jobsProcessed`.  In this loop, no PR-job is needed.



The following is an example of a change in v4/events velocity
In my sandbox, it looks like this
```
Archived jobs(PR) : 4000
Before: 20.80s
After: 5.62s
```
It's going to be fast.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Filter the `PR-Job` so that it is not included in the `existingJobs`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Issue
- https://github.com/screwdriver-cd/screwdriver/issues/2318

Here are the PRs so far
- https://github.com/screwdriver-cd/models/pull/485
- https://github.com/screwdriver-cd/models/pull/489
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
