### PR TITLE
fix: Remove readOnly for getLatestBuilds [1]

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -360,12 +360,13 @@ class BuildFactory extends BaseFactory {
      * @method getLatestBuilds
      * @param  {Object}     config                  Config object
      * @param  {Number}     config.groupEventId     Group event ID to get build statuses for
+     * @param  {Boolean}    [config.readOnly]       Use RO DB (default: true)
      * @return {Promise}
      */
     getLatestBuilds(config) {
         const queryConfig = {
             queries: getQueries(this.datastore.prefix, LATEST_BUILD_QUERY),
-            readOnly: true,
+            readOnly: config.readOnly !== false,
             replacements: {
                 groupEventId: config.groupEventId
             }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.5.3",
-    "screwdriver-data-schema": "^21.22.1",
+    "screwdriver-data-schema": "^21.22.2",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }


### PR DESCRIPTION
## Context

Seeing some `SequelizeUniqueConstraintError` as a result of `triggerNextJobInSamePipeline` for join logic in Screwdriver build index. This might be because the `readOnly` DB has a slight delay, causing `getLatestBuilds` call to not get the CREATED join job.

## Objective

This PR adds option to pass in `readOnly` flag for `getLatestBuilds`.

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
