### PR TITLE
fix(2704): PR job without original job to work.

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -145,10 +145,10 @@ function getJobsFromPR(config) {
         // Make sure original job is also not disabled
         const originalJobName = j.parsePRJobName('job');
         const originalJob = jobs.find(o => o.name === originalJobName);
-        const originalJobEnabled = originalJob.state === 'ENABLED';
-        const originalJobNotArchived = originalJob.archived !== 'true';
+        const originalJobEnabled = originalJob ? originalJob.state === 'ENABLED' : true;
+        const originalJobNotArchived = originalJob ? originalJob.archived !== 'true' : true;
 
-        return j.state === 'ENABLED' && !j.archived && !!originalJobEnabled && !!originalJobNotArchived;
+        return !j.archived && !!originalJobEnabled && !!originalJobNotArchived;
     });
 }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Disabled jobs are no longer executed in PR builds at https://github.com/screwdriver-cd/models/pull/537.

However, jobs for which the original does not exist, such as newly created jobs in PR, are not working.
You are probably getting the following error.
`TypeError: Cannot read property 'state' of undefined`

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Check for the existence of the original job and handle it as ENABLED or notArchived if it does not exist.
- According to the following fixes, the state should always refer to the original.
  - https://github.com/screwdriver-cd/ui/pull/795

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
