### PR TITLE
fix(2496): Pull request sync fails when there are no open pull requests

### DIFF
--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -99,11 +99,12 @@ class JobFactory extends BaseFactory {
      * @param  {Array}    config.prNames        PR identifiers to get jobs for. Ex: ['PR-32', 'PR-34', 'PR-2']
      */
     getPullRequestJobsForPipelineSync(config) {
+        const { prNames } = config;
         const queryConfig = {
             queries: getQueries(this.datastore.prefix, PR_JOBS_FOR_PIPELINE_SYNC),
             replacements: {
                 pipelineId: config.pipelineId,
-                prNames: config.prNames || []
+                prNames: prNames && prNames.length > 0 ? prNames : null
             }
         };
 

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -298,7 +298,6 @@ describe('Job Factory', () => {
 
     describe('getPullRequestJobsForPipelineSync', () => {
         let config;
-        let expectedQueryConfig;
 
         beforeEach(() => {
             sinon.stub(JobFactory.prototype, 'query').returns();
@@ -308,13 +307,9 @@ describe('Job Factory', () => {
             };
         });
 
-        afterEach(() => {
-            assert.calledWith(datastore.query, expectedQueryConfig);
-        });
-
         it('returns pull request jobs for specified pipelineId when there are open pull requests', () => {
             config.prNames = ['PR-2', 'PR-3'];
-            expectedQueryConfig = {
+            const expectedQueryConfig = {
                 queries: getQueries('', PR_JOBS_FOR_PIPELINE_SYNC),
                 replacements: {
                     pipelineId: config.pipelineId,
@@ -366,10 +361,13 @@ describe('Job Factory', () => {
                 jobsForSync.forEach(j => {
                     assert.instanceOf(j, Job);
                 });
+                assert.calledWith(datastore.query, expectedQueryConfig);
             });
         });
 
         describe('should set prNames to null in the query config', () => {
+            let expectedQueryConfig;
+
             beforeEach(() => {
                 expectedQueryConfig = {
                     queries: getQueries('', PR_JOBS_FOR_PIPELINE_SYNC),
@@ -415,19 +413,34 @@ describe('Job Factory', () => {
             it('when prNames is empty', () => {
                 config.prNames = [];
 
-                return factory.getPullRequestJobsForPipelineSync(config);
+                return factory.getPullRequestJobsForPipelineSync(config).then(jobsForSync => {
+                    jobsForSync.forEach(j => {
+                        assert.instanceOf(j, Job);
+                    });
+                    assert.calledWith(datastore.query, expectedQueryConfig);
+                });
             });
 
             it('when prNames is null', () => {
                 config.prNames = null;
 
-                return factory.getPullRequestJobsForPipelineSync(config);
+                return factory.getPullRequestJobsForPipelineSync(config).then(jobsForSync => {
+                    jobsForSync.forEach(j => {
+                        assert.instanceOf(j, Job);
+                    });
+                    assert.calledWith(datastore.query, expectedQueryConfig);
+                });
             });
 
             it('when prNames is undefined', () => {
                 config.prNames = undefined;
 
-                return factory.getPullRequestJobsForPipelineSync(config);
+                return factory.getPullRequestJobsForPipelineSync(config).then(jobsForSync => {
+                    jobsForSync.forEach(j => {
+                        assert.instanceOf(j, Job);
+                    });
+                    assert.calledWith(datastore.query, expectedQueryConfig);
+                });
             });
         });
     });

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -298,45 +298,23 @@ describe('Job Factory', () => {
 
     describe('getPullRequestJobsForPipelineSync', () => {
         let config;
-        let returnValue;
-        let queryConfig;
+        let expectedQueryConfig;
 
         beforeEach(() => {
             sinon.stub(JobFactory.prototype, 'query').returns();
 
             config = {
-                pipelineId: '12345',
-                prNames: ['PR-2', 'PR-3']
+                pipelineId: '12345'
             };
+        });
 
-            returnValue = [
-                {
-                    id: 20,
-                    prParentJobId: 1,
-                    name: 'PR-2:component',
-                    archived: false
-                },
-                {
-                    id: 20,
-                    prParentJobId: 2,
-                    name: 'PR-2:publish',
-                    archived: true
-                },
-                {
-                    id: 20,
-                    prParentJobId: 1,
-                    name: 'PR-3:component',
-                    archived: false
-                },
-                {
-                    id: 20,
-                    prParentJobId: 2,
-                    name: 'PR-3:publish',
-                    archived: false
-                }
-            ];
+        afterEach(() => {
+            assert.calledWith(datastore.query, expectedQueryConfig);
+        });
 
-            queryConfig = {
+        it('returns pull request jobs for specified pipelineId when there are open pull requests', () => {
+            config.prNames = ['PR-2', 'PR-3'];
+            expectedQueryConfig = {
                 queries: getQueries('', PR_JOBS_FOR_PIPELINE_SYNC),
                 replacements: {
                     pipelineId: config.pipelineId,
@@ -345,16 +323,111 @@ describe('Job Factory', () => {
                 rawResponse: false,
                 table: 'jobs'
             };
-        });
 
-        it('returns pull request jobs to be synced for specified pipelineId', () => {
+            const returnValue = [
+                // jobs of closed PR (always only unarchived)
+                {
+                    id: 20,
+                    prParentJobId: 1,
+                    name: 'PR-1:component',
+                    archived: false
+                },
+                // jobs of open PR (archived and unarchived)
+                {
+                    id: 30,
+                    prParentJobId: 1,
+                    name: 'PR-2:component',
+                    archived: false
+                },
+                {
+                    id: 31,
+                    prParentJobId: 2,
+                    name: 'PR-2:publish',
+                    archived: true
+                },
+                // jobs of open PR (all archived)
+                {
+                    id: 40,
+                    prParentJobId: 1,
+                    name: 'PR-3:component',
+                    archived: false
+                },
+                {
+                    id: 41,
+                    prParentJobId: 2,
+                    name: 'PR-3:publish',
+                    archived: false
+                }
+            ];
+
             datastore.query.resolves(returnValue);
 
             return factory.getPullRequestJobsForPipelineSync(config).then(jobsForSync => {
-                assert.calledWith(datastore.query, queryConfig);
                 jobsForSync.forEach(j => {
                     assert.instanceOf(j, Job);
                 });
+            });
+        });
+
+        describe('should set prNames to null in the query config', () => {
+            beforeEach(() => {
+                expectedQueryConfig = {
+                    queries: getQueries('', PR_JOBS_FOR_PIPELINE_SYNC),
+                    replacements: {
+                        pipelineId: config.pipelineId,
+                        prNames: null
+                    },
+                    rawResponse: false,
+                    table: 'jobs'
+                };
+
+                const returnValue = [
+                    // only unarchived jobs of all closed PRs
+                    {
+                        id: 20,
+                        prParentJobId: 1,
+                        name: 'PR-1:component',
+                        archived: false
+                    },
+                    {
+                        id: 30,
+                        prParentJobId: 1,
+                        name: 'PR-2:component',
+                        archived: false
+                    },
+                    {
+                        id: 40,
+                        prParentJobId: 1,
+                        name: 'PR-3:component',
+                        archived: false
+                    },
+                    {
+                        id: 41,
+                        prParentJobId: 2,
+                        name: 'PR-3:publish',
+                        archived: false
+                    }
+                ];
+
+                datastore.query.resolves(returnValue);
+            });
+
+            it('when prNames is empty', () => {
+                config.prNames = [];
+
+                return factory.getPullRequestJobsForPipelineSync(config);
+            });
+
+            it('when prNames is null', () => {
+                config.prNames = null;
+
+                return factory.getPullRequestJobsForPipelineSync(config);
+            });
+
+            it('when prNames is undefined', () => {
+                config.prNames = undefined;
+
+                return factory.getPullRequestJobsForPipelineSync(config);
             });
         });
     });


### PR DESCRIPTION
## Context

Pull request sync workflow uses raw DB query to fetch the jobs associated with the pull requests that need to synced. Query expects 2 parameters
- pipeline identifier
- an array of open pull request names (Ex: `[ 'PR-23', 'PR-32']`)

Query for MySQL DB
```
SELECT *
	FROM  `jobs`
        WHERE pipelineId = :pipelineId
        AND prParentJobId IS NOT NULL
        AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
        ORDER BY id ASC
```

Job will be included if one of the below criteria is met
- unarchived
- archived but associated with the specified pull request names

This query resulted in SQL error when there are no pull requests.
```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '))
        ORDER BY id ASC' at line 5
```

This is caused by empty parenthesis for the `IN` operator in the interpolated query 
```
SELECT *
	FROM  `jobs`
        WHERE pipelineId = 1
        AND prParentJobId IS NOT NULL
        AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1)) IN ())
        ORDER BY id ASC
```

## Objective
This PR overrides the `prNames` param to `null` when there are no open pull requests. Thus fixing the interpolated query to 
```
SELECT *
	FROM  `jobs`
        WHERE pipelineId = 1
        AND prParentJobId IS NOT NULL
        AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1)) IN (NULL))
        ORDER BY id ASC
```

## References

https://github.com/screwdriver-cd/screwdriver/issues/2496
https://github.com/screwdriver-cd/models/pull/538

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
