### PR TITLE
fix(2669): Sync pipeline stages after new jobs are created

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1009,9 +1009,6 @@ class PipelineModel extends BaseModel {
         const parsedConfigJobNames = Object.keys(parsedConfig.jobs);
         const pipelineId = this.id;
 
-        // Sync pipeline stages
-        await syncStages({ pipelineJobs: existingJobs, pipelineId, stages: parsedConfig.stages || [] });
-
         // Loop through non-PR existing jobs
         for (const jobChunks of getJobChunks(existingJobs)) {
             await Promise.all(
@@ -1120,6 +1117,14 @@ class PipelineModel extends BaseModel {
                 return node;
             })
         );
+
+        // Sync pipeline stages
+        await syncStages({
+            // make sure newly created jobs are passed in; remove duplicates
+            pipelineJobs: [...new Set([...existingJobs, ...updatedJobs])],
+            pipelineId,
+            stages: parsedConfig.stages || []
+        });
 
         // jobs updated or new jobs created during sync
         // delete it here so next time this.pipelineJobs is called a DB query will be forced and new jobs will return

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.5.5",
-    "screwdriver-data-schema": "^21.23.1",
+    "screwdriver-data-schema": "^21.25.1",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }


### PR DESCRIPTION
## Context

If a job was renamed, stage list of jobIds is missing the newly created job. This is because `syncStages` was called before job is created.

## Objective

This PR moves syncStages to be called after new jobs are created. Passes in original pipelineJobs and newly created ones.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
