### PR TITLE
fix: Revert to default meta status

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -192,9 +192,9 @@ function getStatusConfig({ metadata }) {
             failure: `${fieldName} check failed`,
             pending: `${fieldName} check pending`
         };
-        const status = hoek.reach(checkObject, 'status', { default: 'pending' });
+        const status = hoek.reach(checkObject, 'status', { default: 'success' });
         const message = hoek.reach(checkObject, 'message', {
-            default: defaultMessages[status] || defaultMessages.pending
+            default: defaultMessages[status] || defaultMessages.failure
         });
         const url = hoek.reach(checkObject, 'url') ? encodeURI(hoek.reach(checkObject, 'url')) : null;
         const config = {


### PR DESCRIPTION
## Context

Seems more intuitive to only check on SUCCESS status, have default message as FAILURE. 

## Objective

This PR reverts previous default status change: https://github.com/screwdriver-cd/models/pull/496/files

## References
Related to https://github.com/screwdriver-cd/models/pull/496

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
