### PR TITLE
fix(2437): Pass in proper scmContext for user.getPermissions [1]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -406,7 +406,6 @@ class PipelineModel extends BaseModel {
      * Attach Screwdriver webhooks to the pipeline's repository
      * @method addWebhooks
      * @param   {String}    webhookUrl    The webhook to be added
-     * @method  addWebhook
      * @return  {Promise}
      */
     async addWebhooks(webhookUrl) {
@@ -621,7 +620,7 @@ class PipelineModel extends BaseModel {
     /**
      * Checks if any admin from this.admins has github permission to given scmUri
      * @method _hasAdminPermission
-     * @param  {String}    scmUri
+     * @param  {String}    scmUri           Scm uri (e.g., gitlab.com:8654386:test)
      * @return {Promise}
      */
     async _hasAdminPermission(scmUri) {
@@ -677,10 +676,8 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     async _createOrUpdatePipeline(scmUrl) {
-        const pipelineFactory = this._getPipelineFactory();
         const { admins } = this;
         const newAdmins = admins;
-        const admin = await this.admin;
 
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
@@ -689,14 +686,12 @@ class PipelineModel extends BaseModel {
 
         // Set scmContext
         const scmContext = this.scm.getScmContext({ hostname });
+        const scmUri = await this._getScmUri({ scmUrl, scmContext });
+        let hasAdminPermission = false;
 
-        let readOnlyInfo = {
-            enabled: false
-        };
-
-        // If read-only scm, add as admin to admin config
         if (this.scmContext !== scmContext) {
-            readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
+            // If read-only scm, add as admin to admin config
+            const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
 
             if (!readOnlyInfo.enabled) {
                 logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
@@ -704,27 +699,20 @@ class PipelineModel extends BaseModel {
                 return null;
             }
 
-            if (!newAdmins[admin]) {
-                newAdmins[admin] = {
-                    push: true,
-                    admin: true,
-                    pull: true
-                };
-            }
+            hasAdminPermission = true;
+        } else {
+            // Check permissions
+            hasAdminPermission = await this._hasAdminPermission(scmUri);
         }
 
-        const scmUri = await this._getScmUri({ scmUrl, scmContext });
-
-        // Check permissions
-        const hasAdminPermission = await this._hasAdminPermission(scmUri);
-
-        if (!hasAdminPermission && !readOnlyInfo.enabled) {
+        if (!hasAdminPermission) {
             // TODO: figure out how to bubble up this err to user
             logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
 
             return null;
         }
 
+        const pipelineFactory = this._getPipelineFactory();
         const pipeline = await pipelineFactory.get({ scmUri });
 
         if (pipeline) {
@@ -765,8 +753,6 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     async _removePipeline(scmUrl) {
-        const pipelineFactory = this._getPipelineFactory();
-
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
         const matched = regex.exec(scmUrl);
@@ -774,24 +760,24 @@ class PipelineModel extends BaseModel {
 
         // Set scmContext
         const scmContext = this.scm.getScmContext({ hostname });
-        let readOnlyInfo = {
-            enabled: false
-        };
+        const scmUri = await this._getScmUri({ scmUrl, scmContext });
+        let hasAdminPermission = false;
 
-        // Check for read-only scm, add headless admin to admin config
         if (this.scmContext !== scmContext) {
-            readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
+            // Check for read-only scm, add headless admin to admin config
+            const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
 
             if (!readOnlyInfo.enabled) {
                 logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
 
                 return null;
             }
-        }
 
-        // Check admin permissions
-        const scmUri = await this._getScmUri({ scmUrl, scmContext });
-        const hasAdminPermission = await this._hasAdminPermission(scmUri);
+            hasAdminPermission = true;
+        } else {
+            // Check admin permissions
+            hasAdminPermission = await this._hasAdminPermission(scmUri);
+        }
 
         if (!hasAdminPermission) {
             // TODO: need to figure out how to bubble up this err to user
@@ -800,6 +786,7 @@ class PipelineModel extends BaseModel {
             return null;
         }
 
+        const pipelineFactory = this._getPipelineFactory();
         const pipeline = await pipelineFactory.get({ scmUri });
 
         // remove pipeline only if it's a child pipeline and belongs to current pipeline
@@ -1157,7 +1144,7 @@ class PipelineModel extends BaseModel {
 
             try {
                 // eslint-disable-next-line no-await-in-loop
-                permission = await user.getPermissions(this.scmUri);
+                permission = await user.getPermissions(this.scmUri, this.scmContext);
             } catch (err) {
                 if (SCM_NO_ACCESS_STATUSES.includes(err.status)) {
                     permission.push = false;

--- a/lib/user.js
+++ b/lib/user.js
@@ -77,15 +77,16 @@ class UserModel extends BaseModel {
      * Get permissions on a specific repo
      * @method getPermissions
      * @param  {String}     scmUri          The scmUri of the repository
+     * @param  {String}     [scmContext]    The scmContext of the repository
      * @return {Promise}                    Contains the permissions for [admin, push, pull]
      *                                      Example: {admin: false, push: true, pull: true}
      */
-    getPermissions(scmUri) {
+    getPermissions(scmUri, scmContext) {
         return this.unsealToken().then(token =>
             this.scm.getPermissions({
                 token,
                 scmUri,
-                scmContext: this.scmContext
+                scmContext: scmContext || this.scmContext
             })
         );
     }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -940,7 +940,6 @@ describe('Pipeline Model', () => {
             parsedYaml.childPipelines = {
                 scmUrls: [SCM_URL_GITLAB, SCM_URL_GITLAB2]
             };
-
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });


### PR DESCRIPTION
## Context

Need to check user permissions against proper `scmContext` for read-only SCMs.

## Objective

This PR:
- passes in proper `scmContext` for `user.getPermissions`
- refactors child pipeline sync permissions check

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437, https://github.com/screwdriver-cd/models/pull/504/files

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
