### PR TITLE
fix: wait until child pipelines updates are completed

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -849,7 +849,7 @@ class PipelineModel extends BaseModel {
         // create or update child pipelines
         newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl)));
 
-        return Promise.resolve(toCreateOrUpdate);
+        return Promise.all(toCreateOrUpdate);
     }
 
     /**


### PR DESCRIPTION
## Context

Sync pipeline may not wait until the child pipelines updates are completed

## Objective

Block until all the child pipeline updates are completed

## References

https://github.com/screwdriver-cd/models/pull/534

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
