### PR TITLE
feat(#2561): Add jobname and apiUri in executor config

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -608,7 +608,9 @@ class BuildModel extends BaseModel {
                             buildId: this.id,
                             jobId: job.id,
                             pipelineId: pipeline.id,
-                            token: getToken(this, job, pipeline)
+                            token: getToken(this, job, pipeline),
+                            jobName: job.name,
+                            apiUri: this[apiUri], 
                         };
 
                         if (this.buildClusterName) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -620,7 +620,7 @@ class BuildModel extends BaseModel {
                             pipelineId: pipeline.id,
                             token: getToken(this, job, pipeline),
                             jobName: job.name,
-                            apiUri: this[apiUri], 
+                            apiUri: this[apiUri]
                         };
 
                         if (this.buildClusterName) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -308,7 +308,9 @@ class Job extends BaseModel {
                                     buildId: build.id,
                                     pipelineId: pipeline.id,
                                     jobId: this.id,
-                                    token: getToken(this[tokenGen], pipeline, this.id)
+                                    token: getToken(this[tokenGen], pipeline, this.id),
+                                    jobName: this.name,
+                                    apiUri: this[apiUri]
                                 };
 
                                 if (hoek.reach(this.permutations[0], 'provider')) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -296,7 +296,9 @@ class Job extends BaseModel {
                                     buildId: build.id,
                                     pipelineId: pipeline.id,
                                     jobId: this.id,
-                                    token: getToken(this[tokenGen], pipeline, this.id)
+                                    token: getToken(this[tokenGen], pipeline, this.id),
+                                    jobName: this.name,
+                                    apiUri: this[apiUri]
                                 });
                             }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "eslint . --quiet",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 10000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "repository": {
     "type": "git",
@@ -30,10 +30,7 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   },
   "devDependencies": {
     "chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint . --quiet",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 10000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 10000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/models.git"
+    "url": "git+https://github.com/screwdriver-cd/models.git"
   },
   "homepage": "https://github.com/screwdriver-cd/models",
   "bugs": "https://github.com/screwdriver-cd/models/issues",

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -272,7 +272,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName: 'PR-5:main',
+                    apiUri
                 });
                 delete stepsMock[0].update;
                 delete stepsMock[1].update;
@@ -348,7 +350,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName: 'PR-5:main',
+                    apiUri
                 });
                 delete stepsMock[0].update;
                 delete stepsMock[1].update;
@@ -432,7 +436,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName: 'PR-5:main',
+                    apiUri
                 });
 
                 delete stepsMock[0].update;
@@ -494,7 +500,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName,
+                    apiUri
                 });
 
                 delete stepsMock[0].update;
@@ -536,7 +544,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName,
+                    apiUri
                 });
 
                 delete stepsMock[0].update;
@@ -628,7 +638,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName,
+                    apiUri
                 });
             });
         });
@@ -696,7 +708,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName: 'PR-5:main',
+                    apiUri
                 });
 
                 // Completed step is not modified
@@ -879,7 +893,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName,
+                    apiUri
                 });
             }));
 
@@ -895,7 +911,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName,
+                    apiUri
                 });
                 assert.calledWith(executorMock.stopTimer, {
                     buildId,
@@ -923,7 +941,9 @@ describe('Build Model', () => {
                     freezeWindows,
                     blockedBy: [jobId],
                     pipelineId,
-                    token: 'equivalentToOneQuarter'
+                    token: 'equivalentToOneQuarter',
+                    jobName,
+                    apiUri
                 });
             });
         });

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -447,7 +447,7 @@ describe('Job Model', () => {
 
     describe('update', () => {
         it('update a job and remove periodic, when job is disabled', () => {
-            const oldJob = Object.assign({}, job);
+            const oldJob = { ...job };
 
             oldJob.permutations = [
                 {
@@ -477,7 +477,7 @@ describe('Job Model', () => {
         });
 
         it('does not start periodic when new and old settings are undefined and job is enabled', () => {
-            const oldJob = Object.assign({}, job);
+            const oldJob = { ...job };
 
             oldJob.permutations = [
                 {
@@ -503,7 +503,7 @@ describe('Job Model', () => {
         });
 
         it('removes periodic when new and old settings are undefined and job is disabled', () => {
-            const oldJob = Object.assign({}, job);
+            const oldJob = { ...job };
 
             oldJob.permutations = [
                 {
@@ -567,7 +567,7 @@ describe('Job Model', () => {
         });
 
         it('no change of buildPeriodically', () => {
-            const oldJob = Object.assign({}, job);
+            const oldJob = { ...job };
 
             oldJob.state = 'ENABLED';
             oldJob.permutations = [
@@ -620,7 +620,7 @@ describe('Job Model', () => {
         });
 
         it('state disabled->enabled should start periodic job', () => {
-            const oldJob = Object.assign({}, job);
+            const oldJob = { ...job };
 
             oldJob.permutations = [
                 {
@@ -649,7 +649,7 @@ describe('Job Model', () => {
         });
 
         it('state archived->unarchived should start periodic job', () => {
-            const oldJob = Object.assign({}, job);
+            const oldJob = { ...job };
 
             oldJob.permutations = [
                 {


### PR DESCRIPTION
## Context

`jobname` and `apiUri` are needed in executor stop config for AWS Integration

## Objective

This PR adds jobname and apiUri in executor stop config

## References
Updated. schema:
https://github.com/screwdriver-cd/data-schema/pull/465

https://github.com/screwdriver-cd/screwdriver/issues/2559
https://github.com/screwdriver-cd/screwdriver/issues/2561

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
