### PR TITLE
fix(2596): Pass namespace to getTemplate in template create

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -156,7 +156,7 @@ class TemplateFactory extends BaseFactory {
                 latestTemplate = latestTemplates[0];
 
                 const configVersion = configMinor ? `${configMajor}${configMinor}` : `${configMajor}`;
-                const configFullTemplateName = `${config.name}@${configVersion}`;
+                const configFullTemplateName = `${result.namespace}/${result.name}@${configVersion}`;
 
                 return this.getTemplate(configFullTemplateName);
             })
@@ -314,7 +314,6 @@ class TemplateFactory extends BaseFactory {
      * @return {Promise}                        Resolves template model or null if not found
      */
     getTemplate(fullTemplateName) {
-        // eslint-disable-next-line max-len, no-underscore-dangle
         const { templateName, versionOrTag, isExactVersion, isVersion } = this.getFullNameAndVersion(fullTemplateName);
 
         if (isExactVersion) {

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -241,6 +241,7 @@ describe('Template Factory', () => {
             return factory
                 .create({
                     name,
+                    namespace,
                     version,
                     maintainer,
                     description,
@@ -1080,6 +1081,15 @@ describe('Template Factory', () => {
             ];
         });
 
+        it('should return empty array when templates are not found', () => {
+            expected = [];
+            datastore.scan.resolves(expected);
+
+            return factory.listWithMetrics(config).then(templates => {
+                assert.deepEqual(templates, expected);
+            });
+        });
+
         it('should list templates with metrics when namespace is passed in', () => {
             expected = [returnValue[0], returnValue[1], returnValue[2]];
             datastore.scan.resolves(expected);
@@ -1115,14 +1125,15 @@ describe('Template Factory', () => {
     });
 
     describe('getTemplate', () => {
-        const templateName = 'namespace/testTemplateName';
+        const templateName = 'testTemplateName';
+        const templateNamespace = 'namespace';
         const templateVersion = '1.0';
         let fullTemplateName;
         let expected;
         let returnValue;
 
         beforeEach(() => {
-            fullTemplateName = `${templateName}@${templateVersion}`;
+            fullTemplateName = `${templateNamespace}/${templateName}@${templateVersion}`;
 
             returnValue = [
                 {
@@ -1168,7 +1179,7 @@ describe('Template Factory', () => {
         });
 
         it('should get the correct template for a given namespace/name@exactVersion 1.0.2', () => {
-            fullTemplateName = `${templateName}@1.0.2`;
+            fullTemplateName = `${templateNamespace}/${templateName}@1.0.2`;
             expected = { namespace: 'namespace', ...returnValue[2] };
             returnValue[2].namespace = 'namespace';
             datastore.scan.onCall(0).resolves([returnValue[2]]);
@@ -1233,7 +1244,7 @@ describe('Template Factory', () => {
         });
 
         it('should get the correct template for a given namespace/name@tag', () => {
-            fullTemplateName = `${templateName}@latest`;
+            fullTemplateName = `${templateNamespace}/${templateName}@latest`;
             expected = { namespace: 'namespace', ...returnValue[2] };
             returnValue[2].namespace = 'namespace';
             templateTagFactoryMock.get.resolves({ version: '1.0.2' });


### PR DESCRIPTION
## Context

When we call `getTemplate` in template `create()` method, we're not passing in `namespace`. This might cause issues when template `name` is the same but `namespace` is different.

## Objective

This PR passes in `namespace` as a part of the full template name to `getTemplate` for template create.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2596

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
