### PR TITLE
fix(2350): Infer namespace from template name during create

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -145,7 +145,7 @@ class TemplateFactory extends BaseFactory {
         const result = hoek.applyToDefaults(config, nameObj);
 
         return super
-            .list({ params: { namespace: config.namespace, name: config.name, latest: true } })
+            .list({ params: { namespace: result.namespace, name: result.name, latest: true } })
             .then(templates => {
                 const latestTemplate = templates[0];
 


### PR DESCRIPTION
## Context

Some users might not have `namespace` explicitly defined for template, so it will not appear in the config.

## Objective

This PR uses `parseTemplateConfigName` results to determine `namespace` field.

## References

Related to https://github.com/screwdriver-cd/models/pull/495

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
