### PR TITLE
feat: send provider name to bookend

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -214,8 +214,8 @@ class BuildFactory extends BaseFactory {
                             pipeline
                         });
                     }
-                    if (job.provider && job.provider.executor) {
-                        buildClusterName = job.provider.executor;
+                    if (job.provider && job.provider.name) {
+                        buildClusterName = job.provider.name;
                     }
 
                     if (buildClusterName) {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -214,6 +214,9 @@ class BuildFactory extends BaseFactory {
                             pipeline
                         });
                     }
+                    if (job.provider && job.provider.executor) {
+                        buildClusterName = job.provider.executor;
+                    }
 
                     if (buildClusterName) {
                         modelConfig.buildClusterName = buildClusterName;

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -616,7 +616,7 @@ describe('Build Factory', () => {
                 permutations,
                 pipeline: Promise.resolve({ scmUri, scmRepo, scmContext }),
                 provider: {
-                    executor: 'aws'
+                    name: 'aws'
                 }
             };
 
@@ -983,7 +983,7 @@ describe('Build Factory', () => {
                 permutations,
                 pipeline: Promise.resolve(pipelineMock),
                 provider: {
-                    executor: 'aws'
+                    name: 'aws'
                 }
             };
 


### PR DESCRIPTION
## Context

Provider name is required in bookend to use deploy key for integration

## Objective

This PR passes provider name to bookend

## References


## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
