### PR TITLE
feat: add correct provider from job permutation

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -214,8 +214,8 @@ class BuildFactory extends BaseFactory {
                             pipeline
                         });
                     }
-                    if (job.provider && job.provider.executor) {
-                        buildClusterName = job.provider.executor;
+                    if (job.provider && job.provider.name) {
+                        buildClusterName = job.provider.name;
                     }
 
                     if (buildClusterName) {

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -214,6 +214,9 @@ class BuildFactory extends BaseFactory {
                             pipeline
                         });
                     }
+                    if (job.provider && job.provider.executor) {
+                        buildClusterName = job.provider.executor;
+                    }
 
                     if (buildClusterName) {
                         modelConfig.buildClusterName = buildClusterName;

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -214,8 +214,12 @@ class BuildFactory extends BaseFactory {
                             pipeline
                         });
                     }
-                    if (job.provider && job.provider.name) {
-                        buildClusterName = job.provider.name;
+                    if (hoek.reach(permutation, 'provider')) {
+                        const { provider } = permutation;
+
+                        if (provider && provider.name) {
+                            buildClusterName = provider.name;
+                        }
                     }
 
                     if (buildClusterName) {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -616,7 +616,7 @@ describe('Build Factory', () => {
                 permutations,
                 pipeline: Promise.resolve({ scmUri, scmRepo, scmContext }),
                 provider: {
-                    executor: 'aws'
+                    name: 'aws'
                 }
             };
 
@@ -983,7 +983,7 @@ describe('Build Factory', () => {
                 permutations,
                 pipeline: Promise.resolve(pipelineMock),
                 provider: {
-                    executor: 'aws'
+                    name: 'aws'
                 }
             };
 

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -245,6 +245,35 @@ describe('Build Factory', () => {
                 image: 'node:6'
             }
         ];
+        const permutationsWithProvider = [
+            {
+                commands: [
+                    { command: 'npm install', name: 'init' },
+                    { command: 'npm test', name: 'test' }
+                ],
+                environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
+                image: 'node:4',
+                provider: {
+                    name: 'aws'
+                }
+            },
+            {
+                commands: [
+                    { command: 'npm install', name: 'init' },
+                    { command: 'npm test', name: 'test' }
+                ],
+                environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
+                image: 'node:5'
+            },
+            {
+                commands: [
+                    { command: 'npm install', name: 'init' },
+                    { command: 'npm test', name: 'test' }
+                ],
+                environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
+                image: 'node:6'
+            }
+        ];
         const permutationsWithAnnotations = [
             {
                 annotations: {
@@ -613,11 +642,8 @@ describe('Build Factory', () => {
         it('sets build cluster from provider if available', () => {
             const user = { unsealToken: sinon.stub().resolves('foo') };
             const jobMock = {
-                permutations,
-                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext }),
-                provider: {
-                    name: 'aws'
-                }
+                permutations: permutationsWithProvider,
+                pipeline: Promise.resolve({ scmUri, scmRepo, scmContext })
             };
 
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
@@ -980,11 +1006,8 @@ describe('Build Factory', () => {
                 configPipeline: Promise.resolve({ spooky: 'ghost' })
             };
             const jobMock = {
-                permutations,
-                pipeline: Promise.resolve(pipelineMock),
-                provider: {
-                    name: 'aws'
-                }
+                permutations: permutationsWithProvider,
+                pipeline: Promise.resolve(pipelineMock)
             };
 
             userFactoryMock.get.resolves({});


### PR DESCRIPTION
## Context

Provider config is part of job permuation

## Objective

This PR fixes usage of provider config from job permutation

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
