### PR TITLE
fix(2575): fix bump version flow when creating command/template.

### DIFF
--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -74,14 +74,10 @@ class CommandFactory extends BaseFactory {
             .then(latestCommands => {
                 latestCommand = latestCommands[0];
 
-                if (latestCommand) {
-                    const configVersion = configMinor ? `${configMajor}${configMinor}` : `${configMajor}`;
-                    const configFullCommandName = `${config.namespace}/${config.name}@${configVersion}`;
+                const configVersion = configMinor ? `${configMajor}${configMinor}` : `${configMajor}`;
+                const configFullCommandName = `${config.namespace}/${config.name}@${configVersion}`;
 
-                    return this.getCommand(configFullCommandName);
-                }
-
-                return null;
+                return this.getCommand(configFullCommandName);
             })
             .then(matchCommand => {
                 if (latestCommand) {

--- a/lib/commandFactory.js
+++ b/lib/commandFactory.js
@@ -65,46 +65,45 @@ class CommandFactory extends BaseFactory {
         let isLatest = true;
         let isTrusted = false;
 
+        const [, configMajor, configMinor] = VERSION_REGEX.exec(config.version);
+
+        let latestCommand;
+
         return super
             .list({ params: { namespace: config.namespace, name: config.name, latest: true } })
             .then(latestCommands => {
-                const latestCommand = latestCommands[0];
-                const [, configMajor, configMinor] = VERSION_REGEX.exec(config.version);
+                latestCommand = latestCommands[0];
 
                 if (latestCommand) {
-                    const [, latestMajor, latestMinor] = VERSION_REGEX.exec(latestCommand.version);
+                    const configVersion = configMinor ? `${configMajor}${configMinor}` : `${configMajor}`;
+                    const configFullCommandName = `${config.namespace}/${config.name}@${configVersion}`;
 
-                    isTrusted = latestCommand.trusted || false;
-                    if (configMajor > latestMajor || (configMajor === latestMajor && configMinor >= latestMinor)) {
-                        latestCommand.latest = false;
-
-                        return latestCommand.update().then(() => latestCommand);
-                    }
-                    isLatest = false;
-
-                    return super
-                        .list({ params: { namespace: config.namespace, name: config.name } })
-                        .then(commands => {
-                            return commands.filter(t => {
-                                const [, targetMajor, targetMinor] = VERSION_REGEX.exec(t.version);
-
-                                return targetMajor === configMajor && targetMinor === configMinor;
-                            });
-                        })
-                        .then(targetCommands => {
-                            if (targetCommands) {
-                                return targetCommands[0];
-                            }
-
-                            return null;
-                        });
+                    return this.getCommand(configFullCommandName);
                 }
 
                 return null;
             })
+            .then(matchCommand => {
+                if (latestCommand) {
+                    const [, latestMajor, latestMinor] = VERSION_REGEX.exec(latestCommand.version);
+                    const [, major, minor] = matchCommand
+                        ? VERSION_REGEX.exec(matchCommand.version)
+                        : VERSION_REGEX.exec(config.version);
+
+                    isTrusted = latestCommand.trusted || false;
+
+                    if (major > latestMajor || (major === latestMajor && minor >= latestMinor)) {
+                        latestCommand.latest = false;
+
+                        return latestCommand.update().then(() => matchCommand);
+                    }
+                    isLatest = false;
+                }
+
+                return matchCommand;
+            })
             .then(targetCommand => {
-                const [, major, minor] = VERSION_REGEX.exec(config.version);
-                const newVersion = minor ? `${major}${minor}.0` : `${major}.0.0`;
+                const newVersion = configMinor ? `${configMajor}${configMinor}.0` : `${configMajor}.0.0`;
 
                 if (!targetCommand) {
                     config.version = newVersion;
@@ -112,9 +111,8 @@ class CommandFactory extends BaseFactory {
                     // eslint-disable-next-line max-len
                     const [, targetMajor, targetMinor, targetPatch] = VERSION_REGEX.exec(targetCommand.version);
                     const patch = parseInt(targetPatch.slice(1), 10) + 1;
-                    const newPatch = targetMajor === major && targetMinor === minor;
 
-                    config.version = newPatch ? `${targetMajor}${targetMinor}.${patch}` : newVersion;
+                    config.version = `${targetMajor}${targetMinor}.${patch}`;
                 }
 
                 config.trusted = isTrusted;

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -155,14 +155,10 @@ class TemplateFactory extends BaseFactory {
             .then(latestTemplates => {
                 latestTemplate = latestTemplates[0];
 
-                if (latestTemplate) {
-                    const configVersion = configMinor ? `${configMajor}${configMinor}` : `${configMajor}`;
-                    const configFullTemplateName = `${config.name}@${configVersion}`;
+                const configVersion = configMinor ? `${configMajor}${configMinor}` : `${configMajor}`;
+                const configFullTemplateName = `${config.name}@${configVersion}`;
 
-                    return this.getTemplate(configFullTemplateName);
-                }
-
-                return null;
+                return this.getTemplate(configFullTemplateName);
             })
             .then(matchTemplate => {
                 if (latestTemplate) {

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -146,46 +146,45 @@ class TemplateFactory extends BaseFactory {
         let isLatest = true;
         let isTrusted = false;
 
+        const [, configMajor, configMinor] = VERSION_REGEX.exec(config.version);
+
+        let latestTemplate;
+
         return super
             .list({ params: { namespace: result.namespace, name: result.name, latest: true } })
             .then(latestTemplates => {
-                const latestTemplate = latestTemplates[0];
-                const [, configMajor, configMinor] = VERSION_REGEX.exec(config.version);
+                latestTemplate = latestTemplates[0];
 
                 if (latestTemplate) {
-                    const [, latestMajor, latestMinor] = VERSION_REGEX.exec(latestTemplate.version);
+                    const configVersion = configMinor ? `${configMajor}${configMinor}` : `${configMajor}`;
+                    const configFullTemplateName = `${config.name}@${configVersion}`;
 
-                    isTrusted = latestTemplate.trusted || false;
-                    if (configMajor > latestMajor || (configMajor === latestMajor && configMinor >= latestMinor)) {
-                        latestTemplate.latest = false;
-
-                        return latestTemplate.update().then(() => latestTemplate);
-                    }
-                    isLatest = false;
-
-                    return super
-                        .list({ params: { namespace: result.namespace, name: result.name } })
-                        .then(templates => {
-                            return templates.filter(t => {
-                                const [, targetMajor, targetMinor] = VERSION_REGEX.exec(t.version);
-
-                                return targetMajor === configMajor && targetMinor === configMinor;
-                            });
-                        })
-                        .then(targetTemplates => {
-                            if (targetTemplates) {
-                                return targetTemplates[0];
-                            }
-
-                            return null;
-                        });
+                    return this.getTemplate(configFullTemplateName);
                 }
 
                 return null;
             })
+            .then(matchTemplate => {
+                if (latestTemplate) {
+                    const [, latestMajor, latestMinor] = VERSION_REGEX.exec(latestTemplate.version);
+                    const [, major, minor] = matchTemplate
+                        ? VERSION_REGEX.exec(matchTemplate.version)
+                        : VERSION_REGEX.exec(config.version);
+
+                    isTrusted = latestTemplate.trusted || false;
+
+                    if (major > latestMajor || (major === latestMajor && minor >= latestMinor)) {
+                        latestTemplate.latest = false;
+
+                        return latestTemplate.update().then(() => matchTemplate);
+                    }
+                    isLatest = false;
+                }
+
+                return matchTemplate;
+            })
             .then(targetTemplate => {
-                const [, major, minor] = VERSION_REGEX.exec(config.version);
-                const newVersion = minor ? `${major}${minor}.0` : `${major}.0.0`;
+                const newVersion = configMinor ? `${configMajor}${configMinor}.0` : `${configMajor}.0.0`;
 
                 if (!targetTemplate) {
                     result.version = newVersion;
@@ -193,9 +192,8 @@ class TemplateFactory extends BaseFactory {
                     // eslint-disable-next-line max-len
                     const [, targetMajor, targetMinor, targetPatch] = VERSION_REGEX.exec(targetTemplate.version);
                     const patch = parseInt(targetPatch.slice(1), 10) + 1;
-                    const newPatch = targetMajor === major && targetMinor === minor;
 
-                    result.version = newPatch ? `${targetMajor}${targetMinor}.${patch}` : newVersion;
+                    result.version = `${targetMajor}${targetMinor}.${patch}`;
                 }
 
                 result.trusted = isTrusted;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If we publish a template or command without specifying a minor version, it sometimes fail.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I changed the logic to specify a published version which is based on the config by using getTemplate/getCommand method.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2575

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
