### PR TITLE
fix: Permit bumping up patch version of t/c even if the version number is not an upward update

### DIFF
--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -62,38 +62,64 @@ class CommandFactory extends BaseFactory {
      * @return {Promise}
      */
     create(config) {
+        let isLatest = true;
+        let isTrusted = false;
+
         return super
             .list({ params: { namespace: config.namespace, name: config.name, latest: true } })
-            .then(commands => {
-                const latestCommand = commands[0];
+            .then(latestCommands => {
+                const latestCommand = latestCommands[0];
+                const [, configMajor, configMinor] = VERSION_REGEX.exec(config.version);
 
                 if (latestCommand) {
-                    latestCommand.latest = false;
+                    const [, latestMajor, latestMinor] = VERSION_REGEX.exec(latestCommand.version);
 
-                    return latestCommand.update().then(() => latestCommand);
+                    isTrusted = latestCommand.trusted || false;
+                    if (configMajor > latestMajor || (configMajor === latestMajor && configMinor >= latestMinor)) {
+                        latestCommand.latest = false;
+
+                        return latestCommand.update().then(() => latestCommand);
+                    }
+                    isLatest = false;
+
+                    return super
+                        .list({ params: { namespace: config.namespace, name: config.name } })
+                        .then(commands => {
+                            return commands.filter(t => {
+                                const [, targetMajor, targetMinor] = VERSION_REGEX.exec(t.version);
+
+                                return targetMajor === configMajor && targetMinor === configMinor;
+                            });
+                        })
+                        .then(targetCommands => {
+                            if (targetCommands) {
+                                return targetCommands[0];
+                            }
+
+                            return null;
+                        });
                 }
 
                 return null;
             })
-            .then(latestCommand => {
+            .then(targetCommand => {
                 const [, major, minor] = VERSION_REGEX.exec(config.version);
                 const newVersion = minor ? `${major}${minor}.0` : `${major}.0.0`;
 
-                if (!latestCommand) {
+                if (!targetCommand) {
                     config.version = newVersion;
-                    config.trusted = false;
                 } else {
                     // eslint-disable-next-line max-len
-                    const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestCommand.version);
-                    const patch = parseInt(latestPatch.slice(1), 10) + 1;
-                    const newPatch = latestMajor === major && latestMinor === minor;
+                    const [, targetMajor, targetMinor, targetPatch] = VERSION_REGEX.exec(targetCommand.version);
+                    const patch = parseInt(targetPatch.slice(1), 10) + 1;
+                    const newPatch = targetMajor === major && targetMinor === minor;
 
-                    config.version = newPatch ? `${latestMajor}${latestMinor}.${patch}` : newVersion;
-                    config.trusted = latestCommand.trusted || false;
+                    config.version = newPatch ? `${targetMajor}${targetMinor}.${patch}` : newVersion;
                 }
 
+                config.trusted = isTrusted;
                 config.createTime = new Date().toISOString();
-                config.latest = true;
+                config.latest = isLatest;
 
                 return super.create(config);
             });

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -143,39 +143,64 @@ class TemplateFactory extends BaseFactory {
     create(config) {
         const nameObj = parseTemplateConfigName(config);
         const result = hoek.applyToDefaults(config, nameObj);
+        let isLatest = true;
+        let isTrusted = false;
 
         return super
             .list({ params: { namespace: result.namespace, name: result.name, latest: true } })
-            .then(templates => {
-                const latestTemplate = templates[0];
+            .then(latestTemplates => {
+                const latestTemplate = latestTemplates[0];
+                const [, configMajor, configMinor] = VERSION_REGEX.exec(config.version);
 
                 if (latestTemplate) {
-                    latestTemplate.latest = false;
+                    const [, latestMajor, latestMinor] = VERSION_REGEX.exec(latestTemplate.version);
 
-                    return latestTemplate.update().then(() => latestTemplate);
+                    isTrusted = latestTemplate.trusted || false;
+                    if (configMajor > latestMajor || (configMajor === latestMajor && configMinor >= latestMinor)) {
+                        latestTemplate.latest = false;
+
+                        return latestTemplate.update().then(() => latestTemplate);
+                    }
+                    isLatest = false;
+
+                    return super
+                        .list({ params: { namespace: result.namespace, name: result.name } })
+                        .then(templates => {
+                            return templates.filter(t => {
+                                const [, targetMajor, targetMinor] = VERSION_REGEX.exec(t.version);
+
+                                return targetMajor === configMajor && targetMinor === configMinor;
+                            });
+                        })
+                        .then(targetTemplates => {
+                            if (targetTemplates) {
+                                return targetTemplates[0];
+                            }
+
+                            return null;
+                        });
                 }
 
                 return null;
             })
-            .then(latestTemplate => {
+            .then(targetTemplate => {
                 const [, major, minor] = VERSION_REGEX.exec(config.version);
                 const newVersion = minor ? `${major}${minor}.0` : `${major}.0.0`;
 
-                if (!latestTemplate) {
+                if (!targetTemplate) {
                     result.version = newVersion;
-                    result.trusted = false;
                 } else {
                     // eslint-disable-next-line max-len
-                    const [, latestMajor, latestMinor, latestPatch] = VERSION_REGEX.exec(latestTemplate.version);
-                    const patch = parseInt(latestPatch.slice(1), 10) + 1;
-                    const newPatch = latestMajor === major && latestMinor === minor;
+                    const [, targetMajor, targetMinor, targetPatch] = VERSION_REGEX.exec(targetTemplate.version);
+                    const patch = parseInt(targetPatch.slice(1), 10) + 1;
+                    const newPatch = targetMajor === major && targetMinor === minor;
 
-                    result.version = newPatch ? `${latestMajor}${latestMinor}.${patch}` : newVersion;
-                    result.trusted = latestTemplate.trusted || false;
+                    result.version = newPatch ? `${targetMajor}${targetMinor}.${patch}` : newVersion;
                 }
 
+                result.trusted = isTrusted;
                 result.createTime = new Date().toISOString();
-                result.latest = true;
+                result.latest = isLatest;
 
                 return super.create(result);
             });

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -100,7 +100,8 @@ describe('Command Factory', () => {
                 habitat,
                 id: generatedId,
                 pipelineId,
-                trusted: false
+                trusted: false,
+                latest: true
             };
         });
 
@@ -125,6 +126,43 @@ describe('Command Factory', () => {
                     assert.instanceOf(model, Command);
                     Object.keys(expected).forEach(key => {
                         assert.strictEqual(model[key], expected[key]);
+                    });
+                });
+        });
+
+        it('creates a Command given lower major version and no target commands', () => {
+            expected.version = '2.0.0';
+            expected.latest = false;
+            const latest = {
+                namespace,
+                name,
+                version: `3.0.0`,
+                maintainer,
+                description,
+                format,
+                habitat,
+                id: generatedId,
+                pipelineId
+            };
+
+            datastore.save.resolves(expected);
+            datastore.scan.resolves([latest]);
+
+            return factory
+                .create({
+                    namespace,
+                    name,
+                    version: '2.0',
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    pipelineId
+                })
+                .then(model => {
+                    assert.instanceOf(model, Command);
+                    Object.keys(expected).forEach(key => {
+                        assert.deepEqual(model[key], expected[key]);
                     });
                 });
         });
@@ -195,6 +233,83 @@ describe('Command Factory', () => {
                     });
                     Object.keys(expected).forEach(key => {
                         assert.strictEqual(model[key], expected[key]);
+                    });
+                });
+        });
+
+        it('creates a Command and auto-bumps version when target version exists', () => {
+            const latest = {
+                namespace,
+                name,
+                version: `3.0.0`,
+                maintainer,
+                description,
+                format,
+                habitat,
+                id: generatedId,
+                pipelineId
+            };
+
+            const target = [
+                {
+                    namespace,
+                    name,
+                    version: `2.1.2`,
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    id: generatedId + 2,
+                    pipelineId
+                },
+                {
+                    namespace,
+                    name,
+                    version: `2.1.1`,
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    id: generatedId + 1,
+                    pipelineId
+                },
+                {
+                    namespace,
+                    name,
+                    version: `2.1.0`,
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    id: generatedId,
+                    pipelineId
+                }
+            ];
+
+            expected.version = `2.1.3`;
+            expected.latest = false;
+
+            datastore.save.resolves(expected);
+            datastore.scan.onFirstCall().resolves([latest]);
+            datastore.scan.onSecondCall().resolves(target);
+            datastore.update.resolves(latest);
+
+            return factory
+                .create({
+                    namespace,
+                    name,
+                    version: '2.1',
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    pipelineId
+                })
+                .then(model => {
+                    assert.instanceOf(model, Command);
+                    assert.notCalled(datastore.update);
+                    Object.keys(expected).forEach(key => {
+                        assert.deepEqual(model[key], expected[key]);
                     });
                 });
         });
@@ -290,6 +405,87 @@ describe('Command Factory', () => {
                     });
                     Object.keys(expected).forEach(key => {
                         assert.strictEqual(model[key], expected[key]);
+                    });
+                });
+        });
+
+        it('creates a trusted Command and bump patch version when latest Command was trusted', () => {
+            const latest = {
+                namespace,
+                name,
+                version: `3.1.0`,
+                maintainer,
+                description,
+                format,
+                habitat,
+                id: generatedId,
+                pipelineId,
+                trusted: true
+            };
+
+            const target = [
+                {
+                    namespace,
+                    name,
+                    version: `2.1.2`,
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    id: generatedId + 2,
+                    pipelineId
+                },
+                {
+                    namespace,
+                    name,
+                    version: `2.1.1`,
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    id: generatedId + 1,
+                    pipelineId
+                },
+                {
+                    namespace,
+                    name,
+                    version: `2.1.0`,
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    id: generatedId,
+                    pipelineId
+                }
+            ];
+
+            const newVersion = '2.1';
+
+            expected.version = `${newVersion}.3`;
+            expected.trusted = true;
+            expected.latest = false;
+
+            datastore.save.resolves(expected);
+            datastore.scan.onFirstCall().resolves([latest]);
+            datastore.scan.onSecondCall().resolves(target);
+            datastore.update.resolves(latest);
+
+            return factory
+                .create({
+                    namespace,
+                    name,
+                    version: '2.1',
+                    maintainer,
+                    description,
+                    format,
+                    habitat,
+                    pipelineId
+                })
+                .then(model => {
+                    assert.instanceOf(model, Command);
+                    assert.notCalled(datastore.update);
+                    Object.keys(expected).forEach(key => {
+                        assert.deepEqual(model[key], expected[key]);
                     });
                 });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We use a cli-tool wrapped as sd-cmd, and the major and minor versions of that sd-cmd are linked to the actual version of the cli-tool.

We updated that the cli-tool from 3.3 to 4.11, but 4.11 didn't work well so we tried to republish and repromote 3.3 and we got a unique constraint error

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR enables to publish by bumping up the patch version, even if the version number is not an upward update.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
