### PR TITLE
fix: Allow pending status for GitHub PR meta status check [1]

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -189,11 +189,12 @@ function getStatusConfig({ metadata }) {
 
         const defaultMessages = {
             success: `${fieldName} check succeeded`,
-            failure: `${fieldName} check failed`
+            failure: `${fieldName} check failed`,
+            pending: `${fieldName} check pending`
         };
         const status = hoek.reach(checkObject, 'status', { default: 'success' });
         const message = hoek.reach(checkObject, 'message', {
-            default: defaultMessages[status] || defaultMessages.failure
+            default: defaultMessages[status] || defaultMessages.success
         });
         const url = hoek.reach(checkObject, 'url') ? encodeURI(hoek.reach(checkObject, 'url')) : null;
         const config = {

--- a/lib/build.js
+++ b/lib/build.js
@@ -192,9 +192,9 @@ function getStatusConfig({ metadata }) {
             failure: `${fieldName} check failed`,
             pending: `${fieldName} check pending`
         };
-        const status = hoek.reach(checkObject, 'status', { default: 'success' });
+        const status = hoek.reach(checkObject, 'status', { default: 'pending' });
         const message = hoek.reach(checkObject, 'message', {
-            default: defaultMessages[status] || defaultMessages.success
+            default: defaultMessages[status] || defaultMessages.pending
         });
         const url = hoek.reach(checkObject, 'url') ? encodeURI(hoek.reach(checkObject, 'url')) : null;
         const config = {


### PR DESCRIPTION
## Context

Users might want to report on a PENDING status for GitHub PR.

## Objective

This PR adds a default message for PENDING status, also changes default message to match default status (SUCCESS).

## References

N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
