### PR TITLE
fix(2720): Jobs fetch query for pull request sync fails

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -48,22 +48,28 @@ const Queries = {
     getPRJobsForPipelineSyncQuery: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND name LIKE 'PR-%'
-        AND (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1) IN (:prNames)))
+        AND CASE 
+            WHEN name LIKE 'PR-%' THEN (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1) IN (:prNames)))
+            ELSE 0
+        END
         ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryPostgres: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND name LIKE 'PR-%'
-        AND (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
+        AND CASE 
+            WHEN name LIKE 'PR-%' THEN (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
+            ELSE false
+        END
         ORDER BY "id" ASC`,
 
     getPRJobsForPipelineSyncQueryMySql: (tablePrefix = '') => `SELECT *
 		FROM  \`${tablePrefix}jobs\`
         WHERE pipelineId = :pipelineId
-        AND name LIKE 'PR-%'
-        AND (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
+        AND CASE 
+            WHEN name LIKE 'PR-%' THEN (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
+            ELSE false
+        END
         ORDER BY id ASC`
 };
 

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -48,7 +48,7 @@ const Queries = {
     getPRJobsForPipelineSyncQuery: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND CASE 
+        AND CASE
             WHEN name LIKE 'PR-%' THEN (archived = 0 OR (SUBSTR(name, 1, INSTR(name, ':')-1) IN (:prNames)))
             ELSE 0
         END
@@ -57,7 +57,7 @@ const Queries = {
     getPRJobsForPipelineSyncQueryPostgres: (tablePrefix = '') => `SELECT *
         FROM "${tablePrefix}jobs"
         WHERE "pipelineId" = :pipelineId
-        AND CASE 
+        AND CASE
             WHEN name LIKE 'PR-%' THEN (archived = false OR (SUBSTR(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
             ELSE false
         END
@@ -66,7 +66,7 @@ const Queries = {
     getPRJobsForPipelineSyncQueryMySql: (tablePrefix = '') => `SELECT *
 		FROM  \`${tablePrefix}jobs\`
         WHERE pipelineId = :pipelineId
-        AND CASE 
+        AND CASE
             WHEN name LIKE 'PR-%' THEN (archived = false OR (SUBSTRING(name, 1, POSITION(':' IN name) - 1) IN (:prNames)))
             ELSE false
         END


### PR DESCRIPTION
## Context
The following error occurs even after #548.
`negative substring length not allowed`
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
<img width="494" alt="negative_error" src="https://user-images.githubusercontent.com/22903716/175898393-7a818cb9-3615-40f5-88f0-c7b5f3346292.png">

## Objective
We update the raw SQL queries to prevent the error. 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
As the following documentation shows, in postgresql, bool expressions are not always evaluated from the left.
https://www.postgresql.org/docs/14/sql-expressions.html#SYNTAX-EXPRESS-EVAL
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
