### PR TITLE
feat(2437): create or update child pipelines with read-only SCM [5]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -669,6 +669,26 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * This function gets a headless user.
+     * @method _getHeadlessToken
+     * @param {String}  username    Headless username
+     * @param {String}  scmContext  Scm context
+     * @return {Promise}
+     */
+    async _getHeadlessToken({ username, scmContext }) {
+        /* eslint-disable global-require */
+        const UserFactory = require('./userFactory');
+        /* eslint-enable global-require */
+        const factory = UserFactory.getInstance();
+        const user = await factory.get({
+            username,
+            scmContext
+        });
+
+        return user.unsealToken();
+    }
+
+    /**
      * Update or create a pipeline given a scmUrl
      * @method _createOrUpdatePipeline
      * @param {String} scmUrl  checkout url for a repository
@@ -678,7 +698,7 @@ class PipelineModel extends BaseModel {
         const pipelineFactory = this._getPipelineFactory();
         const { admins } = this;
         const newAdmins = admins;
-        const token = await this.token;
+        let token = await this.token;
 
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
@@ -695,13 +715,15 @@ class PipelineModel extends BaseModel {
 
             if (!readOnlyEnabled) {
                 logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
-                throw new Error(`User does not have push permission for this scm ${scmContext}`);
+
+                return null;
             }
 
             const genericUsername = this.scm.getUsername({ scmContext });
-            // TODO: get genericUser, unseal token, pass to _getScmUri
 
-            if (!admins[genericUsername]) {
+            token = await this._getHeadlessToken({ username: genericUsername, scmContext });
+
+            if (!newAdmins[genericUsername]) {
                 newAdmins[genericUsername] = {
                     push: true,
                     admin: true,
@@ -711,6 +733,17 @@ class PipelineModel extends BaseModel {
         }
 
         const scmUri = await this._getScmUri({ scmUrl, scmContext, token });
+
+        // Check permissions
+        const hasAdminPermission = await this._hasAdminPermission(scmUri);
+
+        if (!hasAdminPermission && !readOnlyEnabled) {
+            // TODO: figure out how to bubble up this err to user
+            logger.error(`pipelineId:${this.id}: No admins have admin permission on ${scmUrl}.`);
+
+            return null;
+        }
+
         const pipeline = await pipelineFactory.get({ scmUri });
 
         if (pipeline) {
@@ -728,19 +761,10 @@ class PipelineModel extends BaseModel {
             return null;
         }
 
-        const hasAdminPermission = await this._hasAdminPermission(scmUri);
-
-        if (!hasAdminPermission && !readOnlyEnabled) {
-            // TODO: figure out how to bubble up this err to user
-            logger.error(`pipelineId:${this.id}: No admins have admin permission on ${scmUrl}.`);
-
-            return null;
-        }
-
         return pipelineFactory
             .create({
                 admins: newAdmins,
-                scmContext: scmContext || this.scmContext,
+                scmContext,
                 scmUri,
                 configPipelineId: this.id
             })
@@ -762,7 +786,7 @@ class PipelineModel extends BaseModel {
      */
     async _removePipeline(scmUrl) {
         const pipelineFactory = this._getPipelineFactory();
-        const scmUri = await this._getScmUri(scmUrl);
+        const scmUri = await this._getScmUri({ scmUrl });
 
         const hasAdminPermission = await this._hasAdminPermission(scmUri);
 
@@ -861,7 +885,7 @@ class PipelineModel extends BaseModel {
 
                     urlWithActionsList.push({
                         actions: urlObj[scmUrl].map(action => (action[0] === '~' ? action.substring(1) : action)),
-                        scmUri: await this._getScmUri(scmUrl)
+                        scmUri: await this._getScmUri({ scmUrl })
                     });
                 }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -10,6 +10,7 @@ const dayjs = require('dayjs');
 const _ = require('lodash');
 const { PR_JOB_NAME, EXTERNAL_TRIGGER_ALL } = require('screwdriver-data-schema').config.regex;
 const logger = require('screwdriver-logger');
+const Schema = require('screwdriver-data-schema');
 const BaseModel = require('./base');
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
@@ -28,6 +29,8 @@ const SD_API_URI = process.env.URI;
 
 const DEFAULT_DOWNTIME_JOBS = [];
 const DEFAULT_DOWNTIME_STATUSES = ['FAILURE'];
+
+const MATCH_COMPONENT_HOSTNAME = 1;
 
 // Process jobs JOB_CHUNK_SIZE at at time
 const getJobChunks = jobs => _.chunk(jobs || [], JOB_CHUNK_SIZE);
@@ -652,15 +655,14 @@ class PipelineModel extends BaseModel {
      * @param {String} scmUrl  checkout url for a repository
      * @return {Promise}
      */
-    async _getScmUri(scmUrl) {
+    async _getScmUri({ scmUrl, scmContext, token }) {
         const pipelineFactory = this._getPipelineFactory();
-        const token = await this.token;
+        const currentToken = await this.token;
         const admin = await this.admin;
-        const { scmContext } = admin;
         const scmUri = await pipelineFactory.scm.parseUrl({
-            scmContext,
+            scmContext: scmContext || admin.scmContext,
             checkoutUrl: scmUrl,
-            token
+            token: token || currentToken
         });
 
         return scmUri;
@@ -675,39 +677,70 @@ class PipelineModel extends BaseModel {
     async _createOrUpdatePipeline(scmUrl) {
         const pipelineFactory = this._getPipelineFactory();
         const { admins } = this;
-        const { scmContext } = this;
-        const scmUri = await this._getScmUri(scmUrl);
-        const hasAdminPermission = await this._hasAdminPermission(scmUri);
+        const newAdmins = admins;
+        const token = await this.token;
 
-        if (!hasAdminPermission) {
-            // need to figure out how to bubble up this err to user
-            logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+        // Get hostname using scmUrl
+        const regex = Schema.config.regex.CHECKOUT_URL;
+        const matched = regex.exec(scmUrl);
+        const hostname = matched[MATCH_COMPONENT_HOSTNAME];
 
-            return null;
+        // Set scmContext
+        const scmContext = this.scm.getScmContext({ hostname });
+        let readOnlyEnabled = false;
+
+        // Check for read-only scm, add headless admin to admin config
+        if (this.scmContext !== scmContext) {
+            readOnlyEnabled = this.scm.readOnlyEnabled({ scmContext });
+
+            if (!readOnlyEnabled) {
+                logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+                throw new Error(`User does not have push permission for this scm ${scmContext}`);
+            }
+
+            const genericUsername = this.scm.getUsername({ scmContext });
+            // TODO: get genericUser, unseal token, pass to _getScmUri
+
+            if (!admins[genericUsername]) {
+                newAdmins[genericUsername] = {
+                    push: true,
+                    admin: true,
+                    pull: true
+                };
+            }
         }
 
+        const scmUri = await this._getScmUri({ scmUrl, scmContext, token });
         const pipeline = await pipelineFactory.get({ scmUri });
 
         if (pipeline) {
             // Child pipeline belongs to this parent, update it
             if (pipeline.configPipelineId === this.id) {
-                pipeline.admins = admins;
+                pipeline.admins = newAdmins;
 
                 logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with pipelineId:${pipeline.id}.`);
 
                 return pipeline.sync();
             }
-
             // Child pipeline does not belong to this parent, return
             logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
 
             return null;
         }
 
+        const hasAdminPermission = await this._hasAdminPermission(scmUri);
+
+        if (!hasAdminPermission && !readOnlyEnabled) {
+            // TODO: figure out how to bubble up this err to user
+            logger.error(`pipelineId:${this.id}: No admins have admin permission on ${scmUrl}.`);
+
+            return null;
+        }
+
         return pipelineFactory
             .create({
-                admins,
-                scmContext,
+                admins: newAdmins,
+                scmContext: scmContext || this.scmContext,
                 scmUri,
                 configPipelineId: this.id
             })

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -652,17 +652,19 @@ class PipelineModel extends BaseModel {
     /**
      * Get a pipeline given a scmUrl
      * @method _getScmUri
-     * @param {String} scmUrl  checkout url for a repository
+     * @param {Object} config
+     * @param {String} config.scmUrl        Checkout url for a repository
+     * @param {String} [config.scmContext]  Scm context
      * @return {Promise}
      */
-    async _getScmUri({ scmUrl, scmContext, token }) {
+    async _getScmUri({ scmUrl, scmContext }) {
         const pipelineFactory = this._getPipelineFactory();
-        const currentToken = await this.token;
+        const token = await this.token;
         const admin = await this.admin;
         const scmUri = await pipelineFactory.scm.parseUrl({
             scmContext: scmContext || admin.scmContext,
             checkoutUrl: scmUrl,
-            token: token || currentToken
+            token
         });
 
         return scmUri;
@@ -679,7 +681,6 @@ class PipelineModel extends BaseModel {
         const { admins } = this;
         const newAdmins = admins;
         const admin = await this.admin;
-        const token = await this.token;
 
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
@@ -693,7 +694,7 @@ class PipelineModel extends BaseModel {
             enabled: false
         };
 
-        // Check for read-only scm, add headless admin to admin config
+        // If read-only scm, add as admin to admin config
         if (this.scmContext !== scmContext) {
             readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
 
@@ -712,7 +713,7 @@ class PipelineModel extends BaseModel {
             }
         }
 
-        const scmUri = await this._getScmUri({ scmUrl, scmContext, token });
+        const scmUri = await this._getScmUri({ scmUrl, scmContext });
 
         // Check permissions
         const hasAdminPermission = await this._hasAdminPermission(scmUri);
@@ -765,7 +766,6 @@ class PipelineModel extends BaseModel {
      */
     async _removePipeline(scmUrl) {
         const pipelineFactory = this._getPipelineFactory();
-        const token = await this.token;
 
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
@@ -790,7 +790,7 @@ class PipelineModel extends BaseModel {
         }
 
         // Check admin permissions
-        const scmUri = await this._getScmUri({ scmUrl, scmContext, token });
+        const scmUri = await this._getScmUri({ scmUrl, scmContext });
         const hasAdminPermission = await this._hasAdminPermission(scmUri);
 
         if (!hasAdminPermission) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -786,12 +786,38 @@ class PipelineModel extends BaseModel {
      */
     async _removePipeline(scmUrl) {
         const pipelineFactory = this._getPipelineFactory();
-        const scmUri = await this._getScmUri({ scmUrl });
+        let token = await this.token;
 
+        // Get hostname using scmUrl
+        const regex = Schema.config.regex.CHECKOUT_URL;
+        const matched = regex.exec(scmUrl);
+        const hostname = matched[MATCH_COMPONENT_HOSTNAME];
+
+        // Set scmContext
+        const scmContext = this.scm.getScmContext({ hostname });
+        let readOnlyEnabled = false;
+
+        // Check for read-only scm, add headless admin to admin config
+        if (this.scmContext !== scmContext) {
+            readOnlyEnabled = this.scm.readOnlyEnabled({ scmContext });
+
+            if (!readOnlyEnabled) {
+                logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+
+                return null;
+            }
+
+            const genericUsername = this.scm.getUsername({ scmContext });
+
+            token = await this._getHeadlessToken({ username: genericUsername, scmContext });
+        }
+
+        // Check admin permissions
+        const scmUri = await this._getScmUri({ scmUrl, scmContext, token });
         const hasAdminPermission = await this._hasAdminPermission(scmUri);
 
         if (!hasAdminPermission) {
-            // need to figure out how to bubble up this err to user
+            // TODO: need to figure out how to bubble up this err to user
             logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
 
             return null;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -669,26 +669,6 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * This function gets a headless user.
-     * @method _getHeadlessToken
-     * @param {String}  username    Headless username
-     * @param {String}  scmContext  Scm context
-     * @return {Promise}
-     */
-    async _getHeadlessToken({ username, scmContext }) {
-        /* eslint-disable global-require */
-        const UserFactory = require('./userFactory');
-        /* eslint-enable global-require */
-        const factory = UserFactory.getInstance();
-        const user = await factory.get({
-            username,
-            scmContext
-        });
-
-        return user.unsealToken();
-    }
-
-    /**
      * Update or create a pipeline given a scmUrl
      * @method _createOrUpdatePipeline
      * @param {String} scmUrl  checkout url for a repository
@@ -707,23 +687,26 @@ class PipelineModel extends BaseModel {
 
         // Set scmContext
         const scmContext = this.scm.getScmContext({ hostname });
-        let readOnlyEnabled = false;
+
+        let readOnlyInfo = {
+            enabled: false
+        };
 
         // Check for read-only scm, add headless admin to admin config
         if (this.scmContext !== scmContext) {
-            readOnlyEnabled = this.scm.readOnlyEnabled({ scmContext });
+            readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
 
-            if (!readOnlyEnabled) {
+            if (!readOnlyInfo.enabled) {
                 logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
 
                 return null;
             }
 
-            const genericUsername = this.scm.getUsername({ scmContext });
+            token = readOnlyInfo.accessToken;
 
-            token = await this._getHeadlessToken({ username: genericUsername, scmContext });
+            const genericUsername = readOnlyInfo.username;
 
-            if (!newAdmins[genericUsername]) {
+            if (genericUsername && !newAdmins[genericUsername]) {
                 newAdmins[genericUsername] = {
                     push: true,
                     admin: true,
@@ -737,7 +720,7 @@ class PipelineModel extends BaseModel {
         // Check permissions
         const hasAdminPermission = await this._hasAdminPermission(scmUri);
 
-        if (!hasAdminPermission && !readOnlyEnabled) {
+        if (!hasAdminPermission && !readOnlyInfo.enabled) {
             // TODO: figure out how to bubble up this err to user
             logger.error(`pipelineId:${this.id}: No admins have admin permission on ${scmUrl}.`);
 
@@ -750,7 +733,6 @@ class PipelineModel extends BaseModel {
             // Child pipeline belongs to this parent, update it
             if (pipeline.configPipelineId === this.id) {
                 pipeline.admins = newAdmins;
-
                 logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with pipelineId:${pipeline.id}.`);
 
                 return pipeline.sync();
@@ -795,21 +777,21 @@ class PipelineModel extends BaseModel {
 
         // Set scmContext
         const scmContext = this.scm.getScmContext({ hostname });
-        let readOnlyEnabled = false;
+        let readOnlyInfo = {
+            enabled: false
+        };
 
         // Check for read-only scm, add headless admin to admin config
         if (this.scmContext !== scmContext) {
-            readOnlyEnabled = this.scm.readOnlyEnabled({ scmContext });
+            readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
 
-            if (!readOnlyEnabled) {
+            if (!readOnlyInfo.enabled) {
                 logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
 
                 return null;
             }
 
-            const genericUsername = this.scm.getUsername({ scmContext });
-
-            token = await this._getHeadlessToken({ username: genericUsername, scmContext });
+            token = readOnlyInfo.accessToken;
         }
 
         // Check admin permissions

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -678,7 +678,8 @@ class PipelineModel extends BaseModel {
         const pipelineFactory = this._getPipelineFactory();
         const { admins } = this;
         const newAdmins = admins;
-        let token = await this.token;
+        const admin = await this.admin;
+        const token = await this.token;
 
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
@@ -702,12 +703,8 @@ class PipelineModel extends BaseModel {
                 return null;
             }
 
-            token = readOnlyInfo.accessToken;
-
-            const genericUsername = readOnlyInfo.username;
-
-            if (genericUsername && !newAdmins[genericUsername]) {
-                newAdmins[genericUsername] = {
+            if (!newAdmins[admin]) {
+                newAdmins[admin] = {
                     push: true,
                     admin: true,
                     pull: true
@@ -722,7 +719,7 @@ class PipelineModel extends BaseModel {
 
         if (!hasAdminPermission && !readOnlyInfo.enabled) {
             // TODO: figure out how to bubble up this err to user
-            logger.error(`pipelineId:${this.id}: No admins have admin permission on ${scmUrl}.`);
+            logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
 
             return null;
         }
@@ -768,7 +765,7 @@ class PipelineModel extends BaseModel {
      */
     async _removePipeline(scmUrl) {
         const pipelineFactory = this._getPipelineFactory();
-        let token = await this.token;
+        const token = await this.token;
 
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
@@ -790,8 +787,6 @@ class PipelineModel extends BaseModel {
 
                 return null;
             }
-
-            token = readOnlyInfo.accessToken;
         }
 
         // Check admin permissions

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "devDependencies": {
     "chai": "^4.3.0",
-    "eslint": "^7.11.0",
+    "eslint": "^7.27.0",
     "eslint-config-screwdriver": "^5.0.6",
-    "mocha": "^8.2.0",
+    "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.0.0",
@@ -59,7 +59,7 @@
     "docker-parse-image": "^3.0.1",
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.0.0",
-    "screwdriver-data-schema": "^21.0.0",
+    "screwdriver-data-schema": "^21.3.0",
     "screwdriver-logger": "^1.0.2",
     "screwdriver-workflow-parser": "^3.1.1"
   }

--- a/test/data/parserWithSubscribedScms.json
+++ b/test/data/parserWithSubscribedScms.json
@@ -84,7 +84,7 @@
     },
     "subscribe": {
         "scmUrls": [{
-            "foo.git": ["~commit", "~tags", "~release"]
+            "git@github.com:baz/foo.git": ["~commit", "~tags", "~release"]
         }]
     }
 }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -36,7 +36,7 @@ const FAKE_MAX_COUNT = 5;
 const SCM_CONTEXT_GITHUB = 'github:github.com';
 const SCM_CONTEXT_GITLAB = 'gitlab:gitlab.com';
 
-describe.only('Pipeline Model', () => {
+describe('Pipeline Model', () => {
     let PipelineModel;
     let datastore;
     let hashaMock;
@@ -272,8 +272,7 @@ describe.only('Pipeline Model', () => {
             getOpenedPRs: sinon.stub(),
             getPrInfo: sinon.stub(),
             getScmContext: sinon.stub(),
-            readOnlyEnabled: sinon.stub(),
-            getUsername: sinon.stub()
+            getReadOnlyInfo: sinon.stub()
         };
         parserMock = sinon.stub();
         pipelineFactoryMock.getExternalJoinFlag.returns(false);
@@ -437,9 +436,10 @@ describe.only('Pipeline Model', () => {
             scmMock.addWebhook.resolves();
             scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(SCM_CONTEXT_GITHUB);
             scmMock.getScmContext.withArgs({ hostname: 'gitlab.com' }).returns(SCM_CONTEXT_GITLAB);
-            scmMock.readOnlyEnabled.withArgs({ scmContext: SCM_CONTEXT_GITHUB }).returns(false);
-            scmMock.readOnlyEnabled.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns(true);
-            scmMock.getUsername.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns('sd-buildbot');
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITHUB }).returns({ enabled: false });
+            scmMock.getReadOnlyInfo
+                .withArgs({ scmContext: SCM_CONTEXT_GITLAB })
+                .returns({ enabled: true, username: 'sd-buildbot' });
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
@@ -968,13 +968,12 @@ describe.only('Pipeline Model', () => {
             parsedYaml.childPipelines = {
                 scmUrls: [SCM_URL_GITLAB, SCM_URL_GITLAB2]
             };
-
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
             scmMock.getFile.resolves('yamlcontentwithscmurls');
-            scmMock.readOnlyEnabled.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns(false);
             parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns({ enabled: false });
             pipelineFactoryMock.get.resolves(childPipelineMock);
             pipelineFactoryMock.get.withArgs({ scmUri: 'bar' }).resolves(null);
             pipeline.childPipelines = {
@@ -1021,7 +1020,7 @@ describe.only('Pipeline Model', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
-            scmMock.readOnlyEnabled.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns(false);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns({ enabled: false });
             childPipelineMock.configPipelineId = 789;
             pipelineFactoryMock.get.resolves(childPipelineMock);
             pipeline.childPipelines = {
@@ -1040,7 +1039,7 @@ describe.only('Pipeline Model', () => {
             jobFactoryMock.list.resolves(jobs);
             pipelineFactoryMock.get.resolves(null);
             scmMock.getFile.resolves('yamlcontentwithscmurls');
-            scmMock.readOnlyEnabled.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns(false);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns({ enabled: false });
             childPipelineMock.configPipelineId = 789;
             pipelineFactoryMock.get.resolves(childPipelineMock);
             pipeline.childPipelines = {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -28,7 +28,7 @@ const DEFAULT_PAGE = 1;
 const MAX_COUNT = 1000;
 const FAKE_MAX_COUNT = 5;
 
-describe('Pipeline Model', () => {
+describe.only('Pipeline Model', () => {
     let PipelineModel;
     let datastore;
     let hashaMock;


### PR DESCRIPTION
## Context

Should set `scmContext` and `admins` properly when syncing child pipelines.

## Objective

This PR gets proper `scmContext` by parsing the `scmUrl`. Then determines if the scm is read-only and updates admin info accordingly while creating/updating/removing child pipelines.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
