### PR TITLE
feat(2669): Add stage model [3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,8 @@ factory.create(config).then(model => {
 | config.name | String | Yes | Stage name |
 | config.jobIds | Array | No | Jobs IDs that belong to this stage. Default `[]`. |
 | config.state | String | No | State of stage (ARCHIVED, ACTIVE). Default `ACTIVE`. |
+| config.description | String | No | Description for stage |
+| config.color | String | No | Hex color for Stage |
 
 #### Get
 Get stage based on ID.

--- a/README.md
+++ b/README.md
@@ -665,6 +665,46 @@ Update a specific secret
 model.update()
 ```
 
+### Stage Factory
+#### Create
+```js
+factory.create(config).then(model => {
+    // do stuff with stage model
+});
+```
+
+| Parameter        | Type  |  Required | Description |
+| :-------------   | :---- | :-------------|  :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.pipelineId | Number | Yes | Pipeline that this stage belongs to |
+| config.name | String | Yes | Stage name |
+| config.jobIds | Array | No | Jobs IDs that belong to this stage. Default `[]`. |
+| config.state | String | No | State of stage (ARCHIVED, ACTIVE). Default `ACTIVE`. |
+
+#### Get
+Get stage based on ID.
+```js
+factory.get(id).then(model => {
+    // do stuff with stage model
+});
+```
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| id | Number | The unique ID for the stage |
+
+#### List
+List stages that have pipelineId as `12345`
+```js
+factory.list({
+    params: {
+        pipelineId: 12345
+    }
+}).then(recs =>
+    // do things with the records
+);
+```
+
 ### Event Factory
 #### Search
 ```js

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const EventFactory = require('./lib/eventFactory');
 const JobFactory = require('./lib/jobFactory');
 const PipelineFactory = require('./lib/pipelineFactory');
 const SecretFactory = require('./lib/secretFactory');
+const StageFactory = require('./lib/stageFactory');
 const StepFactory = require('./lib/stepFactory');
 const TemplateFactory = require('./lib/templateFactory');
 const TemplateTagFactory = require('./lib/templateTagFactory');
@@ -28,6 +29,7 @@ module.exports = {
     JobFactory,
     PipelineFactory,
     SecretFactory,
+    StageFactory,
     StepFactory,
     TemplateFactory,
     TemplateTagFactory,

--- a/lib/buildClusterFactory.js
+++ b/lib/buildClusterFactory.js
@@ -35,7 +35,7 @@ class BuildClusterFactory extends BaseFactory {
      * @param {String}  config.managedByScrewdriver Managed by screwdriver or not
      * @param {Boolean} [config.isActive=true]      Whether the buildCluster is active
      * @param {String}  [config.description]        Description for the build cluster
-     * @param {Integer} [config.weightage=100]          Weight percentage for build cluster
+     * @param {Integer} [config.weightage=100]      Weight percentage for build cluster
      * @memberof BuildClusterFactory
      */
     create(config) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -233,6 +233,80 @@ function syncExternalTriggers(config) {
     });
 }
 
+/**
+ * Sync stages
+ * Update stage status to ARCHIVED if it is no longer in yaml
+ * Update stage fields if changes are made
+ * Create the stages if it is defined and was not in the database yet
+ * @method syncStages
+ * @param  {Object}     config              config
+ * @param  {Array}      config.pipelineJobs Pipeline jobs
+ * @param  {Number}     config.pipelineId   pipelineId belongs to this job
+ * @param  {Object}     config.stages       Pipeline stages
+ * @return {Promise}
+ */
+function syncStages(config) {
+    // Lazy load factory dependency to prevent circular dependency issues
+    // https://nodejs.org/api/modules.html#modules_cycles
+    /* eslint-disable global-require */
+    const StageFactory = require('./stageFactory');
+    /* eslint-enable global-require */
+
+    const stageFactory = StageFactory.getInstance();
+    const { pipelineId, stages: newStages, pipelineJobs } = config;
+    const newStagesNamesList = newStages.map(s => s.name); // get the new stage names list
+
+    // Convert the jobNames to jobIds
+    newStages.forEach(s => {
+        const jobIds = [];
+
+        s.jobs.forEach(jobName => {
+            const job = pipelineJobs.find(j => j.name === jobName);
+
+            if (job) {
+                jobIds.push(job.id);
+            }
+        });
+
+        s.jobIds = jobIds;
+        s.pipelineId = pipelineId;
+        s.state = 'ACTIVE'; // default stage state
+    });
+
+    const processed = [];
+
+    // list records that would trigger this job
+    return stageFactory.list({ params: { pipelineId } }).then(records => {
+        records.forEach(rec => {
+            // if the stage is not in the new stages list, then archive it
+            if (!newStagesNamesList.includes(rec.name)) {
+                rec.state = 'ARCHIVED';
+            } else {
+                // Get the new stage definition
+                const stageToUpdate = newStages.find(s => s.name === rec.name);
+
+                rec.state = stageToUpdate.state;
+                rec.description = stageToUpdate.description;
+                rec.color = stageToUpdate.color;
+                rec.jobIds = stageToUpdate.jobIds;
+            }
+            processed.push(rec.update());
+        });
+
+        // if the stage is not in the old stages list, then create in datastore
+        const oldStagesNamesList = records.map(r => r.name); // get the old stage names list
+        const toCreate = newStages.filter(s => !oldStagesNamesList.includes(s.name));
+
+        toCreate.forEach(stage => {
+            delete stage.jobs; // extra field from yaml parser
+
+            processed.push(stageFactory.create(stage));
+        });
+
+        return Promise.all(processed);
+    });
+}
+
 class PipelineModel extends BaseModel {
     /**
      * Construct a PipelineModel object
@@ -899,11 +973,13 @@ class PipelineModel extends BaseModel {
         this.subscribedScmUrlsWithActions = urlWithActionsList;
 
         const existingJobs = await this.pipelineJobs;
-
         const jobsProcessed = [];
         const updatedJobs = [];
         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
         const pipelineId = this.id;
+
+        // Sync pipeline stages
+        await syncStages({ pipelineJobs: existingJobs, pipelineId, stages: parsedConfig.stages || [] });
 
         // Loop through non-PR existing jobs
         for (const jobChunks of getJobChunks(existingJobs)) {
@@ -960,7 +1036,7 @@ class PipelineModel extends BaseModel {
                         updatedJobs.push(await factory.create(jobConfig));
 
                         await syncExternalTriggers({
-                            pipelineId: this.id,
+                            pipelineId,
                             jobName,
                             requiresList
                         });

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -234,10 +234,60 @@ function syncExternalTriggers(config) {
 }
 
 /**
+ * Converts the simplified stages into a more consistent format
+ *
+ * This is because the user can provide the stage information as:
+ *  - {"name": { "jobs": ["job1", "job2", "job3"], "description": "Description" },
+ *     { "name2": { "jobs": ["job4", "job5"] } }
+ *
+ * We will convert it to a more standard format:
+ *  - [{ "name": "name", "jobs": ["job1", "job2", "job3"], "description": "value" },
+ *     { "name": "name2", "jobs": ["job4", "job5"] }]
+ * @method convertStages
+ * @param  {Object}     config              config
+ * @param  {Array}      config.pipelineJobs Pipeline jobs
+ * @param  {Number}     config.pipelineId   pipelineId belongs to this job
+ * @param  {Object}     config.stages       Pipeline stages
+ * @return {Array}                New array with stages after up-converting
+ */
+function convertStages(config) {
+    const { pipelineId, stages, pipelineJobs } = config;
+    const newStages = [];
+
+    // Convert stages from object to array of objects
+    Object.entries(stages).forEach(([key, value]) => {
+        const newStage = {
+            name: key,
+            pipelineId,
+            state: 'ACTIVE', // default stage state
+            ...value
+        };
+        const jobIds = [];
+
+        // Convert the jobNames to jobIds
+        value.jobs.forEach(jobName => {
+            const job = pipelineJobs.find(j => j.name === jobName);
+
+            if (job) {
+                jobIds.push(job.id);
+            }
+        });
+
+        newStage.jobIds = jobIds;
+        delete newStage.jobs; // extra field from yaml parser
+
+        newStages.push(newStage);
+    });
+
+    return newStages;
+}
+
+/**
  * Sync stages
- * Update stage status to ARCHIVED if it is no longer in yaml
- * Update stage fields if changes are made
- * Create the stages if it is defined and was not in the database yet
+ * 1. Convert new stages into correct format, prepopulate with jobIds and state
+ * 2. Update stage status to ARCHIVED if it is no longer in yaml
+ *    Update stage fields if changes are made
+ *    Create the stages if it is defined and was not in the database yet
  * @method syncStages
  * @param  {Object}     config              config
  * @param  {Array}      config.pipelineJobs Pipeline jobs
@@ -253,26 +303,9 @@ function syncStages(config) {
     /* eslint-enable global-require */
 
     const stageFactory = StageFactory.getInstance();
-    const { pipelineId, stages: newStages, pipelineJobs } = config;
-    const newStagesNamesList = newStages.map(s => s.name); // get the new stage names list
-
-    // Convert the jobNames to jobIds
-    newStages.forEach(s => {
-        const jobIds = [];
-
-        s.jobs.forEach(jobName => {
-            const job = pipelineJobs.find(j => j.name === jobName);
-
-            if (job) {
-                jobIds.push(job.id);
-            }
-        });
-
-        s.jobIds = jobIds;
-        s.pipelineId = pipelineId;
-        s.state = 'ACTIVE'; // default stage state
-    });
-
+    const { pipelineId, stages } = config;
+    const newStagesNamesList = Object.keys(stages); // get the new stage names list
+    const newStages = convertStages(config);
     const processed = [];
 
     // list records that would trigger this job
@@ -298,8 +331,6 @@ function syncStages(config) {
         const toCreate = newStages.filter(s => !oldStagesNamesList.includes(s.name));
 
         toCreate.forEach(stage => {
-            delete stage.jobs; // extra field from yaml parser
-
             processed.push(stageFactory.create(stage));
         });
 

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -8,10 +8,12 @@ class StageModel extends BaseModel {
      * @method constructor
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
-     * @param  {String}    config.pipelineId    Pipeline the stage belongs to
+     * @param  {String}    [config.color]       Hex color for stage
+     * @param  {String}    [config.description] Stage description
+     * @param  {Array}     [config.jobIds=[]]   Job Ids that belong to this stage
      * @param  {String}    config.name          Name of the stage
-     * @param  {Array}     config.jobIds        Job Ids that belong to this stage
-     * @param  {String}    config.state         Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
+     * @param  {String}    config.pipelineId    Pipeline the stage belongs to
+     * @param  {String}    [config.state='ACTIVE'] Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
      */
     constructor(config) {
         super('stage', config);

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BaseModel = require('./base');
+
+class StageModel extends BaseModel {
+    /**
+     * Construct a StageModel object
+     * @method constructor
+     * @param  {Object}    config
+     * @param  {Object}    config.datastore     Object that will perform operations on the datastore
+     * @param  {String}    config.pipelineId    Pipeline the stage belongs to
+     * @param  {String}    config.name          Name of the stage
+     * @param  {Array}     config.jobIds        Job Ids that belong to this stage
+     * @param  {String}    config.state         Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
+     */
+    constructor(config) {
+        super('stage', config);
+    }
+}
+
+module.exports = StageModel;

--- a/lib/stageFactory.js
+++ b/lib/stageFactory.js
@@ -19,11 +19,6 @@ class StageFactory extends BaseFactory {
      * Instantiate a Stage class
      * @method createClass
      * @param  {Object}     config               Stage data
-     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
-     * @param  {String}     config.pipelineId    Pipeline the stage belongs to
-     * @param  {String}     config.name          Name of the stage
-     * @param  {Array}      config.jobIds        Job Ids that belong to this stage
-     * @param  {String}     config.state         Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
      * @return {Stage}
      */
     createClass(config) {
@@ -32,11 +27,13 @@ class StageFactory extends BaseFactory {
 
     /**
      * Create a Stage model
-     * @param {Object} config
-     * @param {String} config.pipelineId    Pipeline the stage belongs to
-     * @param {String} config.name          Name of the stage
-     * @param {Array}  [config.jobIds]      Job Ids that belong to this stage
-     * @param {String} [config.state]       Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
+     * @param {Object}      config
+     * @param {String}      [config.color]       Hex color for stage
+     * @param {String}      [config.description] Stage description
+     * @param {Array}       [config.jobIds=[]]   Job Ids that belong to this stage
+     * @param {String}      config.name          Name of the stage
+     * @param {String}      config.pipelineId    Pipeline the stage belongs to
+     * @param {String}      [config.state='ACTIVE'] Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
      * @memberof StageFactory
      */
     create(config) {

--- a/lib/stageFactory.js
+++ b/lib/stageFactory.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const BaseFactory = require('./baseFactory');
+const Stage = require('./stage');
+let instance;
+
+class StageFactory extends BaseFactory {
+    /**
+     * Construct a StageFactory object
+     * @method constructor
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     */
+    constructor(config) {
+        super('stage', config);
+    }
+
+    /**
+     * Instantiate a Stage class
+     * @method createClass
+     * @param  {Object}     config               Stage data
+     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
+     * @param  {String}     config.pipelineId    Pipeline the stage belongs to
+     * @param  {String}     config.name          Name of the stage
+     * @param  {Array}      config.jobIds        Job Ids that belong to this stage
+     * @param  {String}     config.state         Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
+     * @return {Stage}
+     */
+    createClass(config) {
+        return new Stage(config);
+    }
+
+    /**
+     * Create a Stage model
+     * @param {Object} config
+     * @param {String} config.pipelineId    Pipeline the stage belongs to
+     * @param {String} config.name          Name of the stage
+     * @param {Array}  [config.jobIds]      Job Ids that belong to this stage
+     * @param {String} [config.state]       Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
+     * @memberof StageFactory
+     */
+    create(config) {
+        if (!config.jobIds) {
+            config.jobIds = [];
+        }
+
+        if (!config.state) {
+            config.state = 'ACTIVE';
+        }
+
+        return super.create(config);
+    }
+
+    /**
+     * Get an instance of the StageFactory
+     * @method getInstance
+     * @param  {Object}     config
+     * @param  {Datastore}  config.datastore
+     * @return {StageFactory}
+     */
+    static getInstance(config) {
+        instance = BaseFactory.getInstance(StageFactory, instance, config);
+
+        return instance;
+    }
+}
+
+module.exports = StageFactory;

--- a/test/data/parserWithStages.json
+++ b/test/data/parserWithStages.json
@@ -98,11 +98,12 @@
     "annotations": {
         "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
     },
-    "stages": [{
-        "name": "canary",
-        "state": "ACTIVE",
-        "color": "#FFFF00",
-        "description": "Canary deployment",
-        "jobs": ["main", "publish"]
-    }]
+    "stages": {
+        "canary": {
+            "state": "ACTIVE",
+            "color": "#FFFF00",
+            "description": "Canary deployment",
+            "jobs": ["main", "publish"]
+        }
+    }
 }

--- a/test/data/parserWithStages.json
+++ b/test/data/parserWithStages.json
@@ -1,0 +1,108 @@
+{
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "4"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            },
+            {
+                "image": "node:5",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "5"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            },
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "init",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_VERSION": "6"
+                },
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
+            }
+        ],
+        "publish": [
+            {
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "bump",
+                        "command": "npm run bump"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish --tag $NODE_TAG"
+                    },
+                    {
+                        "name": "tag",
+                        "command": "git push origin --tags"
+                    }
+                ],
+                "environment": {
+                    "NODE_ENV": "test",
+                    "NODE_TAG": "latest"
+                },
+                "requires": ["main"]
+            }
+        ]
+    },
+    "workflow": [],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" }
+        ]
+    },
+    "annotations": {
+        "beta.screwdriver.cd/executor" : "screwdriver-executor-vm"
+    },
+    "stages": [{
+        "name": "canary",
+        "state": "ACTIVE",
+        "color": "#FFFF00",
+        "description": "Canary deployment",
+        "jobs": ["main", "publish"]
+    }]
+}

--- a/test/lib/stage.test.js
+++ b/test/lib/stage.test.js
@@ -7,12 +7,12 @@ const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('Trigger Model', () => {
+describe('Stage Model', () => {
     let BaseModel;
-    let TriggerModel;
+    let StageModel;
     let datastore;
     let createConfig;
-    let trigger;
+    let stage;
 
     before(() => {
         mockery.enable({
@@ -30,15 +30,15 @@ describe('Trigger Model', () => {
         BaseModel = require('../../lib/base');
 
         // eslint-disable-next-line global-require
-        TriggerModel = require('../../lib/trigger');
+        StageModel = require('../../lib/stage');
 
         createConfig = {
             datastore,
             id: 1111,
-            src: '~sd@12345:component',
-            dest: '~sd@5678:main'
+            pipelineId: 12345,
+            name: 'deploy'
         };
-        trigger = new TriggerModel(createConfig);
+        stage = new StageModel(createConfig);
     });
 
     afterEach(() => {
@@ -52,10 +52,10 @@ describe('Trigger Model', () => {
     });
 
     it('is constructed properly', () => {
-        assert.instanceOf(trigger, TriggerModel);
-        assert.instanceOf(trigger, BaseModel);
-        schema.models.trigger.allKeys.forEach(key => {
-            assert.strictEqual(trigger[key], createConfig[key]);
+        assert.instanceOf(stage, StageModel);
+        assert.instanceOf(stage, BaseModel);
+        schema.models.stage.allKeys.forEach(key => {
+            assert.strictEqual(stage[key], createConfig[key]);
         });
     });
 });

--- a/test/lib/stageFactory.test.js
+++ b/test/lib/stageFactory.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const { assert } = require('chai');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Stage Factory', () => {
+    const pipelineId = 8765;
+    const name = 'deploy';
+    const jobIds = [1, 2, 3];
+    const state = 'ACTIVE';
+    const metaData = {
+        pipelineId,
+        name,
+        jobIds,
+        state
+    };
+    const generatedId = 1234135;
+    let StageFactory;
+    let datastore;
+    let factory;
+    let Stage;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        datastore = {
+            save: sinon.stub(),
+            get: sinon.stub(),
+            scan: sinon.stub()
+        };
+
+        // eslint-disable-next-line global-require
+        Stage = require('../../lib/stage');
+        // eslint-disable-next-line global-require
+        StageFactory = require('../../lib/stageFactory');
+
+        factory = new StageFactory({ datastore });
+    });
+
+    afterEach(() => {
+        datastore = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('createClass', () => {
+        it('should return a Stage model', () => {
+            const model = factory.createClass(metaData);
+
+            assert.instanceOf(model, Stage);
+        });
+    });
+
+    describe('create', () => {
+        let expected;
+
+        beforeEach(() => {
+            expected = {
+                id: generatedId,
+                pipelineId,
+                name,
+                jobIds,
+                state
+            };
+        });
+
+        it('creates a Stage given pipelineId, name, and jobIds', () => {
+            datastore.save.resolves(expected);
+
+            return factory
+                .create({
+                    pipelineId,
+                    name,
+                    jobIds
+                })
+                .then(model => {
+                    assert.instanceOf(model, Stage);
+                    Object.keys(expected).forEach(key => {
+                        assert.strictEqual(model[key], expected[key]);
+                    });
+                });
+        });
+    });
+
+    describe('getInstance', () => {
+        let config;
+
+        beforeEach(() => {
+            config = { datastore };
+        });
+
+        it('should get an instance', () => {
+            const f1 = StageFactory.getInstance(config);
+            const f2 = StageFactory.getInstance(config);
+
+            assert.instanceOf(f1, StageFactory);
+            assert.instanceOf(f2, StageFactory);
+
+            assert.equal(f1, f2);
+        });
+
+        it('should throw when config not supplied', () => {
+            assert.throw(StageFactory.getInstance, Error, 'No datastore provided to StageFactory');
+        });
+    });
+});


### PR DESCRIPTION
## Context

Users might want to group jobs together visually in the UI into stages.

## Objective

This PR adds *stages* model. Also called `syncStages()` during pipeline `sync()`.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
