### PR TITLE
fix: pipeline sync - failure to update child pipeline should not fail rest of the pipeline update

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -849,7 +849,7 @@ class PipelineModel extends BaseModel {
         // create or update child pipelines
         newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl)));
 
-        return Promise.all(toCreateOrUpdate);
+        return Promise.allSettled(toCreateOrUpdate);
     }
 
     /**


### PR DESCRIPTION

## Context

Changes made in this PR https://github.com/screwdriver-cd/models/pull/535 could break parent pipeline update if there is failure in when updating child pipeline.

## Objective

This PR relax the above dependency so that pipeline updates are successfully applied even when child pipeline updates fail.

## References

https://github.com/screwdriver-cd/models/pull/535

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
