### PR TITLE
fix(2496): Job table does not have field jobId

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -50,21 +50,21 @@ const Queries = {
         WHERE "pipelineId" = :pipelineId
         AND "prParentJobId" IS NOT NULL
         AND (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1)) IN (:prNames))
-        ORDER BY "jobId", "id" ASC`,
+        ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryPostgres: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
         AND "prParentJobId" IS NOT NULL
         AND (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
-        ORDER BY "jobId", "id" ASC`,
+        ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryMySql: (tablePrefix = '') => `SELECT *
 		FROM  \`${tablePrefix}jobs\`
         WHERE pipelineId = :pipelineId
         AND prParentJobId IS NOT NULL
         AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
-        ORDER BY jobId, id ASC`
+        ORDER BY id ASC`
 };
 
 const QUERY_MAPPINGS = {


### PR DESCRIPTION
## Context

Pull request sync workflow was fetching all the jobs from the data store associated with the pipeline which could potentially fail the request if the job count huge.

Currently, we're seeing error like `column "jobId" does not exist`.

## Objective
This PR fixes the query to remove sorting by the field `jobId` in the raw query.

## References

https://github.com/screwdriver-cd/models/pull/540
https://github.com/screwdriver-cd/models/pull/538
https://github.com/screwdriver-cd/screwdriver/issues/2496

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
