### PR TITLE
[1]feat(2695): Change PR comment body and add arguments to addPrComment

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -125,10 +125,10 @@ function formatSummary(summary) {
  * @param  {String}   config.container  Container the build is running in (e.g.: node:8)
  * @return {String}   comment           PR comment
  */
-function getPrComment({ metadata, buildId, buildUrl, container }) {
+function getPrComment({ metadata, buildId, buildUrl, jobName, container }) {
     // Format of the comment
     /**
-        ### SD Build [#133652](https://cd.screwdriver.cd/pipelines/1/builds/133652)
+        ### SD Build [#133652](https://cd.screwdriver.cd/pipelines/1/builds/133652) Job main
         _node:8_
         - - - -
         __coverage__ - Coverage increased by 15%
@@ -136,7 +136,7 @@ function getPrComment({ metadata, buildId, buildUrl, container }) {
 
         ###### ~ Screwdriver automated build summary
       */
-    const commentPrefix = `### SD Build [#${buildId}](${buildUrl})\n_${container}_\n- - - -`;
+    const commentPrefix = `### SD Build [#${buildId}](${buildUrl}) Job ${jobName}\n_${container}_\n- - - -`;
     const commentSuffix = '###### ~ Screwdriver automated build summary';
     const summaryText = formatSummary(metadata);
 
@@ -302,15 +302,18 @@ class BuildModel extends BaseModel {
                         metadata: hoek.reach(this.meta, 'meta.summary'),
                         buildId: this.id,
                         buildUrl: config.url,
+                        jobName: config.jobName,
                         container: this.container
                     });
                     const prNum = parseInt(config.jobName.match(/^PR-([0-9]+):[\w-]+$/)[1], 10);
                     const prConfig = {
                         comment,
+                        jobName: config.jobName,
                         prNum,
                         scmContext: config.scmContext,
                         scmUri: config.scmUri,
-                        token
+                        token,
+                        pipelineId: pipeline.id
                     };
 
                     if (comment) {

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -300,11 +300,13 @@ describe('Build Model', () => {
                 });
                 assert.calledWith(scmMock.addPrComment, {
                     token: 'foo',
+                    jobName: 'PR-5:main',
                     scmContext,
                     scmUri,
+                    pipelineId,
                     comment:
                         '### SD Build [#9876](https://display.com/some/' +
-                        'endpoint/pipelines/1234/builds/9876)\n_node:4_\n- - - -\n' +
+                        'endpoint/pipelines/1234/builds/9876) Job PR-5:main\n_node:4_\n- - - -\n' +
                         '__coverage__ - Coverage increased by 15%\n' +
                         '__markdown__ - this markdown comment is **bold** and *italic*\n\n' +
                         '###### ~ Screwdriver automated build summary',


### PR DESCRIPTION
## Context
We need to know the job name from PR comment body to implement https://github.com/screwdriver-cd/screwdriver/issues/2695. It is also necessary to add job name and pipeline id to the argument of `addPrComment` to determine whether to edit an old comment or add a new comment.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We add job name to PR comment format and add job name and pipeline id to the argument of `addPrComment`. 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2695
Reflect at the same time as https://github.com/screwdriver-cd/data-schema/pull/489
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
