### PR TITLE
fix(2720): Include pull request jobs without parentJobId for pull request sync

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -48,22 +48,19 @@ const Queries = {
     getPRJobsForPipelineSyncQuery: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND "prParentJobId" IS NOT NULL
-        AND (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1)) IN (:prNames))
+        AND ((archived = 0 AND name LIKE 'PR-%') OR (SUBSTR(name, 1, INSTR(name, ':')-1) IN (:prNames)))
         ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryPostgres: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND "prParentJobId" IS NOT NULL
-        AND (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
+        AND ((archived = false AND name LIKE 'PR-%') OR (SUBSTR(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
         ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryMySql: (tablePrefix = '') => `SELECT *
 		FROM  \`${tablePrefix}jobs\`
         WHERE pipelineId = :pipelineId
-        AND prParentJobId IS NOT NULL
-        AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1)) IN (:prNames))
+        AND ((archived = false AND name LIKE 'PR-%') OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
         ORDER BY id ASC`
 };
 


### PR DESCRIPTION

## Context

The raw SQL queries introduced for https://github.com/screwdriver-cd/screwdriver/issues/2496 to exclude archived pull request jobs for closed pull requests, excluded the pull request jobs without `prParentJobId`. Thus failing the pull request sync workflow and unable to restart PR builds.

This can occur when a new job is added as part of the pull request.

## Objective

Update the raw SQL queries to also include pull request jobs without `parentJobId`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2720

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
