### PR TITLE
fix: return 403 when pipeline has no admin

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -5,6 +5,7 @@
 
 const parser = require('screwdriver-config-parser');
 const workflowParser = require('screwdriver-workflow-parser');
+const boom = require('@hapi/boom');
 const hoek = require('@hapi/hoek');
 const dayjs = require('dayjs');
 const _ = require('lodash');
@@ -1136,7 +1137,7 @@ class PipelineModel extends BaseModel {
 
         if (Object.keys(newAdmins).length === 0) {
             logger.error(`pipelineId:${id}: Pipeline has no admin.`);
-            throw new Error('Pipeline has no admin');
+            throw boom.forbidden('Pipeline has no admin');
         }
 
         if (!(this.configPipelineId && enabled)) {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1699,6 +1699,7 @@ describe('Pipeline Model', () => {
                 .catch(e => {
                     assert.isOk(e);
                     assert.equal(e.message, 'Pipeline has no admin');
+                    assert.equal(e.output.statusCode, 403);
                 });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When a pipeline does not have an administrator, the 500 error is returned.
However, since this is an authorization error caused by users, I think that the 403 error should be returned.
This change will allow the error data to be aggregated correctly.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Use `hapi/boom.forbidden` to throw the error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Example of status code control using `hapi/boom`
https://github.com/screwdriver-cd/models/blob/18b0bfaab3bdb15358f40a38ec668997d7c89973/lib/build.js#L753-L756

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
