### PR TITLE
fix(1500): [3] add unzipArtifacts method

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -671,6 +671,22 @@ class BuildModel extends BaseModel {
     }
 
     /**
+     * Unzip a ZIP for build artifacts
+     * @method unzipArtifacts
+     * @return {Promise}
+     */
+    unzipArtifacts() {
+        return Promise.resolve()
+                .then(() => Promise.all([this.job, this.pipeline]))
+                .then(([job, pipeline]) =>
+                    this[executor].unzipArtifacts({
+                        buildId: this.id,
+                        token: getToken(this, job, pipeline)
+                    })
+                );
+    }
+
+    /**
      * Check if a build is done
      * @method isDone
      * @return boolean

--- a/lib/build.js
+++ b/lib/build.js
@@ -676,14 +676,12 @@ class BuildModel extends BaseModel {
      * @return {Promise}
      */
     unzipArtifacts() {
-        return Promise.resolve()
-            .then(() => Promise.all([this.job, this.pipeline]))
-            .then(([job, pipeline]) =>
-                this[executor].unzipArtifacts({
-                    buildId: this.id,
-                    token: getToken(this, job, pipeline)
-                })
-            );
+        return Promise.all([this.job, this.pipeline]).then(([job, pipeline]) =>
+            this[executor].unzipArtifacts({
+                buildId: this.id,
+                token: getToken(this, job, pipeline)
+            })
+        );
     }
 
     /**

--- a/lib/build.js
+++ b/lib/build.js
@@ -677,13 +677,13 @@ class BuildModel extends BaseModel {
      */
     unzipArtifacts() {
         return Promise.resolve()
-                .then(() => Promise.all([this.job, this.pipeline]))
-                .then(([job, pipeline]) =>
-                    this[executor].unzipArtifacts({
-                        buildId: this.id,
-                        token: getToken(this, job, pipeline)
-                    })
-                );
+            .then(() => Promise.all([this.job, this.pipeline]))
+            .then(([job, pipeline]) =>
+                this[executor].unzipArtifacts({
+                    buildId: this.id,
+                    token: getToken(this, job, pipeline)
+                })
+            );
     }
 
     /**

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -86,7 +86,8 @@ describe('Build Model', () => {
             stop: sinon.stub(),
             startTimer: sinon.stub(),
             stopTimer: sinon.stub(),
-            stopFrozen: sinon.stub()
+            stopFrozen: sinon.stub(),
+            unzipArtifacts: sinon.stub()
         };
         userFactoryMock = {
             get: sinon.stub()
@@ -1839,5 +1840,21 @@ describe('Build Model', () => {
                     assert.deepEqual(err, expectedError);
                 });
         });
+    });
+
+    describe('unzipArtifacts', () => {
+        beforeEach(() => {
+            executorMock.unzipArtifacts.resolves(null);
+            jobFactoryMock.get.resolves(jobMock);
+            pipelineFactoryMock.get.resolves(pipelineMock);
+        });
+
+        it('promises to unzip a ZIP of artifacts', () =>
+            build.unzipArtifacts().then(() => {
+                assert.calledWith(executorMock.unzipArtifacts, {
+                    buildId,
+                    token
+                });
+            }));
     });
 });


### PR DESCRIPTION
## Context
To implement SD_ZIP_ARTIFACTS feature by [new design](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md)

Please refer the following for the progress of this feature.
https://github.com/screwdriver-cd/screwdriver/issues/1500#issuecomment-998382248

## Objective
This PR add a new method for `build` model to unzip a ZIP of artifacts.

## References
This PR depends on following PRs.
- https://github.com/screwdriver-cd/executor-base/pull/75
- https://github.com/screwdriver-cd/executor-queue/pull/97

[design doc](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md#sd-api-api)

[issue](https://github.com/screwdriver-cd/screwdriver/issues/1500)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
