### PR TITLE
fix(2496): Raw query should have field pipelineId in quotes

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -47,15 +47,15 @@ const Queries = {
     // getPRJobsForPipelineSync()
     getPRJobsForPipelineSyncQuery: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
-        WHERE pipelineId = :pipelineId
-        AND prParentJobId IS NOT NULL
+        WHERE "pipelineId" = :pipelineId
+        AND "prParentJobId" IS NOT NULL
         AND (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1)) IN (:prNames))
         ORDER BY "jobId", "id" ASC`,
 
     getPRJobsForPipelineSyncQueryPostgres: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
-        WHERE pipelineId = :pipelineId
-        AND prParentJobId IS NOT NULL
+        WHERE "pipelineId" = :pipelineId
+        AND "prParentJobId" IS NOT NULL
         AND (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
         ORDER BY "jobId", "id" ASC`,
 
@@ -64,7 +64,7 @@ const Queries = {
         WHERE pipelineId = :pipelineId
         AND prParentJobId IS NOT NULL
         AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
-        ORDER BY "jobId", "id" ASC`
+        ORDER BY jobId, id ASC`
 };
 
 const QUERY_MAPPINGS = {

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "async": "^3.2.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.6.0",
-    "dayjs": "^1.11.2",
+    "dayjs": "^1.11.3",
     "deepcopy": "^2.0.0",
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
-    "screwdriver-config-parser": "^7.5.4",
-    "screwdriver-data-schema": "^21.23.0",
+    "screwdriver-config-parser": "^7.5.5",
+    "screwdriver-data-schema": "^21.23.1",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }


### PR DESCRIPTION
## Context

Pull request sync workflow was fetching all the jobs from the data store associated with the pipeline which could potentially fail the request if the job count huge.

Currently, the previous PR merge is causing failures when trying to sync the pull requests for a pipeline. The error looks like ` column "pipelineid" does not exist`.

## Objective
This PR fixes the query to get pull requests for sync by adding double quotes around field `pipelineId` in the raw query.
Also removes double quotes in mysql query.

## References

https://github.com/screwdriver-cd/models/pull/538
https://github.com/screwdriver-cd/screwdriver/issues/2496

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
