### PR TITLE
fix: add log on build stop

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -591,7 +591,7 @@ class BuildModel extends BaseModel {
             )
             .then(() => this)
             .catch(err => {
-                console.log(`Failed to stop a build: ${err}`);
+                logger.error(`Failed to stop a build: ${err}`);
 
                 return Promise.reject(err);
             });

--- a/lib/build.js
+++ b/lib/build.js
@@ -589,7 +589,12 @@ class BuildModel extends BaseModel {
                         return this[executor].stop(config).then(() => this[executor].stopTimer(config));
                     })
             )
-            .then(() => this);
+            .then(() => this)
+            .catch(err => {
+                console.log(`Failed to stop a build: ${err}`);
+
+                return Promise.reject(err);
+            });
     }
 
     /**


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I wanted to see the error when the build stop failed, but I couldn't.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
We can see the error log when a build stop failed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
