### PR TITLE
feat: Add stopFrozen to build model

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -598,6 +598,30 @@ class BuildModel extends BaseModel {
     }
 
     /**
+     * Stops a frozen build
+     * @method stopFrozen
+     * @param  {string}  previousStatus  The previous build status
+     * @return {Promise}
+     */
+    stopFrozen(previousStatus) {
+        return this.job
+            .then(job =>
+                job.pipeline.then(pipeline => {
+                    const config = {
+                        buildId: this.id,
+                        jobId: job.id,
+                        pipelineId: pipeline.id,
+                        token: getToken(this, job, pipeline),
+                        status: previousStatus
+                    };
+
+                    return this[executor].stopFrozen(config);
+                })
+            )
+            .then(() => this);
+    }
+
+    /**
      * Check if a build is done
      * @method isDone
      * @return boolean

--- a/lib/build.js
+++ b/lib/build.js
@@ -600,7 +600,7 @@ class BuildModel extends BaseModel {
     /**
      * Stops a frozen build
      * @method stopFrozen
-     * @param  {string}  previousStatus  The previous build status
+     * @param  {String}  previousStatus  The previous build status
      * @return {Promise}
      */
     stopFrozen(previousStatus) {

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -75,7 +75,8 @@ describe('Build Model', () => {
             start: sinon.stub(),
             stop: sinon.stub(),
             startTimer: sinon.stub(),
-            stopTimer: sinon.stub()
+            stopTimer: sinon.stub(),
+            stopFrozen: sinon.stub()
         };
         userFactoryMock = {
             get: sinon.stub()
@@ -1713,6 +1714,41 @@ describe('Build Model', () => {
                 .toJsonWithSteps()
                 .then(() => assert.fail('nope'))
                 .catch(err => assert.equal('Steps do not exist', err.message));
+        });
+    });
+
+    describe('stopFrozen', () => {
+        const previousStatus = 'FROZEN';
+
+        beforeEach(() => {
+            executorMock.stopFrozen.resolves(null);
+            jobFactoryMock.get.resolves(jobMock);
+        });
+
+        it('promises to stop a frozen build', () =>
+            build.stopFrozen(previousStatus).then(() => {
+                assert.calledWith(executorMock.stopFrozen, {
+                    buildId,
+                    jobId,
+                    pipelineId,
+                    token: 'equivalentToOneQuarter',
+                    status: previousStatus
+                });
+            }));
+
+        it('rejects on executor failure', () => {
+            const expectedError = new Error('cantStopTheRock');
+
+            executorMock.stopFrozen.rejects(expectedError);
+
+            return build
+                .stopFrozen(previousStatus)
+                .then(() => {
+                    assert.fail('This should not fail the test');
+                })
+                .catch(err => {
+                    assert.deepEqual(err, expectedError);
+                });
         });
     });
 });


### PR DESCRIPTION
## Context

Screwdriver needs a way to allow users to abort a build that has entered frozen state

## Objective

This PR adds a function to models to stop frozen builds

## References

https://github.com/screwdriver-cd/screwdriver/issues/2410

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
