### PR TITLE
fix(2496): Fetch only the jobs that are relevant for pipeline / pull request sync

### DIFF
--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -3,6 +3,7 @@
 const BaseFactory = require('./baseFactory');
 const { getAnnotations, getToken } = require('./helper');
 const Job = require('./job');
+const { getQueries, PR_JOBS_FOR_PIPELINE_SYNC } = require('./rawQueries');
 let instance;
 
 class JobFactory extends BaseFactory {
@@ -81,6 +82,29 @@ class JobFactory extends BaseFactory {
 
             return job;
         });
+    }
+
+    /**
+     * Get all the pull request jobs that needs to be updated during pipeline sync that are associated with the
+     * specified pipeline.
+     * This includes:
+     *  - unarchived jobs for closed pull requests
+     *  - both archived and unarchived jobs for open pull requests
+     * @method getPullRequestJobsForPipelineSync
+     * @param  {Object}   config                Config object
+     * @param  {Number}   config.pipelineId     Pipeline ID to get jobs for. Ex: 76562
+     * @param  {Array}    config.prNames        PR identifiers to get jobs for. Ex: ['PR-32', 'PR-34', 'PR-2']
+     */
+    getPullRequestJobsForPipelineSync(config) {
+        const queryConfig = {
+            queries: getQueries(this.datastore.prefix, PR_JOBS_FOR_PIPELINE_SYNC),
+            replacements: {
+                pipelineId: config.pipelineId,
+                prNames: config.prNames || []
+            }
+        };
+
+        return super.query(queryConfig);
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -418,12 +418,12 @@ class PipelineModel extends BaseModel {
 
     /**
      * archive closed PR jobs
-     * @param {Array}   existingJobs List pipeline's existing jobs
+     * @param {Array}   existingPrJobs List pipeline's existing pull request jobs (excludes already archived jobs for closed PRs)
      * @param {Array}   openedPRs    List of opened PRs coming from SCM
      * @param {Promise}
      */
-    _archiveClosePRs(existingJobs, openedPRs) {
-        const existingPRs = existingJobs.filter(j => j.isPR());
+    _archiveClosePRs(existingPrJobs, openedPRs) {
+        const existingPRs = existingPrJobs.filter(j => j.isPR());
         const openedPRsNames = openedPRs.map(j => j.name);
         const toArchiveList = [];
 
@@ -543,14 +543,14 @@ class PipelineModel extends BaseModel {
         const token = await this.token;
 
         return Promise.all([
-            this.jobs,
+            this.pullRequestJobs,
             this.scm.getOpenedPRs({
                 scmUri: this.scmUri,
                 scmContext: this.scmContext,
                 token
             })
         ])
-            .then(([existingJobs, openedPRs]) => {
+            .then(([existingPrJobs, openedPRs]) => {
                 const synced = [];
 
                 openedPRs.forEach(openedPR => {
@@ -559,7 +559,7 @@ class PipelineModel extends BaseModel {
                     synced.push(this.syncPR(prNum));
                 });
 
-                return Promise.all(synced).then(() => this._archiveClosePRs(existingJobs, openedPRs));
+                return Promise.all(synced).then(() => this._archiveClosePRs(existingPrJobs, openedPRs));
             })
             .then(() => this);
     }
@@ -582,7 +582,7 @@ class PipelineModel extends BaseModel {
             scmRepo: this.scmRepo
         });
 
-        const jobs = await this.jobs;
+        const jobs = await this.pipelineJobs;
         const parsedConfig = await this.getConfiguration({
             ref: prInfo.ref,
             isPR: true
@@ -591,7 +591,8 @@ class PipelineModel extends BaseModel {
 
         logger.info(`pipelineId:${this.id}: chainPR flag is ${this.chainPR}.`);
 
-        const prJobs = jobs.filter(j => j.name.startsWith(`PR-${prNum}:`));
+        const prJobsForOpenPrs = await this.pullRequestJobs;
+        const prJobs = prJobsForOpenPrs.filter(j => j.name.startsWith(`PR-${prNum}:`));
         const { workflowGraph } = parsedConfig;
 
         // Get next jobs for when startFrom is ~pr
@@ -682,7 +683,7 @@ class PipelineModel extends BaseModel {
         await this._updateJobArchive(jobsToArchive, true);
         await this._updateJobArchive(jobsToUnarchive, false, parsedConfig);
 
-        delete this.jobs; // so that next time it will not get the cached version of this.jobs
+        delete this.pullRequestJobs; // so that next time it will not get the cached version of this.pullRequestJobs
 
         return this;
     }
@@ -897,7 +898,7 @@ class PipelineModel extends BaseModel {
         }
         this.subscribedScmUrlsWithActions = urlWithActionsList;
 
-        const existingJobs = (await this.jobs).filter(j => !j.isPR());
+        const existingJobs = await this.pipelineJobs;
 
         const jobsProcessed = [];
         const updatedJobs = [];
@@ -1014,8 +1015,8 @@ class PipelineModel extends BaseModel {
         );
 
         // jobs updated or new jobs created during sync
-        // delete it here so next time this.jobs is called a DB query will be forced and new jobs will return
-        delete this.jobs;
+        // delete it here so next time this.pipelineJobs is called a DB query will be forced and new jobs will return
+        delete this.pipelineJobs;
 
         await this.update();
 
@@ -1207,7 +1208,7 @@ class PipelineModel extends BaseModel {
     get token() {
         const { enabled, accessToken } = this.scm.getReadOnlyInfo({ scmContext: this.scmContext });
 
-        // Use read-only access tokeb if child pipeline is in read-only SCM
+        // Use read-only access token if child pipeline is in read-only SCM
         if (this.configPipelineId && enabled && accessToken) {
             return Promise.resolve(accessToken);
         }
@@ -1244,14 +1245,38 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Fetch all jobs that belong to this pipeline
+     * Fetch all open pull requests associated with pipeline scmUri
      * @property jobs
      * @return {Promise}
      */
-    get jobs() {
+    get openPullRequests() {
+        const openPullRequests = this.token.then(token => {
+            return this.scm.getOpenedPRs({
+                scmUri: this.scmUri,
+                scmContext: this.scmContext,
+                token
+            });
+        });
+
+        Object.defineProperty(this, 'openPullRequests', {
+            configurable: true,
+            enumerable: true,
+            value: openPullRequests
+        });
+
+        return openPullRequests;
+    }
+
+    /**
+     * Fetch all non pull request jobs that belong to this pipeline
+     * @property jobs
+     * @return {Promise}
+     */
+    get pipelineJobs() {
         const listConfig = {
             params: {
-                pipelineId: this.id
+                pipelineId: this.id,
+                prParentJobId: null
             }
         };
 
@@ -1267,13 +1292,43 @@ class PipelineModel extends BaseModel {
         // ES6 has weird getters and setters in classes,
         // so we redefine the pipeline property here to resolve to the
         // resulting promise and not try to recreate the factory, etc.
-        Object.defineProperty(this, 'jobs', {
+        Object.defineProperty(this, 'pipelineJobs', {
             configurable: true,
             enumerable: true,
             value: jobs
         });
 
         return jobs;
+    }
+
+    /**
+     * Fetch all the pull request jobs that needs to be updated during pipeline sync that are associated with the
+     * specified pipeline.
+     * This includes:
+     *      - only unarchived jobs for closed pull requests
+     *      - both archived and unarchived jobs for open pull requests
+     * @property jobs
+     * @return {Promise}
+     */
+    get pullRequestJobs() {
+        return this.openPullRequests.then(openPRs => {
+            const openPrNames = openPRs.map(openedPR => {
+                return openedPR.name;
+            });
+            const listConfig = {
+                pipelineId: this.id,
+                prNames: openPrNames
+            };
+
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const JobFactory = require('./jobFactory');
+            /* eslint-enable global-require */
+            const factory = JobFactory.getInstance();
+
+            return factory.getPullRequestJobsForPipelineSync(listConfig);
+        });
     }
 
     /**

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -42,13 +42,36 @@ const Queries = {
 
     // removeSteps()
     deleteBuildStepsQuery: (tablePrefix = '') => `DELETE FROM "${tablePrefix}steps" WHERE "buildId" = :buildId`,
-    deleteBuildStepsQueryMySql: (tablePrefix = '') => `DELETE FROM \`${tablePrefix}steps\` WHERE buildId = :buildId`
+    deleteBuildStepsQueryMySql: (tablePrefix = '') => `DELETE FROM \`${tablePrefix}steps\` WHERE buildId = :buildId`,
+
+    // getPRJobsForPipelineSync()
+    getPRJobsForPipelineSyncQuery: (tablePrefix = '') => `SELECT *
+        FROM "${tablePrefix}jobs"
+        WHERE pipelineId = :pipelineId
+        AND prParentJobId IS NOT NULL
+        AND (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1)) IN (:prNames))
+        ORDER BY "jobId", "id" ASC`,
+
+    getPRJobsForPipelineSyncQueryPostgres: (tablePrefix = '') => `SELECT *
+        FROM "${tablePrefix}jobs"
+        WHERE pipelineId = :pipelineId
+        AND prParentJobId IS NOT NULL
+        AND (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
+        ORDER BY "jobId", "id" ASC`,
+
+    getPRJobsForPipelineSyncQueryMySql: (tablePrefix = '') => `SELECT *
+		FROM  \`${tablePrefix}jobs\`
+        WHERE pipelineId = :pipelineId
+        AND prParentJobId IS NOT NULL
+        AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
+        ORDER BY "jobId", "id" ASC`
 };
 
 const QUERY_MAPPINGS = {
     STATUS_QUERY: Symbol('status_query'),
     LATEST_BUILD_QUERY: Symbol('latest build'),
-    DELETE_STEPS_QUERY: Symbol('delete steps')
+    DELETE_STEPS_QUERY: Symbol('delete steps'),
+    PR_JOBS_FOR_PIPELINE_SYNC: Symbol('pull request jobs for pipeline sync')
 };
 
 const getQueries = (tablePrefix, querylabel) => {
@@ -71,6 +94,12 @@ const getQueries = (tablePrefix, querylabel) => {
                 { dbType: 'sqlite', query: Queries.deleteBuildStepsQuery(tablePrefix) },
                 { dbType: 'mysql', query: Queries.deleteBuildStepsQueryMySql(tablePrefix) }
             ];
+        case QUERY_MAPPINGS.PR_JOBS_FOR_PIPELINE_SYNC:
+            return [
+                { dbType: 'postgres', query: Queries.getPRJobsForPipelineSyncQueryPostgres(tablePrefix) },
+                { dbType: 'sqlite', query: Queries.getPRJobsForPipelineSyncQuery(tablePrefix) },
+                { dbType: 'mysql', query: Queries.getPRJobsForPipelineSyncQueryMySql(tablePrefix) }
+            ];
         default:
             throw new Error('Unsupported Raw Query');
     }
@@ -81,5 +110,6 @@ module.exports = {
     getQueries,
     STATUS_QUERY: QUERY_MAPPINGS.STATUS_QUERY,
     LATEST_BUILD_QUERY: QUERY_MAPPINGS.LATEST_BUILD_QUERY,
-    DELETE_STEPS_QUERY: QUERY_MAPPINGS.DELETE_STEPS_QUERY
+    DELETE_STEPS_QUERY: QUERY_MAPPINGS.DELETE_STEPS_QUERY,
+    PR_JOBS_FOR_PIPELINE_SYNC: QUERY_MAPPINGS.PR_JOBS_FOR_PIPELINE_SYNC
 };


### PR DESCRIPTION
## Context

Pull request sync workflow was fetching all the jobs from the data store associated with the pipeline which could potentially fail the request if the job count huge.

## Objective
This PR optimizes the jobs fetched by excluding the archived pull request jobs for closed pull requests.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2496

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
