### PR TITLE
fix(2346): Do not include job parameters from PR jobs

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -533,13 +533,16 @@ async function getJobParameters(config) {
     const jobs = await pipeline.getJobs();
 
     jobs.forEach(job => {
-        const jobParameters = job.permutations[0].parameters; // TODO: Revisit while supporting matrix job
+        // Ignore PR jobs (Ex: PR-2:component) as the parameters would be included from the parent jobs (Ex: component)
+        if (job.prParentJobId === null || job.prParentJobId === undefined) {
+            const jobParameters = job.permutations[0].parameters; // TODO: Revisit while supporting matrix job
 
-        if (jobParameters) {
-            allowedParameters[job.name] = validateAndMergeParameters(
-                jobParameters,
-                hoek.reach(eventConfig, `meta.parameters.${job.name}`)
-            );
+            if (jobParameters) {
+                allowedParameters[job.name] = validateAndMergeParameters(
+                    jobParameters,
+                    hoek.reach(eventConfig, `meta.parameters.${job.name}`)
+                );
+            }
         }
     });
 

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -2241,7 +2241,7 @@ describe('Event Factory', () => {
                         name: 'component',
                         permutations: [
                             {
-                                requires: ['~commit'],
+                                requires: ['~commit', '~pr'],
                                 sourcePaths: ['src/test'],
                                 parameters: {
                                     color: 'white',
@@ -2273,6 +2273,29 @@ describe('Event Factory', () => {
                                     car: ['Ferrari', 'Lamborghini'],
                                     sports: {
                                         value: ['cricket', 'soccer']
+                                    }
+                                }
+                            }
+                        ],
+                        state: 'ENABLED'
+                    },
+                    {
+                        id: 3,
+                        pipelineId: 8765,
+                        name: 'PR-3:component',
+                        prParentJobId: 1,
+                        permutations: [
+                            {
+                                requires: ['~commit', '~pr'],
+                                sourcePaths: ['src/test'],
+                                parameters: {
+                                    color: 'white',
+                                    cuisine: {
+                                        value: 'Italian'
+                                    },
+                                    car: ['Audi', 'Tesla'],
+                                    music: {
+                                        value: ['jazz', 'rock']
                                     }
                                 }
                             }


### PR DESCRIPTION
## Context

Same job level parameters are being include twice in `meta`. Once under job name (Ex: `component`) and again under PR job name (Ex: `PR-3:component`).

Note: Even for PR builds, job level parameters for all the jobs in the pipeline are added to `meta`

## Objective
Ignore parameters from PR jobs (Ex: `PR-3:component`) as the parameters would be included from their parent jobs (Ex: `component`)

**Before**
`{
  "parameters": {
    "PR-3:component": {
      "param_car": "Audi",
      "param_color": "red",
      "param_sports": "cricket"
    },
    "component": {
      "param_car": "Audi",
      "param_color": "red",
      "param_sports": "cricket"
    },
    "publish": {
      "param_color": {
        "value": "white"
      },
      "param_music": {
        "value": "Jazz"
      },
      "param_region": {
        "value": "us-west"
      }
    },
    "param_region": {
      "value": "us-east"
    },
    "param_sports": {
      "value": "badminton"
    },
    "param_superuser": {
      "value": "yes"
    }
  }
}`

**After**
`{
  "parameters": {
    "component": {
      "param_car": "Audi",
      "param_color": "red",
      "param_sports": "cricket"
    },
    "publish": {
      "param_color": {
        "value": "white"
      },
      "param_music": {
        "value": "Jazz"
      },
      "param_region": {
        "value": "us-west"
      }
    },
    "param_region": {
      "value": "us-east"
    },
    "param_sports": {
      "value": "badminton"
    },
    "param_superuser": {
      "value": "yes"
    }
  }
}`

## References
https://github.com/screwdriver-cd/screwdriver/issues/2346
https://github.com/screwdriver-cd/models/pull/514

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
