### PR TITLE
fix(2704): Do not run PR job if original job is disabled

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -5,7 +5,7 @@ const dayjs = require('dayjs');
 const hoek = require('@hapi/hoek');
 const deepcopy = require('deepcopy');
 const logger = require('screwdriver-logger');
-const { PR_JOB_NAME, EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
+const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const { SCM_STATE_MAP, SCM_STATUSES } = require('screwdriver-data-schema').plugins.scm;
 const BaseModel = require('./base');
 
@@ -26,16 +26,7 @@ const TEMPORAL_JWT_TIMEOUT = 12 * 60; // 12 hours in minutes
  */
 function findIdsOfMatchedJobs(jobs, jobNames) {
     return jobs.reduce((match, j) => {
-        let { name } = j;
-
-        // Get the actual job name if the matching job is a PR job
-        if (j.isPR()) {
-            const prJobName = j.name.match(PR_JOB_NAME);
-
-            if (prJobName) {
-                name = prJobName[2];
-            }
-        }
+        const name = j.parsePRJobName('job') || j.name;
 
         if (jobNames.includes(name)) {
             match.push(j.id);

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -139,16 +139,13 @@ function getJobsFromPR(config) {
         );
     }
 
-    // Handle PR jobs with PR-#: prefix
-    const nextJobsWithoutPrPrefix = nextJobs.map(j => helper.parsePRJobName(j).name);
-    const jobsToStartWithoutPrPrefix = jobs.filter(j => nextJobsWithoutPrPrefix.includes(j.name));
-
     const jobsToStart = jobs.filter(j => nextJobs.includes(j.name));
 
     return jobsToStart.filter(j => {
+        // Handle PR jobs with PR-#: prefix
         // Make sure original job is also not disabled
         const originalJobName = helper.parsePRJobName(j.name).name;
-        const originalJob = jobsToStartWithoutPrPrefix.find(o => o.name === originalJobName);
+        const originalJob = jobs.find(o => o.name === originalJobName);
         const originalJobEnabled = originalJob.state === 'ENABLED';
         const originalJobNotArchived = originalJob.archived !== 'true';
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -13,7 +13,6 @@ const logger = require('screwdriver-logger');
 const hoek = require('@hapi/hoek');
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
-const helper = require('./helper');
 let instance;
 
 /**
@@ -144,7 +143,7 @@ function getJobsFromPR(config) {
     return jobsToStart.filter(j => {
         // Handle PR jobs with PR-#: prefix
         // Make sure original job is also not disabled
-        const originalJobName = helper.parsePRJobName(j.name).name;
+        const originalJobName = j.parsePRJobName('job');
         const originalJob = jobs.find(o => o.name === originalJobName);
         const originalJobEnabled = originalJob.state === 'ENABLED';
         const originalJobNotArchived = originalJob.archived !== 'true';

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -13,6 +13,7 @@ const logger = require('screwdriver-logger');
 const hoek = require('@hapi/hoek');
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
+const helper = require('./helper');
 let instance;
 
 /**
@@ -138,9 +139,21 @@ function getJobsFromPR(config) {
         );
     }
 
+    // Handle PR jobs with PR-#: prefix
+    const nextJobsWithoutPrPrefix = nextJobs.map(j => helper.parsePRJobName(j).name);
+    const jobsToStartWithoutPrPrefix = jobs.filter(j => nextJobsWithoutPrPrefix.includes(j.name));
+
     const jobsToStart = jobs.filter(j => nextJobs.includes(j.name));
 
-    return jobsToStart.filter(j => j.state === 'ENABLED' && !j.archived);
+    return jobsToStart.filter(j => {
+        // Make sure original job is also not disabled
+        const originalJobName = helper.parsePRJobName(j.name).name;
+        const originalJob = jobsToStartWithoutPrPrefix.find(o => o.name === originalJobName);
+        const originalJobEnabled = originalJob.state === 'ENABLED';
+        const originalJobNotArchived = originalJob.archived !== 'true';
+
+        return j.state === 'ENABLED' && !j.archived && !!originalJobEnabled && !!originalJobNotArchived;
+    });
 }
 
 /**

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -3,23 +3,8 @@
 const schema = require('screwdriver-data-schema');
 const hoek = require('@hapi/hoek');
 const dayjs = require('dayjs');
-const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
-const PR_JOB_NAME_REGEX = schema.config.regex.PR_JOB_NAME;
-
-/**
- * Get the original job name and PR number from full PR job name
- * @param  {String} name Full PR job name (e.g.: PR-100:main)
- * @return {Object}      PR number and job name
- */
-function parsePRJobName(name) {
-    const [, fullPrNum, jobName] = PR_JOB_NAME_REGEX.exec(name);
-
-    return {
-        prNum: fullPrNum,
-        name: jobName
-    };
-}
+const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 
 /**
  * Get the value of the annotation that matches name
@@ -239,7 +224,6 @@ function getToken(fn, pipeline, jobId) {
 }
 
 module.exports = {
-    parsePRJobName,
     getAnnotations,
     parseTemplateConfigName,
     getAllRecords,

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -5,6 +5,21 @@ const hoek = require('@hapi/hoek');
 const dayjs = require('dayjs');
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const formatDate = dateTime => dayjs(dateTime).format('YYYY-MM-DD');
+const PR_JOB_NAME_REGEX = schema.config.regex.PR_JOB_NAME;
+
+/**
+ * Get the original job name and PR number from full PR job name
+ * @param  {String} name Full PR job name (e.g.: PR-100:main)
+ * @return {Object}      PR number and job name
+ */
+function parsePRJobName(name) {
+    const [, fullPrNum, jobName] = PR_JOB_NAME_REGEX.exec(name);
+
+    return {
+        prNum: fullPrNum,
+        name: jobName
+    };
+}
 
 /**
  * Get the value of the annotation that matches name
@@ -224,6 +239,7 @@ function getToken(fn, pipeline, jobId) {
 }
 
 module.exports = {
+    parsePRJobName,
     getAnnotations,
     parseTemplateConfigName,
     getAllRecords,

--- a/lib/job.js
+++ b/lib/job.js
@@ -3,12 +3,16 @@
 const logger = require('screwdriver-logger');
 const dayjs = require('dayjs');
 const hoek = require('@hapi/hoek');
+const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
 const BaseModel = require('./base');
 const { getAnnotations, getAllRecords, getToken } = require('./helper');
 const executor = Symbol('executor');
 const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
-const START_INDEX = 3;
+const REGEX_CAPTURING_GROUP = {
+    pr: 1, // PR-1
+    job: 2 // main or undefined if using legacy
+};
 const MAX_METRIC_GET_COUNT = 1000;
 const MAX_BUILD_DELETE_COUNT = 100;
 const DEFAULT_COUNT = 10;
@@ -128,11 +132,21 @@ class Job extends BaseModel {
     }
 
     /**
+     * Get part of a PR job name based on given type
+     * @method parsePRJobName
+     * @param  {String}    type         Type can either be pr or job, e.g. pr => PR-1, job => main
+     * @return {String}                 Substring of a PR job name based on given type
+     */
+    parsePRJobName(type) {
+        return this.isPR() ? this.name.match(PR_JOB_NAME)[REGEX_CAPTURING_GROUP[type]] : null;
+    }
+
+    /**
      * Return PR number. Returns null if this is not a PR job
      * @return {Number}     PR number
      */
     get prNum() {
-        return this.isPR() ? parseInt(this.name.slice(START_INDEX), 10) : null;
+        return this.isPR() ? parseInt(this.parsePRJobName('pr').split('-')[1], 10) : null;
     }
 
     /**

--- a/lib/job.js
+++ b/lib/job.js
@@ -11,7 +11,7 @@ const tokenGen = Symbol('tokenGen');
 const apiUri = Symbol('apiUri');
 const REGEX_CAPTURING_GROUP = {
     pr: 1, // PR-1
-    job: 2 // main or undefined if using legacy
+    job: 2 // undefined if using legacy
 };
 const MAX_METRIC_GET_COUNT = 1000;
 const MAX_BUILD_DELETE_COUNT = 100;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -10,14 +10,10 @@ const hoek = require('@hapi/hoek');
 const dayjs = require('dayjs');
 const yamlParser = require('js-yaml');
 const _ = require('lodash');
-const { PR_JOB_NAME, EXTERNAL_TRIGGER_ALL, CHECKOUT_URL } = require('screwdriver-data-schema').config.regex;
+const { EXTERNAL_TRIGGER_ALL, CHECKOUT_URL } = require('screwdriver-data-schema').config.regex;
 const logger = require('screwdriver-logger');
 const Schema = require('screwdriver-data-schema');
 const BaseModel = require('./base');
-const REGEX_CAPTURING_GROUP = {
-    pr: 1, // PR-1
-    job: 2 // main or undefined if using legacy
-};
 const MAX_METRIC_GET_COUNT = 1000;
 const MAX_JOB_DELETE_COUNT = 10;
 const MAX_EVENT_DELETE_COUNT = 100;
@@ -421,17 +417,6 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Get part of a PR job name based on given type
-     * @method _getPartialJobName
-     * @param  {String}    jobName      Name of a PR job
-     * @param  {String}    type         Type can either be pr or job, e.g. pr => PR-1, job => main
-     * @return {String}                 Substring of a PR job name based on given type
-     */
-    _getPartialJobName(jobName, type) {
-        return jobName.match(PR_JOB_NAME)[REGEX_CAPTURING_GROUP[type]];
-    }
-
-    /**
      * archive closed PR jobs
      * @param {Array}   existingJobs List pipeline's existing jobs
      * @param {Array}   openedPRs    List of opened PRs coming from SCM
@@ -444,7 +429,7 @@ class PipelineModel extends BaseModel {
 
         existingPRs.forEach(job => {
             // getting PR and number e.g. PR-1
-            const prName = this._getPartialJobName(job.name, 'pr');
+            const prName = job.parsePRJobName('pr');
 
             // if PR is closed, add it to archive list
             if (!openedPRsNames.includes(prName) && !job.archived) {
@@ -467,7 +452,7 @@ class PipelineModel extends BaseModel {
         const jobsToUpdate = [];
 
         jobList.forEach(j => {
-            const jobName = this._getPartialJobName(j.name, 'job') || 'main';
+            const jobName = j.parsePRJobName('job') || 'main';
 
             if (parsedConfig) {
                 j.permutations = parsedConfig.jobs[jobName];

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -383,7 +383,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('main')
                     }
                 ];
 
@@ -442,7 +443,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('main')
                     },
                     {
                         id: 6,
@@ -454,6 +456,7 @@ describe('Event Factory', () => {
                             }
                         ],
                         state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('outdated'),
                         archived: true
                     },
                     {
@@ -476,7 +479,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('main')
                     },
                     {
                         id: 3,
@@ -496,7 +500,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr']
                             }
                         ],
-                        state: 'DISABLED'
+                        state: 'DISABLED',
+                        parsePRJobName: sinon.stub().returns('publish')
                     }
                 ];
 
@@ -535,7 +540,6 @@ describe('Event Factory', () => {
                 });
             });
 
-            // eslint-disable-next-line max-len
             it('should start existing unarchived branch pr jobs without creating duplicates', () => {
                 jobsMock = [
                     {
@@ -558,7 +562,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr:branch']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('main')
                     },
                     {
                         id: 6,
@@ -570,7 +575,8 @@ describe('Event Factory', () => {
                             }
                         ],
                         state: 'ENABLED',
-                        archived: true
+                        archived: true,
+                        parsePRJobName: sinon.stub().returns('outdated')
                     },
                     {
                         id: 7,
@@ -581,7 +587,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr:branch']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('main')
                     },
                     {
                         id: 8,
@@ -603,7 +610,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr:branch']
                             }
                         ],
-                        state: 'DISABLED'
+                        state: 'DISABLED',
+                        parsePRJobName: sinon.stub().returns('pr-branch')
                     }
                 ];
 
@@ -647,7 +655,6 @@ describe('Event Factory', () => {
                 });
             });
 
-            // eslint-disable-next-line max-len
             it("should start existing pipeline's branch pr jobs without creating duplicates", () => {
                 jobsMock = [
                     {
@@ -659,7 +666,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr', '~pr:branch']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('main')
                     },
                     {
                         id: 2,
@@ -670,7 +678,8 @@ describe('Event Factory', () => {
                                 requires: ['~pr:branch']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('pr-branch')
                     },
                     {
                         id: 3,
@@ -2051,7 +2060,8 @@ describe('Event Factory', () => {
                             sourcePaths: ['src/test/']
                         }
                     ],
-                    state: 'ENABLED'
+                    state: 'ENABLED',
+                    parsePRJobName: sinon.stub().returns('main')
                 },
                 {
                     id: 2,
@@ -2063,7 +2073,8 @@ describe('Event Factory', () => {
                             sourcePaths: ['src/test/']
                         }
                     ],
-                    state: 'ENABLED'
+                    state: 'ENABLED',
+                    parsePRJobName: sinon.stub().returns('publish')
                 },
                 {
                     id: 3,
@@ -2120,7 +2131,8 @@ describe('Event Factory', () => {
                             sourcePaths: ['src/test']
                         }
                     ],
-                    state: 'ENABLED'
+                    state: 'ENABLED',
+                    parsePRJobName: sinon.stub().returns('main')
                 },
                 {
                     id: 2,

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -457,6 +457,17 @@ describe('Event Factory', () => {
                         archived: true
                     },
                     {
+                        id: 2,
+                        name: 'outdated',
+                        permutations: [
+                            {
+                                requires: ['~pr']
+                            }
+                        ],
+                        state: 'DISABLED',
+                        archived: true
+                    },
+                    {
                         id: 7,
                         pipelineId: 8765,
                         name: 'PR-2:main',

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -475,7 +475,7 @@ describe('Event Factory', () => {
                                 requires: ['~pr']
                             }
                         ],
-                        state: 'ENABLED'
+                        state: 'DISABLED'
                     },
                     {
                         id: 6,
@@ -657,6 +657,28 @@ describe('Event Factory', () => {
                         permutations: [
                             {
                                 requires: ['~pr:branch']
+                            }
+                        ],
+                        state: 'ENABLED'
+                    },
+                    {
+                        id: 3,
+                        pipelineId: 8765,
+                        name: 'main',
+                        permutations: [
+                            {
+                                requires: ['~commit', '~pr', '~sd@123:main', '~commit:branch', '~pr:branch']
+                            }
+                        ],
+                        state: 'ENABLED'
+                    },
+                    {
+                        id: 4,
+                        pipelineId: 8765,
+                        name: 'pr-branch',
+                        permutations: [
+                            {
+                                requires: ['~pr']
                             }
                         ],
                         state: 'ENABLED'
@@ -2031,6 +2053,28 @@ describe('Event Factory', () => {
                         }
                     ],
                     state: 'ENABLED'
+                },
+                {
+                    id: 3,
+                    pipelineId: 8765,
+                    name: 'main',
+                    permutations: [
+                        {
+                            requires: ['~commit', '~pr', '~sd@123:main', '~commit:branch', '~pr:branch']
+                        }
+                    ],
+                    state: 'ENABLED'
+                },
+                {
+                    id: 4,
+                    pipelineId: 8765,
+                    name: 'publish',
+                    permutations: [
+                        {
+                            requires: ['~pr']
+                        }
+                    ],
+                    state: 'ENABLED'
                 }
             ];
             afterSyncedPRPipelineMock.update = sinon.stub().resolves({
@@ -2063,6 +2107,28 @@ describe('Event Factory', () => {
                         {
                             requires: ['~pr'],
                             sourcePaths: ['src/test']
+                        }
+                    ],
+                    state: 'ENABLED'
+                },
+                {
+                    id: 2,
+                    pipelineId: 8765,
+                    name: 'main',
+                    permutations: [
+                        {
+                            requires: ['~commit', '~pr', '~sd@123:main', '~commit:branch', '~pr:branch']
+                        }
+                    ],
+                    state: 'ENABLED'
+                },
+                {
+                    id: 3,
+                    pipelineId: 8765,
+                    name: 'publish',
+                    permutations: [
+                        {
+                            requires: ['~pr']
                         }
                     ],
                     state: 'ENABLED'


### PR DESCRIPTION
## Context

Sometimes a user might disable a job in the main workflow. We currently don't allow users to individually disable PR jobs, but we are not handling when a PR job shouldn't run when its original job is disabled.

## Objective

This PR checks if the original job is disabled before trying to start a PR job.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2704

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
