### PR TITLE
feat: Pass buildclustername from provider

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -214,6 +214,9 @@ class BuildFactory extends BaseFactory {
                             pipeline
                         });
                     }
+                    if (job.provider && job.provider.executor) {
+                        buildClusterName = job.provider.executor;
+                    }
 
                     if (buildClusterName) {
                         modelConfig.buildClusterName = buildClusterName;


### PR DESCRIPTION
## Context

We need a mechanism to pass provider executor information to bookends

## Objective

This PR adds a logic to pass buildclustername from provider information in job if available

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
