### PR TITLE
feat(2580): Deactivate child pipelines when SCM URL is removed from external config

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -791,6 +791,7 @@ class PipelineModel extends BaseModel {
             // Child pipeline belongs to this parent, update it
             if (pipeline.configPipelineId === this.id) {
                 pipeline.admins = newAdmins;
+                pipeline.state = 'ACTIVE';
                 logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with pipelineId:${pipeline.id}.`);
 
                 return pipeline.sync();
@@ -823,6 +824,62 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Deactivate a pipeline given a scmUrl
+     * @method _deactivatePipeline
+     * @param {String} scmUrl  checkout url for a repository
+     * @return {Promise}
+     */
+    async _deactivatePipeline(scmUrl) {
+        // Get hostname using scmUrl
+        const regex = Schema.config.regex.CHECKOUT_URL;
+        const matched = regex.exec(scmUrl);
+        const hostname = matched[MATCH_COMPONENT_HOSTNAME];
+
+        // Set scmContext
+        const scmContext = this.scm.getScmContext({ hostname });
+        const scmUri = await this._getScmUri({ scmUrl, scmContext });
+        let hasAdminPermission = false;
+
+        if (this.scmContext !== scmContext) {
+            // Check for read-only scm, add headless admin to admin config
+            const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
+
+            if (!readOnlyInfo.enabled) {
+                logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+
+                return null;
+            }
+
+            hasAdminPermission = true;
+        } else {
+            // Check admin permissions
+            hasAdminPermission = await this._hasAdminPermission(scmUri);
+        }
+
+        if (!hasAdminPermission) {
+            // TODO: need to figure out how to bubble up this err to user
+            logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+
+            return null;
+        }
+
+        const pipelineFactory = this._getPipelineFactory();
+        const pipeline = await pipelineFactory.get({ scmUri });
+
+        // deactivate pipeline only if it's a child pipeline and belongs to current pipeline
+        if (pipeline && pipeline.configPipelineId === this.id) {
+            logger.info(
+                `pipelineId:${this.id}: Deactivating child pipeline for ${scmUrl} with pipelineId:${pipeline.id}.`
+            );
+            pipeline.state = 'INACTIVE';
+
+            return pipeline.update();
+        }
+
+        return null;
+    }
+
+    /**
      * Sync child pipelines given scmUrls
      * @method syncChildPipelines
      * @param {Array} scmUrls  An array of scmUrls for child pipelines
@@ -830,12 +887,19 @@ class PipelineModel extends BaseModel {
      */
     async _syncChildPipelines(scmUrls) {
         const toCreateOrUpdate = [];
+        const toDeactivate = [];
+        const oldScmUrls = hoek.reach(this.childPipelines, 'scmUrls') || [];
         const newScmUrls = scmUrls || [];
+        // scmUrls in the old list but not the new list should be removed
+        const scmUrlsToDeactivate = oldScmUrls.filter(scmUrl => !newScmUrls.includes(scmUrl));
 
-        // create or update child pipelines
+        // create or update active child pipelines
         newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl)));
 
-        return Promise.allSettled(toCreateOrUpdate);
+        // deactivate obsolete child pipelines
+        scmUrlsToDeactivate.forEach(scmUrl => toDeactivate.push(this._deactivatePipeline(scmUrl)));
+
+        return Promise.allSettled([...toCreateOrUpdate, ...toDeactivate]);
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -743,11 +743,13 @@ class PipelineModel extends BaseModel {
      * Update or create a pipeline given a scmUrl
      * @method _createOrUpdatePipeline
      * @param {String} scmUrl  checkout url for a repository
+     * @param {String} newState  new state for the pipeline associated with the specified scmUrl
      * @return {Promise}
      */
-    async _createOrUpdatePipeline(scmUrl) {
+    async _createOrUpdatePipeline(scmUrl, newState) {
         const { admins } = this;
         const newAdmins = admins;
+        const shouldCreateOrSyncPipeline = newState !== 'INACTIVE';
         let scmToken;
 
         // Get hostname using scmUrl
@@ -791,10 +793,10 @@ class PipelineModel extends BaseModel {
             // Child pipeline belongs to this parent, update it
             if (pipeline.configPipelineId === this.id) {
                 pipeline.admins = newAdmins;
-                pipeline.state = 'ACTIVE';
+                pipeline.state = newState;
                 logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with pipelineId:${pipeline.id}.`);
 
-                return pipeline.sync();
+                return shouldCreateOrSyncPipeline ? pipeline.sync() : pipeline.update();
             }
             // Child pipeline does not belong to this parent, return
             logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
@@ -802,78 +804,26 @@ class PipelineModel extends BaseModel {
             return null;
         }
 
-        const pipelineConfig = {
-            admins: newAdmins,
-            scmContext,
-            scmUri,
-            configPipelineId: this.id
-        };
+        if (shouldCreateOrSyncPipeline) {
+            const pipelineConfig = {
+                admins: newAdmins,
+                scmContext,
+                scmUri,
+                configPipelineId: this.id
+            };
 
-        if (scmToken) {
-            pipelineConfig.scmToken = scmToken;
-        }
-
-        return pipelineFactory.create(pipelineConfig).then(async p => {
-            logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
-            // sync pipeline to create jobs
-            await p.sync();
-            if (SD_API_URI) {
-                await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
-            }
-        });
-    }
-
-    /**
-     * Deactivate a pipeline given a scmUrl
-     * @method _deactivatePipeline
-     * @param {String} scmUrl  checkout url for a repository
-     * @return {Promise}
-     */
-    async _deactivatePipeline(scmUrl) {
-        // Get hostname using scmUrl
-        const regex = Schema.config.regex.CHECKOUT_URL;
-        const matched = regex.exec(scmUrl);
-        const hostname = matched[MATCH_COMPONENT_HOSTNAME];
-
-        // Set scmContext
-        const scmContext = this.scm.getScmContext({ hostname });
-        const scmUri = await this._getScmUri({ scmUrl, scmContext });
-        let hasAdminPermission = false;
-
-        if (this.scmContext !== scmContext) {
-            // Check for read-only scm, add headless admin to admin config
-            const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
-
-            if (!readOnlyInfo.enabled) {
-                logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
-
-                return null;
+            if (scmToken) {
+                pipelineConfig.scmToken = scmToken;
             }
 
-            hasAdminPermission = true;
-        } else {
-            // Check admin permissions
-            hasAdminPermission = await this._hasAdminPermission(scmUri);
-        }
-
-        if (!hasAdminPermission) {
-            // TODO: need to figure out how to bubble up this err to user
-            logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
-
-            return null;
-        }
-
-        const pipelineFactory = this._getPipelineFactory();
-        const pipeline = await pipelineFactory.get({ scmUri });
-
-        // deactivate pipeline only if it's a child pipeline and belongs to current pipeline
-        if (pipeline && pipeline.configPipelineId === this.id) {
-            logger.info(
-                `pipelineId:${this.id}: Deactivating child pipeline for ${scmUrl} with pipelineId:${pipeline.id}.`
-            );
-            pipeline.state = 'INACTIVE';
-
-            return pipeline.update();
+            return pipelineFactory.create(pipelineConfig).then(async p => {
+                logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
+                // sync pipeline to create jobs
+                await p.sync();
+                if (SD_API_URI) {
+                    await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
+                }
+            });
         }
 
         return null;
@@ -894,10 +844,10 @@ class PipelineModel extends BaseModel {
         const scmUrlsToDeactivate = oldScmUrls.filter(scmUrl => !newScmUrls.includes(scmUrl));
 
         // create or update active child pipelines
-        newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl)));
+        newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl, 'ACTIVE')));
 
         // deactivate obsolete child pipelines
-        scmUrlsToDeactivate.forEach(scmUrl => toDeactivate.push(this._deactivatePipeline(scmUrl)));
+        scmUrlsToDeactivate.forEach(scmUrl => toDeactivate.push(this._createOrUpdatePipeline(scmUrl, 'INACTIVE')));
 
         return Promise.allSettled([...toCreateOrUpdate, ...toDeactivate]);
     }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -749,7 +749,6 @@ class PipelineModel extends BaseModel {
     async _createOrUpdatePipeline(scmUrl, newState) {
         const { admins } = this;
         const newAdmins = admins;
-        const shouldCreateOrSyncPipeline = newState !== 'INACTIVE';
         let scmToken;
 
         // Get hostname using scmUrl
@@ -796,7 +795,7 @@ class PipelineModel extends BaseModel {
                 pipeline.state = newState;
                 logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with pipelineId:${pipeline.id}.`);
 
-                return shouldCreateOrSyncPipeline ? pipeline.sync() : pipeline.update();
+                return newState === 'ACTIVE' ? pipeline.sync() : pipeline.update();
             }
             // Child pipeline does not belong to this parent, return
             logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
@@ -804,29 +803,25 @@ class PipelineModel extends BaseModel {
             return null;
         }
 
-        if (shouldCreateOrSyncPipeline) {
-            const pipelineConfig = {
-                admins: newAdmins,
-                scmContext,
-                scmUri,
-                configPipelineId: this.id
-            };
+        const pipelineConfig = {
+            admins: newAdmins,
+            scmContext,
+            scmUri,
+            configPipelineId: this.id
+        };
 
-            if (scmToken) {
-                pipelineConfig.scmToken = scmToken;
-            }
-
-            return pipelineFactory.create(pipelineConfig).then(async p => {
-                logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
-                // sync pipeline to create jobs
-                await p.sync();
-                if (SD_API_URI) {
-                    await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
-                }
-            });
+        if (scmToken) {
+            pipelineConfig.scmToken = scmToken;
         }
 
-        return null;
+        return pipelineFactory.create(pipelineConfig).then(async p => {
+            logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
+            // sync pipeline to create jobs
+            await p.sync();
+            if (SD_API_URI) {
+                await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
+            }
+        });
     }
 
     /**

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -53,6 +53,7 @@ class PipelineFactory extends BaseFactory {
         const modelConfig = config;
 
         modelConfig.createTime = new Date().toISOString();
+        modelConfig.state = 'ACTIVE';
 
         if (!scmToken) {
             // Lazy load factory dependency to prevent circular dependency issues

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.5.5",
-    "screwdriver-data-schema": "^21.26.4",
+    "screwdriver-data-schema": "^21.27.0",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1153,7 +1153,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('activates child pipeline if scmUrls is read-only SCM and removed from new yaml', () => {
+        it('deactivates child pipeline if scmUrls is read-only SCM and removed from new yaml', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
@@ -1171,7 +1171,7 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('deactivates child pipeline if scmUrls added back (previously removed) in the new yaml', () => {
+        it('reactivates child pipeline if scmUrls is added back (previously removed) in the new yaml', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
             const inActiveChildPipelineMock = getChildPipelineMock({ state: 'INACTIVE' });
 

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -105,6 +105,7 @@ describe('Pipeline Factory', () => {
             params: {
                 admins,
                 createTime: nowTime,
+                state: 'ACTIVE',
                 name: scmRepo.name,
                 scmUri,
                 scmContext,


### PR DESCRIPTION
## Context

Changes were made in https://github.com/screwdriver-cd/models/pull/534 to stop auto deletion of child pipelines when the SCM URLs removed/modified in the external config.

We need a way to distinguish between active and obsolete child pipeline to allow the user to review and take necessary actions on obsolete child pipelines
- reactivate the pipeline by restoring the SCM URL in the external config
- explicitly delete the pipeline from the UI/API

## Objective

This PR adds update the `state` field of the pipeline distinguish between active and obsolete child pipelines.
- `state = "ACTIVE"` when a new pipeline is created
- `state = "INACTIVE"` when child pipeline SCM URL is removed from the external config yaml
- `state = "ACTIVE"` when child pipeline SCM URL is added back in the external config yaml

## References

https://github.com/screwdriver-cd/screwdriver/issues/2580

Related PRs:
https://github.com/screwdriver-cd/data-schema/pull/490

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
