### PR TITLE
fix(2503): limit concurrent process number when pipelines are removed

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -9,7 +9,7 @@ const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
 const START_INDEX = 3;
-const MAX_COUNT = 1000;
+const MAX_METRIC_GET_COUNT = 1000;
 const MAX_BUILD_DELETE_COUNT = 100;
 const DEFAULT_COUNT = 10;
 const DEPLOY_KEY_SECRET = 'SD_SCM_DEPLOY_KEY';
@@ -342,7 +342,7 @@ class Job extends BaseModel {
             sort: 'ascending',
             sortBy: 'id',
             paginate: {
-                count: MAX_COUNT
+                count: MAX_METRIC_GET_COUNT
             },
             readOnly: true
         };

--- a/lib/job.js
+++ b/lib/job.js
@@ -10,6 +10,7 @@ const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
 const START_INDEX = 3;
 const MAX_COUNT = 1000;
+const MAX_BUILD_DELETE_COUNT = 100;
 const DEFAULT_COUNT = 10;
 const DEPLOY_KEY_SECRET = 'SD_SCM_DEPLOY_KEY';
 
@@ -279,7 +280,7 @@ class Job extends BaseModel {
     remove() {
         const removeBuilds = () =>
             // Iterate through the builds and remove MAX_COUNT at a time
-            Promise.all([this.getBuilds({ paginate: { count: MAX_COUNT } }), this.pipeline]).then(
+            Promise.all([this.getBuilds({ paginate: { count: MAX_BUILD_DELETE_COUNT } }), this.pipeline]).then(
                 ([builds, pipeline]) => {
                     if (builds.length === 0) {
                         // Done removing builds

--- a/lib/job.js
+++ b/lib/job.js
@@ -279,7 +279,7 @@ class Job extends BaseModel {
      */
     remove() {
         const removeBuilds = () =>
-            // Iterate through the builds and remove MAX_COUNT at a time
+            // Iterate through the builds and remove MAX_BUILD_DELETE_COUNT at a time
             Promise.all([this.getBuilds({ paginate: { count: MAX_BUILD_DELETE_COUNT } }), this.pipeline]).then(
                 ([builds, pipeline]) => {
                     if (builds.length === 0) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -16,7 +16,7 @@ const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
     job: 2 // main or undefined if using legacy
 };
-const MAX_COUNT = 1000;
+const MAX_METRIC_GET_COUNT = 1000;
 const MAX_JOB_DELETE_COUNT = 10;
 const MAX_EVENT_DELETE_COUNT = 100;
 // The default page for fetching not by aggregatedInteval
@@ -1670,7 +1670,7 @@ class PipelineModel extends BaseModel {
             sortBy: 'id',
             paginate: {
                 page: DEFAULT_PAGE,
-                count: MAX_COUNT
+                count: MAX_METRIC_GET_COUNT
             },
             readOnly: true
         };

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -17,6 +17,8 @@ const REGEX_CAPTURING_GROUP = {
     job: 2 // main or undefined if using legacy
 };
 const MAX_COUNT = 1000;
+const MAX_JOB_DELETE_COUNT = 10;
+const MAX_EVENT_DELETE_COUNT = 100;
 // The default page for fetching not by aggregatedInteval
 // And the start page for fetching by aggregatedInteval
 const DEFAULT_PAGE = 1;
@@ -1506,6 +1508,9 @@ class PipelineModel extends BaseModel {
             this.getJobs({
                 params: {
                     archived
+                },
+                paginate: {
+                    count: MAX_JOB_DELETE_COUNT
                 }
             }).then(jobs => {
                 if (jobs.length === 0) {
@@ -1521,6 +1526,9 @@ class PipelineModel extends BaseModel {
             this.getEvents({
                 params: {
                     type
+                },
+                paginate: {
+                    count: MAX_EVENT_DELETE_COUNT
                 }
             }).then(events => {
                 if (events.length === 0) {

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -7,8 +7,8 @@ const schema = require('screwdriver-data-schema');
 const hoek = require('@hapi/hoek');
 const rewire = require('rewire');
 const dayjs = require('dayjs');
-const MAX_COUNT = 1000;
-const FAKE_MAX_COUNT = 5;
+const MAX_METRIC_GET_COUNT = 1000;
+const FAKE_MAX_METRIC_GET_COUNT = 5;
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -797,7 +797,7 @@ describe('Job Model', () => {
                 sort: 'ascending',
                 sortBy: 'id',
                 paginate: {
-                    count: MAX_COUNT
+                    count: MAX_METRIC_GET_COUNT
                 },
                 readOnly: true
             };
@@ -814,7 +814,7 @@ describe('Job Model', () => {
             const RewireJobModel = rewire('../../lib/job');
 
             // eslint-disable-next-line no-underscore-dangle
-            RewireJobModel.__set__('MAX_COUNT', FAKE_MAX_COUNT);
+            RewireJobModel.__set__('MAX_METRIC_GET_COUNT', FAKE_MAX_METRIC_GET_COUNT);
             let buildListConfig;
 
             beforeEach(() => {
@@ -829,7 +829,7 @@ describe('Job Model', () => {
                     sortBy: 'id',
                     paginate: {
                         page: 1,
-                        count: FAKE_MAX_COUNT
+                        count: FAKE_MAX_METRIC_GET_COUNT
                     },
                     readOnly: true
                 };
@@ -945,7 +945,7 @@ describe('Job Model', () => {
                 sort: 'ascending',
                 sortBy: 'id',
                 paginate: {
-                    count: MAX_COUNT
+                    count: MAX_METRIC_GET_COUNT
                 },
                 readOnly: true
             };

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2661,10 +2661,10 @@ describe('Pipeline Model', () => {
 
         it('remove jobs recursively', () => {
             const nonArchivedMatcher = sinon.match(function(value) {
-                return !value.params.archived;
+                return value && value.params && !value.params.archived;
             });
             const archivedMatcher = sinon.match(function(value) {
-                return value.params.archived;
+                return value && value.params && value.params.archived;
             });
             let i;
 
@@ -2762,10 +2762,10 @@ describe('Pipeline Model', () => {
 
         it('remove events recursively', () => {
             const pipelineTypeMatcher = sinon.match(function(value) {
-                return value.params.type === 'pipeline';
+                return value && value.params && value.params.type === 'pipeline';
             });
             const prTypeMatcher = sinon.match(function(value) {
-                return value.params.type === 'pr';
+                return value && value.params && value.params.type === 'pr';
             });
             let i;
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2585,9 +2585,6 @@ describe('Pipeline Model', () => {
     });
 
     describe('remove', () => {
-        let archived;
-        let prType;
-
         const testEvent = {
             pipelineId: testId,
             remove: sinon.stub().resolves(null),
@@ -2619,21 +2616,6 @@ describe('Pipeline Model', () => {
         };
 
         beforeEach(() => {
-            archived = {
-                params: {
-                    pipelineId: testId,
-                    archived: true
-                }
-            };
-
-            prType = {
-                params: {
-                    pipelineId: testId,
-                    type: 'pr'
-                },
-                sort: 'descending'
-            };
-
             eventFactoryMock.list.resolves([]);
             jobFactoryMock.list.resolves([]);
             collectionFactoryMock.list.resolves([collection]);
@@ -2678,30 +2660,33 @@ describe('Pipeline Model', () => {
             }));
 
         it('remove jobs recursively', () => {
-            const nonArchived = hoek.clone(archived);
+            const nonArchivedMatcher = sinon.match(function(value) {
+                return !value.params.archived;
+            });
+            const archivedMatcher = sinon.match(function(value) {
+                return value.params.archived;
+            });
             let i;
-
-            nonArchived.params.archived = false;
 
             for (i = 0; i < 4; i += 1) {
                 jobFactoryMock.list
-                    .withArgs(nonArchived)
+                    .withArgs(nonArchivedMatcher)
                     .onCall(i)
                     .resolves([publishJob, mainJob]);
             }
             jobFactoryMock.list
-                .withArgs(nonArchived)
+                .withArgs(nonArchivedMatcher)
                 .onCall(i)
                 .resolves([]);
 
             for (i = 0; i < 2; i += 1) {
                 jobFactoryMock.list
-                    .withArgs(archived)
+                    .withArgs(archivedMatcher)
                     .onCall(i)
                     .resolves([blahJob]);
             }
             jobFactoryMock.list
-                .withArgs(archived)
+                .withArgs(archivedMatcher)
                 .onCall(i)
                 .resolves([]);
 
@@ -2776,30 +2761,33 @@ describe('Pipeline Model', () => {
         });
 
         it('remove events recursively', () => {
-            const pipelineType = hoek.clone(prType);
+            const pipelineTypeMatcher = sinon.match(function(value) {
+                return value.params.type === 'pipeline';
+            });
+            const prTypeMatcher = sinon.match(function(value) {
+                return value.params.type === 'pr';
+            });
             let i;
-
-            pipelineType.params.type = 'pipeline';
 
             for (i = 0; i < 4; i += 1) {
                 eventFactoryMock.list
-                    .withArgs(pipelineType)
+                    .withArgs(pipelineTypeMatcher)
                     .onCall(i)
                     .resolves([testEvent]);
             }
             eventFactoryMock.list
-                .withArgs(pipelineType)
+                .withArgs(pipelineTypeMatcher)
                 .onCall(i)
                 .resolves([]);
 
             for (i = 0; i < 2; i += 1) {
                 eventFactoryMock.list
-                    .withArgs(prType)
+                    .withArgs(prTypeMatcher)
                     .onCall(i)
                     .resolves([testEvent]);
             }
             eventFactoryMock.list
-                .withArgs(prType)
+                .withArgs(prTypeMatcher)
                 .onCall(i)
                 .resolves([]);
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -31,8 +31,8 @@ const NON_CHAINPR_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML_PR, {
     annotations: { 'screwdriver.cd/chainPR': false }
 });
 const DEFAULT_PAGE = 1;
-const MAX_COUNT = 1000;
-const FAKE_MAX_COUNT = 5;
+const MAX_METRIC_GET_COUNT = 1000;
+const FAKE_MAX_METRIC_GET_COUNT = 5;
 const SCM_CONTEXT_GITHUB = 'github:github.com';
 const SCM_CONTEXT_GITLAB = 'gitlab:gitlab.com';
 
@@ -3082,7 +3082,7 @@ describe('Pipeline Model', () => {
                 sortBy: 'id',
                 paginate: {
                     page: DEFAULT_PAGE,
-                    count: MAX_COUNT
+                    count: MAX_METRIC_GET_COUNT
                 },
                 startTime,
                 endTime,
@@ -3109,7 +3109,7 @@ describe('Pipeline Model', () => {
                 sortBy: 'id',
                 paginate: {
                     page: DEFAULT_PAGE,
-                    count: MAX_COUNT
+                    count: MAX_METRIC_GET_COUNT
                 },
                 startTime,
                 endTime,
@@ -3244,7 +3244,7 @@ describe('Pipeline Model', () => {
             const RewirePipelineModel = rewire('../../lib/pipeline');
 
             // eslint-disable-next-line no-underscore-dangle
-            RewirePipelineModel.__set__('MAX_COUNT', FAKE_MAX_COUNT);
+            RewirePipelineModel.__set__('MAX_METRIC_GET_COUNT', FAKE_MAX_METRIC_GET_COUNT);
             let eventListConfig;
 
             beforeEach(() => {
@@ -3260,7 +3260,7 @@ describe('Pipeline Model', () => {
                     sortBy: 'id',
                     paginate: {
                         page: DEFAULT_PAGE,
-                        count: FAKE_MAX_COUNT
+                        count: FAKE_MAX_METRIC_GET_COUNT
                     },
                     readOnly: true
                 };
@@ -3448,7 +3448,7 @@ describe('Pipeline Model', () => {
                 sortBy: 'id',
                 paginate: {
                     page: DEFAULT_PAGE,
-                    count: MAX_COUNT
+                    count: MAX_METRIC_GET_COUNT
                 },
                 readOnly: true
             };


### PR DESCRIPTION
## Context
When large pipelines are erased, the number of concurrent processes becomes too large and API is crashed. We want to limit the number of concurrent processes.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
## Objective
We limit the number of concurrent processes to delete jobs and events and change that of builds.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2503
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
