### PR TITLE
fix: get event creator info from config creator

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -828,8 +828,8 @@ class EventFactory extends BaseFactory {
                                 modelConfig.meta.parameters = updatedParameters;
                             }
 
-                            if (username) {
-                                modelConfig.meta.event = { creator: username };
+                            if (modelConfig.creator) {
+                                modelConfig.meta.event = { creator: modelConfig.creator.username };
                             }
 
                             if (!config.meta) {

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1445,6 +1445,7 @@ describe('Event Factory', () => {
 
             config.creator = creatorTest;
             expected.creator = creatorTest;
+            expected.meta.event.creator = creatorTest.username;
 
             return eventFactory.create(config).then(model => {
                 assert.instanceOf(model, Event);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Event creator metadata should match the event config creator.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Get event creator info from config creator.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
follows up https://github.com/screwdriver-cd/models/pull/532

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
