### PR TITLE
fix(2561): Make provider param optional

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -483,7 +483,6 @@ class BuildModel extends BaseModel {
                                 jobState: job.state,
                                 jobArchived: job.archived,
                                 jobName: job.name,
-                                provider: hoek.reach(job.permutations[0], 'provider', { default: {} }),
                                 annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
                                 blockedBy,
                                 pipeline: {
@@ -506,6 +505,10 @@ class BuildModel extends BaseModel {
 
                             if (this.buildClusterName) {
                                 config.buildClusterName = this.buildClusterName;
+                            }
+
+                            if (hoek.reach(job.permutations[0], 'provider')) {
+                                config.provider = job.permutations[0].provider;
                             }
 
                             return this[executor].start(config);
@@ -566,12 +569,15 @@ class BuildModel extends BaseModel {
                         buildId: this.id,
                         jobId: job.id,
                         startTime: this.startTime,
-                        provider: job.permutations[0].provider,
                         annotations: job.permutations[0].annotations,
                         buildStatus: this.status,
                         pipelineId: pipeline.id,
                         token: getToken(this, job, pipeline)
                     };
+
+                    if (hoek.reach(job.permutations[0], 'provider')) {
+                        config.provider = job.permutations[0].provider;
+                    }
 
                     return this[executor].startTimer(config);
                 }
@@ -606,7 +612,6 @@ class BuildModel extends BaseModel {
                     .then(pipeline => Promise.all([getBlockedByIds(pipeline, job), this.pipeline]))
                     .then(([blockedBy, pipeline]) => {
                         const config = {
-                            provider: job.permutations[0].provider,
                             annotations: job.permutations[0].annotations,
                             freezeWindows: job.permutations[0].freezeWindows,
                             blockedBy,
@@ -618,6 +623,10 @@ class BuildModel extends BaseModel {
 
                         if (this.buildClusterName) {
                             config.buildClusterName = this.buildClusterName;
+                        }
+
+                        if (hoek.reach(job.permutations[0], 'provider')) {
+                            config.provider = job.permutations[0].provider;
                         }
 
                         return this[executor].stop(config).then(() => this[executor].stopTimer(config));
@@ -642,13 +651,16 @@ class BuildModel extends BaseModel {
             .then(job =>
                 job.pipeline.then(pipeline => {
                     const config = {
-                        provider: job.permutations[0].provider,
                         buildId: this.id,
                         jobId: job.id,
                         pipelineId: pipeline.id,
                         token: getToken(this, job, pipeline),
                         status: previousStatus
                     };
+
+                    if (hoek.reach(job.permutations[0], 'provider')) {
+                        config.provider = job.permutations[0].provider;
+                    }
 
                     return this[executor].stopFrozen(config);
                 })

--- a/lib/job.js
+++ b/lib/job.js
@@ -244,15 +244,20 @@ class Job extends BaseModel {
                 isNewJobEnabled &&
                 !isNewJobArchived
             ) {
-                await this[executor].startPeriodic({
-                    provider: newJob.permutations[0].provider,
+                const config = {
                     pipeline,
                     job: newJob,
                     tokenGen: this[tokenGen],
                     token: getToken(this[tokenGen], pipeline, newJob.id),
                     apiUri: this[apiUri],
                     isUpdate: true
-                });
+                };
+
+                if (hoek.reach(newJob.permutations[0], 'provider')) {
+                    config.provider = newJob.permutations[0].provider;
+                }
+
+                await this[executor].startPeriodic(config);
 
                 return this;
             }
@@ -261,12 +266,17 @@ class Job extends BaseModel {
                 (!isNewJobEnabled && isOldJobEnabled) ||
                 (isNewJobArchived && !isOldJobArchived)
             ) {
-                await this[executor].stopPeriodic({
-                    provider: newJob.permutations[0].provider,
+                const config = {
                     jobId: this.id,
                     pipelineId: pipeline.id,
                     token: getToken(this[tokenGen], pipeline, this.id)
-                });
+                };
+
+                if (hoek.reach(newJob.permutations[0], 'provider')) {
+                    config.provider = newJob.permutations[0].provider;
+                }
+
+                await this[executor].stopPeriodic(config);
             }
         } catch (err) {
             logger.error(`job:${this.id}: failed to update queue status`, err);
@@ -294,13 +304,18 @@ class Job extends BaseModel {
                             const stoppedStatuses = ['ABORTED', 'FAILURE', 'SUCCESS', 'COLLAPSED'];
 
                             if (!stoppedStatuses.includes(build.status)) {
-                                this[executor].stop({
-                                    provider: this.permutations[0].provider,
+                                const config = {
                                     buildId: build.id,
                                     pipelineId: pipeline.id,
                                     jobId: this.id,
                                     token: getToken(this[tokenGen], pipeline, this.id)
-                                });
+                                };
+
+                                if (hoek.reach(this.permutations[0], 'provider')) {
+                                    config.provider = this.permutations[0].provider;
+                                }
+
+                                this[executor].stop(config);
                             }
 
                             return build.remove();
@@ -316,12 +331,17 @@ class Job extends BaseModel {
             .then(pipeline => {
                 // Remove periodic job
                 if (getAnnotations(this.permutations[0], 'screwdriver.cd/buildPeriodically')) {
-                    return this[executor].stopPeriodic({
-                        provider: this.permutations[0].provider,
+                    const config = {
                         jobId: this.id,
                         pipelineId: pipeline.id,
                         token: getToken(this[tokenGen], pipeline, this.id)
-                    });
+                    };
+
+                    if (hoek.reach(this.permutations[0], 'provider')) {
+                        config.provider = this.permutations[0].provider;
+                    }
+
+                    return this[executor].stopPeriodic(config);
                 }
 
                 return null;


### PR DESCRIPTION
## Context

Adding provider param to executors is not backwards compatible and causes this error when shifting traffic:
```
Error: "provider" is not allowed
```
## Objective

This PR only passes provider when it exists.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2561, https://github.com/screwdriver-cd/models/pull/516

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
