### PR TITLE
fix(2581): Set parentEventId even in case PR

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -714,10 +714,12 @@ class EventFactory extends BaseFactory {
                 // Sync pipeline to make sure workflowGraph is generated
                 .then(p => {
                     prevChainPR = p.chainPR;
+                    if (parentEventId) {
+                        modelConfig.parentEventId = parentEventId;
+                    }
+
                     // Sync pipeline with the parentEvent sha and create jobs based on that sha
                     if (parentEventId && !prRef) {
-                        modelConfig.parentEventId = parentEventId;
-
                         // for child pipelines restart event, sync with configPipelineSha
                         if (configPipelineSha) {
                             modelConfig.configPipelineSha = configPipelineSha;

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1615,6 +1615,17 @@ describe('Event Factory', () => {
             });
         });
 
+        it('should create event with parentEventId even if it is pr event', () => {
+            config.prNum = 20;
+            config.prRef = 'branch';
+            config.parentEventId = 222;
+
+            return eventFactory.create(config).then(model => {
+                assert.instanceOf(model, Event);
+                assert.deepEqual(model.parentEventId, config.parentEventId);
+            });
+        });
+
         it('should not call pipeline sync with configPipelineSha if it is pr event', () => {
             config.parentEventId = 222;
             config.configPipelineSha = 'configpipelinesha';


### PR DESCRIPTION
## Context
Currently restarted PR events do not fetch the metadata set in the parent event.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We set `parentEventId` to events even in case PR event. Then metadata of parent event will be fetched [here](https://github.com/screwdriver-cd/launcher/blob/c566f097bb9bceb248799774f8520cf4f3e12ba6/launch.go#L488-L498).
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2581#issuecomment-1172195954
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
