### PR TITLE
fix: Set DISABLED state for new job if screwdriver.cd/jobDisabledByDefault annotation is true [2]

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -18,6 +18,24 @@ function getAnnotations(perm, name) {
 }
 
 /**
+ * Convert value to Boolean
+ * @method convertToBool
+ * @param {(Boolean|String)} value
+ * @return {Boolean}
+ */
+function convertToBool(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    // trueList refers to https://yaml.org/type/bool.html
+    const trueList = ['on', 'true', 'yes', 'y'];
+    const lowerValue = String(value).toLowerCase();
+
+    return trueList.includes(lowerValue);
+}
+
+/**
  * Returns an object with the parsed name and namespace to be merged with
  * the original config for template or templateTag creation
  * @param  {Object} config
@@ -225,6 +243,7 @@ function getToken(fn, pipeline, jobId) {
 
 module.exports = {
     getAnnotations,
+    convertToBool,
     parseTemplateConfigName,
     getAllRecords,
     getBuildClusterName,

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BaseFactory = require('./baseFactory');
-const { getAnnotations, getToken } = require('./helper');
+const { getAnnotations, getToken, convertToBool } = require('./helper');
 const Job = require('./job');
 const { getQueries, PR_JOBS_FOR_PIPELINE_SYNC } = require('./rawQueries');
 let instance;
@@ -55,8 +55,11 @@ class JobFactory extends BaseFactory {
      */
     create(config) {
         const c = config;
+        const jobDisabledByDefault = convertToBool(
+            getAnnotations(c.permutations[0], 'screwdriver.cd/jobDisabledByDefault')
+        );
 
-        c.state = 'ENABLED';
+        c.state = jobDisabledByDefault === true ? 'DISABLED' : 'ENABLED';
         c.archived = false;
 
         // eslint-disable-next-line global-require

--- a/package.json
+++ b/package.json
@@ -47,18 +47,18 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@hapi/hoek": "^9.2.1",
+    "@hapi/hoek": "^9.3.0",
     "@hapi/iron": "^6.0.0",
     "async": "^3.2.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.6.0",
-    "dayjs": "^1.11.0",
+    "dayjs": "^1.11.2",
     "deepcopy": "^2.0.0",
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
-    "screwdriver-config-parser": "^7.5.3",
-    "screwdriver-data-schema": "^21.22.2",
+    "screwdriver-config-parser": "^7.5.4",
+    "screwdriver-data-schema": "^21.23.0",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -139,6 +139,51 @@ describe('Job Factory', () => {
                 });
         });
 
+        it('creates a new DISABLED job in the datastore', () => {
+            const permutationsWithAnnotation = [
+                {
+                    commands: [
+                        { command: 'npm install', name: 'init' },
+                        { command: 'npm test', name: 'test' }
+                    ],
+                    image: 'node:4',
+                    annotations: {
+                        'screwdriver.cd/jobDisabledByDefault': 'true'
+                    }
+                }
+            ];
+            const expected = {
+                name,
+                pipelineId,
+                state: 'DISABLED',
+                archived: false,
+                id: jobId,
+                permutations: permutationsWithAnnotation
+            };
+
+            datastore.save.resolves(expected);
+
+            return factory
+                .create({
+                    pipelineId,
+                    name,
+                    permutations: permutationsWithAnnotation
+                })
+                .then(model => {
+                    assert.calledWith(datastore.save, {
+                        table: 'jobs',
+                        params: {
+                            name,
+                            pipelineId,
+                            state: 'DISABLED',
+                            archived: false,
+                            permutations: permutationsWithAnnotation
+                        }
+                    });
+                    assert.instanceOf(model, Job);
+                });
+        });
+
         it('calls executor to create a periodic job', () => {
             const tokenGenFunc = () => 'bar';
             const periodicPermutations = [


### PR DESCRIPTION
## Context

Sometimes users might have repos/pipelines with build periodic configs. If developers fork and create their own pipelines, they might not want these cron jobs to get auto triggered. It would be nice to have an additional annotation for disabling jobs upon creation so users are required to consciously enable them if they want the periodic builds.

## Objective

This PR sets a new job's state to DISABLED upon job creation if `screwdriver.cd/jobDisabledByDefault: true`.

## References

Blocked by https://github.com/screwdriver-cd/data-schema/pull/488

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
