### PR TITLE
fix: remove build steps when removing build

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -563,6 +563,16 @@ class BuildModel extends BaseModel {
     }
 
     /**
+     * Remove all steps associated with this build and the build itself
+     * @return {Promise}        Resolves to null if remove successfully
+     */
+    remove() {
+        return this.getSteps()
+            .then(steps => Promise.all(steps.map(t => t.remove())))
+            .then(() => super.remove());
+    }
+
+    /**
      * Stop a build
      * @method stop
      * @return {Promise}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
currently screwdriver does not remove build steps when removing a build

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
remove build steps when removing a build
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
