### PR TITLE
fix(2720): Jobs fetch query for pull request sync fails for PostgreSQL

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -48,19 +48,22 @@ const Queries = {
     getPRJobsForPipelineSyncQuery: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND ((archived = 0 AND name LIKE 'PR-%') OR (SUBSTR(name, 1, INSTR(name, ':')-1) IN (:prNames)))
+        AND name LIKE 'PR-%'
+        AND (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1) IN (:prNames)))
         ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryPostgres: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND ((archived = false AND name LIKE 'PR-%') OR (SUBSTR(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
+        AND name LIKE 'PR-%'
+        AND (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
         ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryMySql: (tablePrefix = '') => `SELECT *
 		FROM  \`${tablePrefix}jobs\`
         WHERE pipelineId = :pipelineId
-        AND ((archived = false AND name LIKE 'PR-%') OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
+        AND name LIKE 'PR-%'
+        AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
         ORDER BY id ASC`
 };
 


### PR DESCRIPTION
## Context

The raw SQL query updated in https://github.com/screwdriver-cd/models/pull/547 is causing below error when executed against PostgreSQL
`negative substring length not allowed`

## Objective

This PR updates the raw SQL queries to prevent the error

## References

https://github.com/screwdriver-cd/screwdriver/issues/2720
https://github.com/screwdriver-cd/screwdriver/issues/2496

Related PR:
https://github.com/screwdriver-cd/models/pull/547

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
