### PR TITLE
fix(1645): Add step retry to commands [2]

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -264,10 +264,18 @@ class BuildFactory extends BaseFactory {
                         // Launcher is hardcoded to do some business in sd-setup-launcher
                         { name: 'sd-setup-launcher' },
                         ...setup,
-                        ...permutation.commands.map(command => ({
-                            name: command.name,
-                            command: command.command
-                        })),
+                        ...permutation.commands.map(command =>
+                            command.retry
+                                ? {
+                                      name: command.name,
+                                      command: command.command,
+                                      retry: command.retry
+                                  }
+                                : {
+                                      name: command.name,
+                                      command: command.command
+                                  }
+                        ),
                         ...teardown
                     ];
 

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "chai": "^4.3.0",
     "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.7",
-    "mocha": "^8.4.0",
+    "mocha": "^9.2.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.0.0",
     "nyc": "^15.0.0",
-    "rewire": "^5.0.0",
+    "rewire": "^6.0.0",
     "sinon": "^9.2.0"
   },
   "dependencies": {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -48,7 +48,15 @@ describe('Build Factory', () => {
         { name: 'sd-setup-launcher' },
         { name: 'sd-setup-scm', command: 'git clone' },
         { command: 'npm install', name: 'init' },
-        { command: 'npm test', name: 'test' }
+        {
+            command: 'npm test',
+            name: 'test',
+            retry: {
+                attempt: 0,
+                interval: 0,
+                max: 1
+            }
+        }
     ];
     const scmContext = 'github:github.com';
     const sdBuildClusters = [


### PR DESCRIPTION
## Context

Sometimes users might have a flaky step or will want to retry a step on failure.

## Objective

This PR passes step retry config when it exists.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1645

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
