### PR TITLE
fix: Omit collecting PR jobs in getBlockedByIds

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -65,7 +65,8 @@ function getBlockedByIds(pipeline, job) {
     // Remove ~ prefix for job names
     blockedByNames = blockedByNames.map(name => name.replace('~', ''));
 
-    return pipeline.getJobs().then(pipelineJobs => {
+    // Without PR jobs
+    return pipeline.getJobs({ type: 'pipeline' }).then(pipelineJobs => {
         // Get internal blocked by first
         blockedByIds = blockedByIds.concat(findIdsOfMatchedJobs(pipelineJobs, blockedByNames));
 
@@ -92,7 +93,7 @@ function getBlockedByIds(pipeline, job) {
                                 return [];
                             }
 
-                            return p.getJobs();
+                            return p.getJobs({ type: 'pipeline' });
                         })
                         .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));
                 })

--- a/lib/build.js
+++ b/lib/build.js
@@ -65,8 +65,7 @@ function getBlockedByIds(pipeline, job) {
     // Remove ~ prefix for job names
     blockedByNames = blockedByNames.map(name => name.replace('~', ''));
 
-    // Without PR jobs
-    return pipeline.getJobs({ type: 'pipeline' }).then(pipelineJobs => {
+    return pipeline.getJobs().then(pipelineJobs => {
         // Get internal blocked by first
         blockedByIds = blockedByIds.concat(findIdsOfMatchedJobs(pipelineJobs, blockedByNames));
 
@@ -93,6 +92,7 @@ function getBlockedByIds(pipeline, job) {
                                 return [];
                             }
 
+                            // Without PR jobs
                             return p.getJobs({ type: 'pipeline' });
                         })
                         .then(jobs => findIdsOfMatchedJobs(jobs, [jobname]));

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1181,6 +1181,11 @@ describe('Build Model', () => {
                 id: 222,
                 isPR: () => false
             };
+            const prJob = {
+                name: `PR-999:${blocking2.name}`,
+                isPR: () => true,
+                id: 333
+            };
 
             pipelineMockB = {
                 id: pipelineId,
@@ -1195,7 +1200,8 @@ describe('Build Model', () => {
                         blocking1,
                         { id: 123, name: 'somejob', isPR: () => false },
                         blocking2,
-                        { id: 456, name: 'someotherjob', isPR: () => false }
+                        { id: 456, name: 'someotherjob', isPR: () => false },
+                        prJob
                     ])
             };
 
@@ -1225,7 +1231,7 @@ describe('Build Model', () => {
                     jobState,
                     jobArchived,
                     eventId,
-                    blockedBy: [jobId, blocking1.id, blocking2.id],
+                    blockedBy: [jobId, blocking1.id, blocking2.id, prJob.id],
                     annotations,
                     freezeWindows,
                     apiUri,

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1181,11 +1181,6 @@ describe('Build Model', () => {
                 id: 222,
                 isPR: () => false
             };
-            const prJob = {
-                name: `PR-999:${blocking2.name}`,
-                isPR: () => true,
-                id: 333
-            };
 
             pipelineMockB = {
                 id: pipelineId,
@@ -1200,8 +1195,7 @@ describe('Build Model', () => {
                         blocking1,
                         { id: 123, name: 'somejob', isPR: () => false },
                         blocking2,
-                        { id: 456, name: 'someotherjob', isPR: () => false },
-                        prJob
+                        { id: 456, name: 'someotherjob', isPR: () => false }
                     ])
             };
 
@@ -1231,7 +1225,7 @@ describe('Build Model', () => {
                     jobState,
                     jobArchived,
                     eventId,
-                    blockedBy: [jobId, blocking1.id, blocking2.id, prJob.id],
+                    blockedBy: [jobId, blocking1.id, blocking2.id],
                     annotations,
                     freezeWindows,
                     apiUri,


### PR DESCRIPTION
## Context
If there are a large number of remote pipelines (in the order of 1000) in blockedBy, there will be a large amount of access to SCM.

`screwdriver.yaml`:
```
jobs:
  main:
    blockedBy:
      - ~sd@123:job1
      - ~sd@123:job2
      - ~sd@123:job3
      ......
      - ~sd@123:job1000
      - ~sd@456:job1
      - ~sd@456:job2
      ......
```

PR job should not be necessary for [blockedBy](https://docs.screwdriver.cd/user-guide/configuration/workflow#blocked-by).

> This feature does not apply to PR jobs.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Save unnecessary access to SCM.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
