### PR TITLE
feat(2631): Add event creator name to metadata

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -828,6 +828,10 @@ class EventFactory extends BaseFactory {
                                 modelConfig.meta.parameters = updatedParameters;
                             }
 
+                            if (username) {
+                                modelConfig.meta.event = { creator: username };
+                            }
+
                             if (!config.meta) {
                                 config.meta = modelConfig.meta;
                             }

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -217,7 +217,7 @@ describe('Event Factory', () => {
                 createTime: nowTime,
                 creator,
                 commit,
-                meta: {}
+                meta: { event: { creator: 'stjohn' } }
             };
 
             syncedPipelineMock = {


### PR DESCRIPTION
## Context
We want to get the event creator information from metadata.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We add event creator information to metadata. The SCM username of the person who created the event will be obtained with `meta get event.creator`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[#2631](https://github.com/screwdriver-cd/screwdriver/issues/2631)
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
