### PR TITLE
fix(2720): fix get pipelineJobs

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1394,7 +1394,9 @@ class PipelineModel extends BaseModel {
         /* eslint-enable global-require */
         const factory = JobFactory.getInstance();
 
-        const jobs = factory.list(listConfig);
+        const jobs = factory.list(listConfig).then(value => {
+            return value.filter(j => !j.name.startsWith('PR-'));
+        });
 
         // ES6 has weird getters and setters in classes,
         // so we redefine the pipeline property here to resolve to the

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1395,7 +1395,7 @@ class PipelineModel extends BaseModel {
         const factory = JobFactory.getInstance();
 
         const jobs = factory.list(listConfig).then(value => {
-            return value.filter(j => !j.name.startsWith('PR-'));
+            return value.filter(j => !j.isPR());
         });
 
         // ES6 has weird getters and setters in classes,

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1930,6 +1930,14 @@ describe('Pipeline Model', () => {
             // as the model's pipeline property, now
             assert.calledOnce(jobFactoryMock.list);
         });
+
+        it('gets only pipelineJobs', () => {
+            jobFactoryMock.list.resolves([mainJob, pr10]);
+
+            return pipeline.pipelineJobs.then(value => {
+                assert.deepEqual(value, [mainJob]);
+            });
+        });
     });
 
     describe('get secrets', () => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1392,6 +1392,7 @@ describe('Pipeline Model', () => {
             const error = new Error('pipelineId:123: Failed to fetch screwdriver.yaml.');
 
             scmMock.getFile.rejects(error);
+            jobFactoryMock.list.resolves([]);
 
             return pipeline.syncPR(1).catch(err => {
                 assert.equal(err.message, error.message);


### PR DESCRIPTION
## Context
Every time the [sync function](https://github.com/screwdriver-cd/models/blob/e8df4c43843d430a51162cb62a00a5365a340095/lib/pipeline.js#L955) is called, PR jobs without `parentJobId` are archived. This is because the getter of `pipeline.js` named `pipelineJobs` gets not only non pull request jobs but also pull request jobs without `parentJobId`.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We fix the `pipelineJobs` to only get non pull request job. 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2720#issuecomment-1165358293
https://github.com/screwdriver-cd/screwdriver/issues/2496
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
