### PR TITLE
fix: delete steps in one shot

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -585,9 +585,11 @@ class BuildModel extends BaseModel {
      * @return {Promise}        Resolves to null if remove successfully
      */
     remove() {
-        return this.getSteps()
-            .then(steps => Promise.all(steps.map(t => t.remove())))
-            .then(() => super.remove());
+        // eslint-disable-next-line global-require
+        const BuildFactory = require('./buildFactory');
+        const factory = BuildFactory.getInstance();
+
+        return factory.removeSteps({ buildId: this.id }).then(() => super.remove());
     }
 
     /**

--- a/lib/build.js
+++ b/lib/build.js
@@ -586,8 +586,8 @@ class BuildModel extends BaseModel {
      */
     remove() {
         // eslint-disable-next-line global-require
-        const BuildFactory = require('./buildFactory');
-        const factory = BuildFactory.getInstance();
+        const stepFactory = require('./stepFactory');
+        const factory = stepFactory.getInstance();
 
         return factory.removeSteps({ buildId: this.id }).then(() => super.remove());
     }

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -5,7 +5,7 @@ const hoek = require('@hapi/hoek');
 const logger = require('screwdriver-logger');
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
-const { STATUS_QUERY, LATEST_BUILD_QUERY, getQueries } = require('./rawQueries');
+const { STATUS_QUERY, LATEST_BUILD_QUERY, DELETE_STEPS_QUERY, getQueries } = require('./rawQueries');
 const helper = require('./helper');
 let instance;
 
@@ -393,6 +393,25 @@ class BuildFactory extends BaseFactory {
         instance = BaseFactory.getInstance(BuildFactory, instance, config);
 
         return instance;
+    }
+
+    /**
+     * Delete steps for a build with matching buildId
+     * @method removeSteps
+     * @param  {Object}     config                  Config object
+     * @param  {Number}     config.buildId          build ID to delete steps for
+     * @return {Promise}
+     */
+    removeSteps(config) {
+        const queryConfig = {
+            queries: getQueries(this.datastore.prefix, DELETE_STEPS_QUERY),
+            replacements: {
+                buildId: config.buildId
+            },
+            rawResponse: true
+        };
+
+        return super.query(queryConfig);
     }
 }
 

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -5,7 +5,7 @@ const hoek = require('@hapi/hoek');
 const logger = require('screwdriver-logger');
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
-const { STATUS_QUERY, LATEST_BUILD_QUERY, DELETE_STEPS_QUERY, getQueries } = require('./rawQueries');
+const { STATUS_QUERY, LATEST_BUILD_QUERY, getQueries } = require('./rawQueries');
 const helper = require('./helper');
 let instance;
 
@@ -393,25 +393,6 @@ class BuildFactory extends BaseFactory {
         instance = BaseFactory.getInstance(BuildFactory, instance, config);
 
         return instance;
-    }
-
-    /**
-     * Delete steps for a build with matching buildId
-     * @method removeSteps
-     * @param  {Object}     config                  Config object
-     * @param  {Number}     config.buildId          build ID to delete steps for
-     * @return {Promise}
-     */
-    removeSteps(config) {
-        const queryConfig = {
-            queries: getQueries(this.datastore.prefix, DELETE_STEPS_QUERY),
-            replacements: {
-                buildId: config.buildId
-            },
-            rawResponse: true
-        };
-
-        return super.query(queryConfig);
     }
 }
 

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -38,12 +38,16 @@ const Queries = {
             WHERE a.eventId IN (SELECT id FROM \`${tablePrefix}events\` WHERE groupEventId = :groupEventId)
             GROUP BY a.jobId, a.id) as R
         WHERE rank=1
-        ORDER BY jobId, id DESC`
+        ORDER BY jobId, id DESC`,
+
+    deleteBuildStepsQuery: (tablePrefix = '') => `DELETE FROM "${tablePrefix}steps" WHERE "buildId" = :buildId`,
+    deleteBuildStepsQueryMySql: (tablePrefix = '') => `DELETE FROM \`${tablePrefix}steps\` WHERE buildId = :buildId`
 };
 
 const QUERY_MAPPINGS = {
     STATUS_QUERY: Symbol('status_query'),
-    LATEST_BUILD_QUERY: Symbol('latest build')
+    LATEST_BUILD_QUERY: Symbol('latest build'),
+    DELETE_STEPS_QUERY: Symbol('delete steps')
 };
 
 const getQueries = (tablePrefix, querylabel) => {
@@ -60,6 +64,12 @@ const getQueries = (tablePrefix, querylabel) => {
                 { dbType: 'sqlite', query: Queries.latestBuildQuery(tablePrefix) },
                 { dbType: 'mysql', query: Queries.latestBuildQueryMySql(tablePrefix) }
             ];
+        case QUERY_MAPPINGS.DELETE_STEPS_QUERY:
+            return [
+                { dbType: 'postgres', query: Queries.deleteBuildStepsQuery(tablePrefix) },
+                { dbType: 'sqlite', query: Queries.deleteBuildStepsQuery(tablePrefix) },
+                { dbType: 'mysql', query: Queries.deleteBuildStepsQueryMySql(tablePrefix) }
+            ];
         default:
             throw new Error('Unsupported Raw Query');
     }
@@ -69,5 +79,6 @@ module.exports = {
     Queries,
     getQueries,
     STATUS_QUERY: QUERY_MAPPINGS.STATUS_QUERY,
-    LATEST_BUILD_QUERY: QUERY_MAPPINGS.LATEST_BUILD_QUERY
+    LATEST_BUILD_QUERY: QUERY_MAPPINGS.LATEST_BUILD_QUERY,
+    DELETE_STEPS_QUERY: QUERY_MAPPINGS.DELETE_STEPS_QUERY
 };

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -2,14 +2,14 @@
 
 const Queries = {
     // getBuildStatuses()
-    statusesQuery: (tablePrefix = '') => `SELECT "id", "jobId", "status", "startTime", "endTime"
+    getStatusesQuery: (tablePrefix = '') => `SELECT "id", "jobId", "status", "startTime", "endTime"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime",
         RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
         FROM "${tablePrefix}builds" WHERE "jobId" in (:jobIds)) as R
         WHERE rank > :offset AND rank <= :maxRank
         ORDER BY "jobId", "id" ASC`,
 
-    statusesQueryMySql: (tablePrefix = '') => `SELECT id, jobId, status, startTime, endTime FROM (
+    getStatusesQueryMySql: (tablePrefix = '') => `SELECT id, jobId, status, startTime, endTime FROM (
 	    SELECT a.id, a.jobId, a.status, a.startTime,  a.endTime, count(b.id) AS rank
 		FROM  \`${tablePrefix}builds\` a LEFT JOIN (SELECT id, jobId FROM \`${tablePrefix}builds\` WHERE jobId IN (:jobIds)) b
                 ON a.id<=b.id AND a.jobId=b.jobId
@@ -19,13 +19,13 @@ const Queries = {
             ORDER BY jobId, id ASC`,
 
     // getLatestBuilds()
-    latestBuildQuery: (tablePrefix = '') => `SELECT * FROM (
+    getLatestBuildQuery: (tablePrefix = '') => `SELECT * FROM (
         SELECT *, RANK() OVER ( PARTITION BY "jobId" ORDER BY "id" DESC ) AS rank
         FROM "${tablePrefix}builds" WHERE "eventId" in (SELECT "id" FROM "${tablePrefix}events" WHERE "groupEventId" = (:groupEventId))) AS events
         WHERE rank = 1
         ORDER BY "jobId", "id" DESC`,
 
-    latestBuildQueryMySql: (tablePrefix = '') =>
+    getLatestBuildQueryMySql: (tablePrefix = '') =>
         `SELECT id, environment, eventId, jobId, parentBuildId, number, container, cause, sha,
                 commit, createTime, startTime, endTime, parameters, meta, status, statusMessage,
                 buildClusterName, stats, parentBuilds, templateId FROM (
@@ -40,6 +40,7 @@ const Queries = {
         WHERE rank=1
         ORDER BY jobId, id DESC`,
 
+    // removeSteps()
     deleteBuildStepsQuery: (tablePrefix = '') => `DELETE FROM "${tablePrefix}steps" WHERE "buildId" = :buildId`,
     deleteBuildStepsQueryMySql: (tablePrefix = '') => `DELETE FROM \`${tablePrefix}steps\` WHERE buildId = :buildId`
 };
@@ -54,15 +55,15 @@ const getQueries = (tablePrefix, querylabel) => {
     switch (querylabel) {
         case QUERY_MAPPINGS.STATUS_QUERY:
             return [
-                { dbType: 'postgres', query: Queries.statusesQuery(tablePrefix) },
-                { dbType: 'sqlite', query: Queries.statusesQuery(tablePrefix) },
-                { dbType: 'mysql', query: Queries.statusesQueryMySql(tablePrefix) }
+                { dbType: 'postgres', query: Queries.getStatusesQuery(tablePrefix) },
+                { dbType: 'sqlite', query: Queries.getStatusesQuery(tablePrefix) },
+                { dbType: 'mysql', query: Queries.getStatusesQueryMySql(tablePrefix) }
             ];
         case QUERY_MAPPINGS.LATEST_BUILD_QUERY:
             return [
-                { dbType: 'postgres', query: Queries.latestBuildQuery(tablePrefix) },
-                { dbType: 'sqlite', query: Queries.latestBuildQuery(tablePrefix) },
-                { dbType: 'mysql', query: Queries.latestBuildQueryMySql(tablePrefix) }
+                { dbType: 'postgres', query: Queries.getLatestBuildQuery(tablePrefix) },
+                { dbType: 'sqlite', query: Queries.getLatestBuildQuery(tablePrefix) },
+                { dbType: 'mysql', query: Queries.getLatestBuildQueryMySql(tablePrefix) }
             ];
         case QUERY_MAPPINGS.DELETE_STEPS_QUERY:
             return [

--- a/lib/stepFactory.js
+++ b/lib/stepFactory.js
@@ -2,6 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Step = require('./step');
+const { DELETE_STEPS_QUERY, getQueries } = require('./rawQueries');
 
 let instance;
 
@@ -36,6 +37,25 @@ class StepFactory extends BaseFactory {
         instance = BaseFactory.getInstance(StepFactory, instance, config);
 
         return instance;
+    }
+
+    /**
+     * Delete steps for a build with matching buildId
+     * @method removeSteps
+     * @param  {Object}     config                  Config object
+     * @param  {Number}     config.buildId          build ID to delete steps for
+     * @return {Promise}
+     */
+    removeSteps(config) {
+        const queryConfig = {
+            queries: getQueries(this.datastore.prefix, DELETE_STEPS_QUERY),
+            replacements: {
+                buildId: config.buildId
+            },
+            rawResponse: true
+        };
+
+        return super.query(queryConfig);
     }
 }
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -50,7 +50,6 @@ describe('Build Model', () => {
     let jobFactoryMock;
     let pipelineFactoryMock;
     let stepFactoryMock;
-    let buildFactoryMock;
     let scmMock;
     let tokenGen;
     let pipelineMock;
@@ -91,10 +90,8 @@ describe('Build Model', () => {
             get: sinon.stub().resolves(null)
         };
         stepFactoryMock = {
-            list: sinon.stub().resolves([])
-        };
-        buildFactoryMock = {
-            removeSteps: sinon.stub().resolves(null)
+            list: sinon.stub().resolves([]),
+            removeSteps: sinon.stub().resolves([])
         };
 
         pipelineMock = {
@@ -130,15 +127,11 @@ describe('Build Model', () => {
         const sF = {
             getInstance: sinon.stub().returns(stepFactoryMock)
         };
-        const bF = {
-            getInstance: sinon.stub().returns(buildFactoryMock)
-        };
 
         mockery.registerMock('./pipelineFactory', pF);
         mockery.registerMock('./userFactory', uF);
         mockery.registerMock('./jobFactory', jF);
         mockery.registerMock('./stepFactory', sF);
-        mockery.registerMock('./buildFactory', bF);
         mockery.registerMock('screwdriver-hashr', hashaMock);
 
         // eslint-disable-next-line global-require
@@ -834,13 +827,13 @@ describe('Build Model', () => {
 
         it('remove build and build steps', () => {
             return build.remove().then(() => {
-                assert.calledOnce(buildFactoryMock.removeSteps); // remove steps in one shot
+                assert.calledOnce(stepFactoryMock.removeSteps); // remove steps in one shot
                 assert.calledOnce(datastore.remove); // remove the build
             });
         });
 
         it('fail if removeSteps returns error', () => {
-            buildFactoryMock.removeSteps.rejects(new Error('error removing step'));
+            stepFactoryMock.removeSteps.rejects(new Error('error removing step'));
 
             return build
                 .remove()

--- a/test/lib/stepFactory.test.js
+++ b/test/lib/stepFactory.test.js
@@ -3,6 +3,7 @@
 const { assert } = require('chai');
 const mockery = require('mockery');
 const sinon = require('sinon');
+const { DELETE_STEPS_QUERY, getQueries } = require('../../lib/rawQueries');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -33,7 +34,8 @@ describe('Step Factory', () => {
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
-            get: sinon.stub()
+            get: sinon.stub(),
+            query: sinon.stub()
         };
 
         /* eslint-disable global-require */
@@ -118,6 +120,36 @@ describe('Step Factory', () => {
 
         it('should throw an error when config not supplied', () => {
             assert.throw(StepFactory.getInstance, Error, 'No datastore provided to StepFactory');
+        });
+    });
+
+    describe('removeSteps', () => {
+        let config;
+        let queryConfig;
+
+        beforeEach(() => {
+            sinon.stub(StepFactory.prototype, 'query').returns();
+
+            config = {
+                buildId: '12345'
+            };
+
+            queryConfig = {
+                queries: getQueries('', DELETE_STEPS_QUERY),
+                replacements: {
+                    buildId: config.buildId
+                },
+                rawResponse: true,
+                table: 'steps'
+            };
+        });
+
+        it('returns latest builds for groupEventId', () => {
+            datastore.query.resolves([]);
+
+            return factory.removeSteps(config).then(() => {
+                assert.calledWith(datastore.query, queryConfig);
+            });
         });
     });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

This is approaching to the comment
https://github.com/screwdriver-cd/screwdriver/issues/2503#issuecomment-899773799

> Delete build is iterating over reach step. There is no reason we should be doing this. We need to use DB query to delete in one shot.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Reduces memory consumption by skipping loading `step` models.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2503#issuecomment-899773799

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
