### PR TITLE
fix(2071): add try catch to build create

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -268,7 +268,14 @@ class BuildFactory extends BaseFactory {
 
                     modelConfig.stats = {};
 
-                    const build = await super.create(modelConfig);
+                    let build;
+
+                    try {
+                        build = await super.create(modelConfig);
+                    } catch (err) {
+                        logger.error(`Error in BuildFactory create - buildId:${build.id}`, err);
+                        return null;    
+                    }
 
                     // eslint-disable-next-line no-restricted-syntax
                     for (const step of steps) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
build create will throw unique constraint error after https://github.com/screwdriver-cd/data-schema/pull/443
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add try catch to guard build create
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2071
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
