### PR TITLE
fix: do not auto delete obsolete child pipelines

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -837,58 +837,6 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Remove a pipeline given a scmUrl
-     * @method _removePipeline
-     * @param {String} scmUrl  checkout url for a repository
-     * @return {Promise}
-     */
-    async _removePipeline(scmUrl) {
-        // Get hostname using scmUrl
-        const regex = Schema.config.regex.CHECKOUT_URL;
-        const matched = regex.exec(scmUrl);
-        const hostname = matched[MATCH_COMPONENT_HOSTNAME];
-
-        // Set scmContext
-        const scmContext = this.scm.getScmContext({ hostname });
-        const scmUri = await this._getScmUri({ scmUrl, scmContext });
-        let hasAdminPermission = false;
-
-        if (this.scmContext !== scmContext) {
-            // Check for read-only scm, add headless admin to admin config
-            const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
-
-            if (!readOnlyInfo.enabled) {
-                logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
-
-                return null;
-            }
-
-            hasAdminPermission = true;
-        } else {
-            // Check admin permissions
-            hasAdminPermission = await this._hasAdminPermission(scmUri);
-        }
-
-        if (!hasAdminPermission) {
-            // TODO: need to figure out how to bubble up this err to user
-            logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
-
-            return null;
-        }
-
-        const pipelineFactory = this._getPipelineFactory();
-        const pipeline = await pipelineFactory.get({ scmUri });
-
-        // remove pipeline only if it's a child pipeline and belongs to current pipeline
-        if (pipeline && pipeline.configPipelineId === this.id) {
-            logger.info(`pipelineId:${this.id}: Removing child pipeline for ${scmUrl} with pipelineId:${pipeline.id}.`);
-            pipeline.remove();
-        }
-
-        return null;
-    }
-
-    /**
      * Sync child pipelines given scmUrls
      * @method syncChildPipelines
      * @param {Array} scmUrls  An array of scmUrls for child pipelines
@@ -896,18 +844,12 @@ class PipelineModel extends BaseModel {
      */
     async _syncChildPipelines(scmUrls) {
         const toCreateOrUpdate = [];
-        const toRemove = [];
-        // const oldScmUrls = hoek.reach(this.childPipelines, 'scmUrls') || [];
         const newScmUrls = scmUrls || [];
-        // scmUrls in the old list but not the new list should be removed
-        // const scmUrlsToRemove = oldScmUrls.filter(scmUrl => !newScmUrls.includes(scmUrl));
 
         // create or update child pipelines
         newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl)));
-        // remove child pipelines
-        // scmUrlsToRemove.forEach(scmUrl => toRemove.push(this._removePipeline(scmUrl)));
 
-        return Promise.all([toCreateOrUpdate, toRemove]);
+        return Promise.resolve(toCreateOrUpdate);
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -897,15 +897,15 @@ class PipelineModel extends BaseModel {
     async _syncChildPipelines(scmUrls) {
         const toCreateOrUpdate = [];
         const toRemove = [];
-        const oldScmUrls = hoek.reach(this.childPipelines, 'scmUrls') || [];
+        // const oldScmUrls = hoek.reach(this.childPipelines, 'scmUrls') || [];
         const newScmUrls = scmUrls || [];
         // scmUrls in the old list but not the new list should be removed
-        const scmUrlsToRemove = oldScmUrls.filter(scmUrl => !newScmUrls.includes(scmUrl));
+        // const scmUrlsToRemove = oldScmUrls.filter(scmUrl => !newScmUrls.includes(scmUrl));
 
         // create or update child pipelines
         newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl)));
         // remove child pipelines
-        scmUrlsToRemove.forEach(scmUrl => toRemove.push(this._removePipeline(scmUrl)));
+        // scmUrlsToRemove.forEach(scmUrl => toRemove.push(this._removePipeline(scmUrl)));
 
         return Promise.all([toCreateOrUpdate, toRemove]);
     }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -997,7 +997,7 @@ describe('Pipeline Model', () => {
                 assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
                 assert.calledOnce(pipelineFactoryMock.create);
                 assert.calledOnce(childPipelineMock.sync);
-                assert.calledOnce(childPipelineMock.remove);
+                assert.notCalled(childPipelineMock.remove);
             });
         });
 
@@ -1024,7 +1024,7 @@ describe('Pipeline Model', () => {
                 assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
                 assert.calledOnce(pipelineFactoryMock.create);
                 assert.calledOnce(childPipelineMock.sync);
-                assert.calledOnce(childPipelineMock.remove);
+                assert.notCalled(childPipelineMock.remove);
             });
         });
 
@@ -1052,7 +1052,7 @@ describe('Pipeline Model', () => {
                 assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
                 assert.notCalled(pipelineFactoryMock.create);
                 assert.notCalled(childPipelineMock.sync);
-                assert.calledOnce(childPipelineMock.remove);
+                assert.notCalled(childPipelineMock.remove);
             });
         });
 
@@ -1119,7 +1119,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('removes child pipeline and resets scmUrls if it is removed from new yaml', () => {
+        it('does not remove child pipeline if scmUrls is removed from new yaml', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
@@ -1133,11 +1133,11 @@ describe('Pipeline Model', () => {
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
                 assert.equal(p.childPipelines, null);
-                assert.calledOnce(childPipelineMock.remove);
+                assert.notCalled(childPipelineMock.remove);
             });
         });
 
-        it('removes child pipeline and resets scmUrls if it is read-only SCM', () => {
+        it('does not remove child pipeline if scmUrls is is read-only SCM and removed from new yaml', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
@@ -1151,7 +1151,7 @@ describe('Pipeline Model', () => {
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
                 assert.equal(p.childPipelines, null);
-                assert.calledOnce(childPipelineMock.remove);
+                assert.notCalled(childPipelineMock.remove);
             });
         });
 


### PR DESCRIPTION
## Context

Child pipelines are programmatically deleted when there is only domain change in the SCM URI of child pipelines. This is not recoverable and lead to loss of build history of child pipelines.

## Objective

Stop deleting child pipelines programmatically

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2580

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
