### PR TITLE
feat: add flag archived false while fetching jobs

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1249,7 +1249,8 @@ class PipelineModel extends BaseModel {
     get jobs() {
         const listConfig = {
             params: {
-                pipelineId: this.id
+                pipelineId: this.id,
+                archived: false
             }
         };
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1801,7 +1801,8 @@ describe('Pipeline Model', () => {
         it('has a jobs getter', () => {
             const listConfig = {
                 params: {
-                    pipelineId: pipeline.id
+                    pipelineId: pipeline.id,
+                    archived: false
                 }
             };
 


### PR DESCRIPTION
## Context

The pipeline model fetches all the jobs (archived and unarchived) from the data-store via the `jobs()` function, leading to perf issues and fetch an unnecessary load of data. This becomes problematic during syncPRs via /v4/webhook API

## Objective

This PR adds a param to skip all archived jobs while fetching the list of jobs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2496

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
