### PR TITLE
fix(2437): Read-only child pipelines should use parent admins

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -410,7 +410,6 @@ class PipelineModel extends BaseModel {
      */
     async addWebhooks(webhookUrl) {
         const webhookUrlsWithActionsList = [];
-
         const webhookUrlWithActions = {
             webhookUrl,
             actions: [],
@@ -426,39 +425,49 @@ class PipelineModel extends BaseModel {
             webhookUrlsWithActionsList.push(...this.subscribedScmUrlsWithActions);
         }
 
-        return this.getFirstRepoAdmin()
-            .then(admin => admin.unsealToken())
-            .then(async token => {
-                const addWebhookList = [];
-                let mappedActions = [];
+        const { enabled, accessToken } = this.scm.getReadOnlyInfo({ scmContext: this.scmContext });
+        let token;
 
-                const scmActionMappings = this.scm.getWebhookEventsMapping({ scmContext: this.scmContext });
+        // Use read-only access token
+        if (this.configPipelineId && enabled && accessToken) {
+            token = accessToken;
+        } else {
+            const repoAdmin = await this.getFirstRepoAdmin();
 
-                for (let i = 0; i < webhookUrlsWithActionsList.length; i += 1) {
-                    mappedActions = [];
+            token = await repoAdmin.unsealToken();
+        }
 
-                    for (const action of webhookUrlsWithActionsList[i].actions) {
-                        if (scmActionMappings[action]) {
-                            if (Array.isArray(scmActionMappings[action]))
-                                mappedActions.concat(scmActionMappings[action]);
-                            else mappedActions.push(scmActionMappings[action]);
-                        }
+        const addWebhookList = [];
+        let mappedActions = [];
+
+        const scmActionMappings = this.scm.getWebhookEventsMapping({ scmContext: this.scmContext });
+
+        for (let i = 0; i < webhookUrlsWithActionsList.length; i += 1) {
+            mappedActions = [];
+
+            for (const action of webhookUrlsWithActionsList[i].actions) {
+                if (scmActionMappings[action]) {
+                    if (Array.isArray(scmActionMappings[action])) {
+                        mappedActions.concat(scmActionMappings[action]);
+                    } else {
+                        mappedActions.push(scmActionMappings[action]);
                     }
-
-                    // eslint-disable-next-line no-await-in-loop
-                    const addWebhook = await this.scm.addWebhook({
-                        scmUri: webhookUrlsWithActionsList[i].scmUri,
-                        scmContext: this.scmContext,
-                        token,
-                        actions: mappedActions,
-                        webhookUrl: webhookUrlsWithActionsList[i].webhookUrl
-                    });
-
-                    addWebhookList.push(addWebhook);
                 }
+            }
 
-                return addWebhookList;
+            // eslint-disable-next-line no-await-in-loop
+            const addWebhook = await this.scm.addWebhook({
+                scmUri: webhookUrlsWithActionsList[i].scmUri,
+                scmContext: this.scmContext,
+                token,
+                actions: mappedActions,
+                webhookUrl: webhookUrlsWithActionsList[i].webhookUrl
             });
+
+            addWebhookList.push(addWebhook);
+        }
+
+        return addWebhookList;
     }
 
     /**
@@ -467,28 +476,28 @@ class PipelineModel extends BaseModel {
      * @method syncPRs
      * @return {Promise}
      */
-    syncPRs() {
-        return this.token
-            .then(token =>
-                Promise.all([
-                    this.jobs,
-                    this.scm.getOpenedPRs({
-                        scmUri: this.scmUri,
-                        scmContext: this.scmContext,
-                        token
-                    })
-                ]).then(([existingJobs, openedPRs]) => {
-                    const synced = [];
+    async syncPRs() {
+        const token = await this.token;
 
-                    openedPRs.forEach(openedPR => {
-                        const prNum = openedPR.name.split('-')[1];
+        return Promise.all([
+            this.jobs,
+            this.scm.getOpenedPRs({
+                scmUri: this.scmUri,
+                scmContext: this.scmContext,
+                token
+            })
+        ])
+            .then(([existingJobs, openedPRs]) => {
+                const synced = [];
 
-                        synced.push(this.syncPR(prNum));
-                    });
+                openedPRs.forEach(openedPR => {
+                    const prNum = openedPR.name.split('-')[1];
 
-                    return Promise.all(synced).then(() => this._archiveClosePRs(existingJobs, openedPRs));
-                })
-            )
+                    synced.push(this.syncPR(prNum));
+                });
+
+                return Promise.all(synced).then(() => this._archiveClosePRs(existingJobs, openedPRs));
+            })
             .then(() => this);
     }
 
@@ -496,14 +505,12 @@ class PipelineModel extends BaseModel {
      * Sync PR by looking up the PR's screwdriver.yaml
      * Update the permutations to be correct
      * Create missing PR jobs
-     * @param   {Number}   prNum        PR Number
      * @method  syncPR
+     * @param   {Number}   prNum        PR Number
      * @return  {Promise}
      */
     async syncPR(prNum) {
-        const user = await this.admin;
-        const token = await user.unsealToken();
-
+        const token = await this.token;
         const prInfo = await this.scm.getPrInfo({
             scmUri: this.scmUri,
             scmContext: this.scmContext,
@@ -618,7 +625,7 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Checks if any admin from this.admins has github permission to given scmUri
+     * Checks if any admin from this.admins has SCM permission to given scmUri
      * @method _hasAdminPermission
      * @param  {String}    scmUri           Scm uri (e.g., gitlab.com:8654386:test)
      * @return {Promise}
@@ -659,9 +666,8 @@ class PipelineModel extends BaseModel {
     async _getScmUri({ scmUrl, scmContext }) {
         const pipelineFactory = this._getPipelineFactory();
         const token = await this.token;
-        const admin = await this.admin;
         const scmUri = await pipelineFactory.scm.parseUrl({
-            scmContext: scmContext || admin.scmContext,
+            scmContext: scmContext || this.scmContext,
             checkoutUrl: scmUrl,
             token
         });
@@ -678,6 +684,7 @@ class PipelineModel extends BaseModel {
     async _createOrUpdatePipeline(scmUrl) {
         const { admins } = this;
         const newAdmins = admins;
+        let scmToken;
 
         // Get hostname using scmUrl
         const regex = Schema.config.regex.CHECKOUT_URL;
@@ -699,6 +706,7 @@ class PipelineModel extends BaseModel {
                 return null;
             }
 
+            scmToken = readOnlyInfo.accessToken;
             hasAdminPermission = true;
         } else {
             // Check permissions
@@ -729,21 +737,25 @@ class PipelineModel extends BaseModel {
             return null;
         }
 
-        return pipelineFactory
-            .create({
-                admins: newAdmins,
-                scmContext,
-                scmUri,
-                configPipelineId: this.id
-            })
-            .then(async p => {
-                logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
-                // sync pipeline to create jobs
-                await p.sync();
-                if (SD_API_URI) {
-                    await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
-                }
-            });
+        const pipelineConfig = {
+            admins: newAdmins,
+            scmContext,
+            scmUri,
+            configPipelineId: this.id
+        };
+
+        if (scmToken) {
+            pipelineConfig.scmToken = scmToken;
+        }
+
+        return pipelineFactory.create(pipelineConfig).then(async p => {
+            logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
+            // sync pipeline to create jobs
+            await p.sync();
+            if (SD_API_URI) {
+                await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
+            }
+        });
     }
 
     /**
@@ -1030,8 +1042,8 @@ class PipelineModel extends BaseModel {
     }
 
     /** Fetch a pipeline's tokens
-     /* @property tokens
-     /* @return {Promise}
+     * @property tokens
+     * @return {Promise}
      */
     get tokens() {
         const listConfig = {
@@ -1060,13 +1072,32 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * This function deletes admins who does not have proper
-     * GitHub permission, and returns a proper admin.
+     * This function deletes pipeline admins who does not have proper
+     * SCM permission, and returns a proper admin (user with push permission).
      * @method getFirstAdmin
      * @return {Promise}
      */
     async getFirstAdmin() {
-        const newAdmins = this.admins;
+        let oldAdmins = this.admins;
+        let newAdmins = this.admins;
+        let { id, scmContext, scmUri } = this;
+        const { enabled } = this.scm.getReadOnlyInfo({ scmContext });
+
+        // Use parent pipeline info if child pipeline is in read-only SCM
+        if (this.configPipelineId && enabled) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const pipelineFactory = this._getPipelineFactory();
+            /* eslint-enable global-require */
+            const parentPipeline = await pipelineFactory.get(this.configPipelineId);
+
+            oldAdmins = parentPipeline.admins;
+            newAdmins = parentPipeline.admins;
+            scmContext = parentPipeline.scmContext;
+            id = parentPipeline.id;
+            scmUri = parentPipeline.scmUri;
+        }
 
         /* eslint-disable global-require */
         const UserFactory = require('./userFactory');
@@ -1074,19 +1105,19 @@ class PipelineModel extends BaseModel {
         const factory = UserFactory.getInstance();
 
         /* eslint-disable no-restricted-syntax */
-        for (const username of Object.keys(this.admins)) {
+        for (const username of Object.keys(oldAdmins)) {
             // Lazy load factory dependency to prevent circular dependency issues
             // https://nodejs.org/api/modules.html#modules_cycles
             // eslint-disable-next-line no-await-in-loop
             const user = await factory.get({
                 username,
-                scmContext: this.scmContext
+                scmContext
             });
             let permission = {};
 
             try {
                 // eslint-disable-next-line no-await-in-loop
-                permission = await user.getPermissions(this.scmUri);
+                permission = await user.getPermissions(scmUri);
             } catch (err) {
                 if (SCM_NO_ACCESS_STATUSES.includes(err.status)) {
                     permission.push = false;
@@ -1097,7 +1128,7 @@ class PipelineModel extends BaseModel {
 
             if (!permission.push) {
                 delete newAdmins[username];
-                logger.info(`pipelineId:${this.id}: ${username} has been removed from admins.`);
+                logger.info(`pipelineId:${id}: ${username} has been removed from admins.`);
             } else {
                 break;
             }
@@ -1105,19 +1136,21 @@ class PipelineModel extends BaseModel {
         /* eslint-enable no-restricted-syntax */
 
         if (Object.keys(newAdmins).length === 0) {
-            logger.error(`pipelineId:${this.id}: Pipeline has no admin.`);
+            logger.error(`pipelineId:${id}: Pipeline has no admin.`);
             throw new Error('Pipeline has no admin');
-        } else {
+        }
+
+        if (!(this.configPipelineId && enabled)) {
             // This is needed to make admins dirty and update db
             this.admins = newAdmins;
-
-            const result = await factory.get({
-                username: Object.keys(this.admins)[0],
-                scmContext: this.scmContext
-            });
-
-            return result;
         }
+
+        const result = await factory.get({
+            username: Object.keys(newAdmins)[0],
+            scmContext
+        });
+
+        return result;
     }
 
     /**
@@ -1170,6 +1203,13 @@ class PipelineModel extends BaseModel {
      * @return {Promise} Resolves the admin's token
      */
     get token() {
+        const { enabled, accessToken } = this.scm.getReadOnlyInfo({ scmContext: this.scmContext });
+
+        // Use read-only access tokeb if child pipeline is in read-only SCM
+        if (this.configPipelineId && enabled && accessToken) {
+            return Promise.resolve(accessToken);
+        }
+
         return this.admin.then(admin => admin.unsealToken());
     }
 
@@ -1418,16 +1458,15 @@ class PipelineModel extends BaseModel {
      * @method update
      * @return {Promise}
      */
-    update() {
-        return this.admin
-            .then(user => user.unsealToken())
-            .then(token =>
-                this.scm.decorateUrl({
-                    scmUri: this.scmUri,
-                    scmContext: this.scmContext,
-                    token
-                })
-            )
+    async update() {
+        const token = await this.token;
+
+        return this.scm
+            .decorateUrl({
+                scmUri: this.scmUri,
+                scmContext: this.scmContext,
+                token
+            })
             .then(async scmRepo => {
                 this.scmRepo = scmRepo;
                 this.name = scmRepo.name;

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -45,39 +45,41 @@ class PipelineFactory extends BaseFactory {
      * @param  {Object}   config.admins         The admins of this repository
      * @param  {String}   config.scmUri         The scmUri for the application
      * @param  {String}   config.scmContext     The scm context to which user belongs
+     * @param  {String}   [config.scmToken]     The scm token for this repository
      * @return {Promise}
      */
-    create(config) {
-        // Lazy load factory dependency to prevent circular dependency issues
-        // https://nodejs.org/api/modules.html#modules_cycles
-        /* eslint-disable global-require */
-        const UserFactory = require('./userFactory');
-        /* eslint-enable global-require */
-
-        const userFactory = UserFactory.getInstance();
+    async create(config) {
+        let { scmToken } = config;
         const modelConfig = config;
 
         modelConfig.createTime = new Date().toISOString();
 
-        return userFactory
-            .get({
+        if (!scmToken) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const UserFactory = require('./userFactory');
+            /* eslint-enable global-require */
+
+            const userFactory = UserFactory.getInstance();
+            const user = await userFactory.get({
                 username: Object.keys(config.admins)[0],
                 scmContext: config.scmContext
-            })
-            .then(user => user.unsealToken())
-            .then(token =>
-                this.scm.decorateUrl({
-                    scmUri: config.scmUri,
-                    scmContext: config.scmContext,
-                    token
-                })
-            )
-            .then(async scmRepo => {
-                modelConfig.scmRepo = scmRepo;
-                modelConfig.name = scmRepo.name;
-
-                return super.create(modelConfig);
             });
+
+            scmToken = await user.unsealToken();
+        }
+
+        const scmRepo = await this.scm.decorateUrl({
+            scmUri: config.scmUri,
+            scmContext: config.scmContext,
+            token: scmToken
+        });
+
+        modelConfig.scmRepo = scmRepo;
+        modelConfig.name = scmRepo.name;
+
+        return super.create(modelConfig);
     }
 
     /**


### PR DESCRIPTION
## Context

Cannot save read-only user as admin in read-only child pipeline because it is not logged into Screwdriver. We should use the parent's admins instead and inject the proper `token` where appropriate.

## Objective

This PR looks for the child pipeline's parent admins if the child pipeline belongs to a read-only SCM in:
- update
- sync
- addWebhooks
- getFirstAdmin
- get token
- pipelineFactory.create

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
