### PR TITLE
fix(2669): Create new stage or use old stage based off groupEventId [2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,9 +679,8 @@ factory.create(config).then(model => {
 | config.pipelineId | Number | Yes | Pipeline that this stage belongs to |
 | config.name | String | Yes | Stage name |
 | config.jobIds | Array | No | Jobs IDs that belong to this stage. Default `[]`. |
-| config.state | String | No | State of stage (ARCHIVED, ACTIVE). Default `ACTIVE`. |
+| config.groupEventId | Number | Yes | Group event ID that this stage belongs to |
 | config.description | String | No | Description for stage |
-| config.color | String | No | Hex color for Stage |
 
 #### Get
 Get stage based on ID.
@@ -696,11 +695,12 @@ factory.get(id).then(model => {
 | id | Number | The unique ID for the stage |
 
 #### List
-List stages that have pipelineId as `12345`
+List stages that have pipelineId as `12345` and groupEventId as `555`
 ```js
 factory.list({
     params: {
-        pipelineId: 12345
+        pipelineId: 12345,
+        groupEventId: 555
     }
 }).then(recs =>
     // do things with the records

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -402,6 +402,103 @@ function createBuilds(config) {
 }
 
 /**
+ * Converts the simplified stages into a more consistent format
+ *
+ * This is because the user can provide the stage information as:
+ *  - {"name": { "jobs": ["job1", "job2", "job3"], "description": "Description" },
+ *     { "name2": { "jobs": ["job4", "job5"] } }
+ *
+ * We will convert it to a more standard format:
+ *  - [{ "name": "name", "jobs": ["job1", "job2", "job3"], "description": "value" },
+ *     { "name": "name2", "jobs": ["job4", "job5"] }]
+ * @method convertStages
+ * @param  {Object}     config              config
+ * @param  {Number}     config.groupEventId Group event ID
+ * @param  {Array}      config.pipelineJobs Pipeline jobs
+ * @param  {Number}     config.pipelineId   pipelineId belongs to this job
+ * @param  {Object}     config.stages       Pipeline stages
+ * @return {Array}                New array with stages after up-converting
+ */
+function convertStages(config) {
+    const { pipelineId, stages, pipelineJobs, groupEventId } = config;
+    const newStages = [];
+
+    // Convert stages from object to array of objects
+    Object.entries(stages).forEach(([key, value]) => {
+        const newStage = {
+            name: key,
+            pipelineId,
+            groupEventId,
+            ...value
+        };
+        const jobIds = [];
+
+        // Convert the jobNames to jobIds
+        value.jobs.forEach(jobName => {
+            const job = pipelineJobs.find(j => j.name === jobName);
+
+            if (job) {
+                jobIds.push(job.id);
+            }
+        });
+
+        newStage.jobIds = jobIds;
+        delete newStage.jobs; // extra field from yaml parser
+
+        newStages.push(newStage);
+    });
+
+    return newStages;
+}
+
+/**
+ * Sync stages
+ * 1. Convert new stages into correct format, prepopulate with jobIds and state
+ * 2. Create the stages if it is defined and was not in the database yet
+ * @method syncStages
+ * @param  {Object}     config              config
+ * @param  {Array}      config.pipeline     Pipeline
+ * @return {Promise}
+ */
+async function syncStages({ pipeline, groupEventId }) {
+    // Lazy load factory dependency to prevent circular dependency issues
+    // https://nodejs.org/api/modules.html#modules_cycles
+    /* eslint-disable global-require */
+    const StageFactory = require('./stageFactory');
+    /* eslint-enable global-require */
+
+    const stageFactory = StageFactory.getInstance();
+    const { id: pipelineId } = pipeline;
+
+    // Get pipeline jobs
+    const pipelineJobs = await pipeline.pipelineJobs;
+    // Get new stages
+    const parsedYaml = await pipeline.getConfiguration({});
+    const stages = parsedYaml.stages || {};
+
+    if (Object.keys(stages).length === 0) {
+        return Promise.resolve();
+    }
+
+    const newStages = convertStages({ pipelineJobs, pipelineId, stages, groupEventId });
+
+    const processed = [];
+
+    // list records that would trigger this job
+    return stageFactory.list({ params: { pipelineId, groupEventId } }).then(records => {
+        // if the stage is not in the old stages list, then create in datastore
+        const oldStagesNamesList = records.map(r => r.name); // get the old stage names list
+        const toCreate = newStages.filter(s => !oldStagesNamesList.includes(s.name));
+
+        toCreate.forEach(stage => {
+            processed.push(stageFactory.create(stage));
+        });
+
+        return Promise.all(processed);
+    });
+}
+
+/**
  * Get the latest workflowGraph
  * @method getLatestWorkflowGraph
  * @param  {Object}         config
@@ -857,6 +954,10 @@ class EventFactory extends BaseFactory {
                             }
 
                             return Promise.resolve(event);
+                        })
+                        .then(event => {
+                            // Sync pipeline stages
+                            return syncStages({ pipeline, groupEventId: event.groupEventId }).then(() => event);
                         })
                         .then(event => {
                             if (modelConfig.type === 'pipeline') {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -453,7 +453,7 @@ function convertStages(config) {
 
 /**
  * Sync stages
- * 1. Convert new stages into correct format, prepopulate with jobIds and state
+ * 1. Convert new stages into correct format, prepopulate with jobIds
  * 2. Create the stages if it is defined and was not in the database yet
  * @method syncStages
  * @param  {Object}     config              config

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -233,111 +233,6 @@ function syncExternalTriggers(config) {
     });
 }
 
-/**
- * Converts the simplified stages into a more consistent format
- *
- * This is because the user can provide the stage information as:
- *  - {"name": { "jobs": ["job1", "job2", "job3"], "description": "Description" },
- *     { "name2": { "jobs": ["job4", "job5"] } }
- *
- * We will convert it to a more standard format:
- *  - [{ "name": "name", "jobs": ["job1", "job2", "job3"], "description": "value" },
- *     { "name": "name2", "jobs": ["job4", "job5"] }]
- * @method convertStages
- * @param  {Object}     config              config
- * @param  {Array}      config.pipelineJobs Pipeline jobs
- * @param  {Number}     config.pipelineId   pipelineId belongs to this job
- * @param  {Object}     config.stages       Pipeline stages
- * @return {Array}                New array with stages after up-converting
- */
-function convertStages(config) {
-    const { pipelineId, stages, pipelineJobs } = config;
-    const newStages = [];
-
-    // Convert stages from object to array of objects
-    Object.entries(stages).forEach(([key, value]) => {
-        const newStage = {
-            name: key,
-            pipelineId,
-            state: 'ACTIVE', // default stage state
-            ...value
-        };
-        const jobIds = [];
-
-        // Convert the jobNames to jobIds
-        value.jobs.forEach(jobName => {
-            const job = pipelineJobs.find(j => j.name === jobName);
-
-            if (job) {
-                jobIds.push(job.id);
-            }
-        });
-
-        newStage.jobIds = jobIds;
-        delete newStage.jobs; // extra field from yaml parser
-
-        newStages.push(newStage);
-    });
-
-    return newStages;
-}
-
-/**
- * Sync stages
- * 1. Convert new stages into correct format, prepopulate with jobIds and state
- * 2. Update stage status to ARCHIVED if it is no longer in yaml
- *    Update stage fields if changes are made
- *    Create the stages if it is defined and was not in the database yet
- * @method syncStages
- * @param  {Object}     config              config
- * @param  {Array}      config.pipelineJobs Pipeline jobs
- * @param  {Number}     config.pipelineId   pipelineId belongs to this job
- * @param  {Object}     config.stages       Pipeline stages
- * @return {Promise}
- */
-function syncStages(config) {
-    // Lazy load factory dependency to prevent circular dependency issues
-    // https://nodejs.org/api/modules.html#modules_cycles
-    /* eslint-disable global-require */
-    const StageFactory = require('./stageFactory');
-    /* eslint-enable global-require */
-
-    const stageFactory = StageFactory.getInstance();
-    const { pipelineId, stages } = config;
-    const newStagesNamesList = Object.keys(stages); // get the new stage names list
-    const newStages = convertStages(config);
-    const processed = [];
-
-    // list records that would trigger this job
-    return stageFactory.list({ params: { pipelineId } }).then(records => {
-        records.forEach(rec => {
-            // if the stage is not in the new stages list, then archive it
-            if (!newStagesNamesList.includes(rec.name)) {
-                rec.state = 'ARCHIVED';
-            } else {
-                // Get the new stage definition
-                const stageToUpdate = newStages.find(s => s.name === rec.name);
-
-                rec.state = stageToUpdate.state;
-                rec.description = stageToUpdate.description;
-                rec.color = stageToUpdate.color;
-                rec.jobIds = stageToUpdate.jobIds;
-            }
-            processed.push(rec.update());
-        });
-
-        // if the stage is not in the old stages list, then create in datastore
-        const oldStagesNamesList = records.map(r => r.name); // get the old stage names list
-        const toCreate = newStages.filter(s => !oldStagesNamesList.includes(s.name));
-
-        toCreate.forEach(stage => {
-            processed.push(stageFactory.create(stage));
-        });
-
-        return Promise.all(processed);
-    });
-}
-
 class PipelineModel extends BaseModel {
     /**
      * Construct a PipelineModel object
@@ -1117,14 +1012,6 @@ class PipelineModel extends BaseModel {
                 return node;
             })
         );
-
-        // Sync pipeline stages
-        await syncStages({
-            // make sure newly created jobs are passed in; remove duplicates
-            pipelineJobs: [...new Set([...existingJobs, ...updatedJobs])],
-            pipelineId,
-            stages: parsedConfig.stages || []
-        });
 
         // jobs updated or new jobs created during sync
         // delete it here so next time this.pipelineJobs is called a DB query will be forced and new jobs will return

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -7,7 +7,6 @@ class StageModel extends BaseModel {
      * Construct a StageModel object
      * @method constructor
      * @param  {Object}    config
-     * @param  {Object}    config.createTime    Create time
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
      * @param  {String}    [config.description] Stage description
      * @param  {Number}    config.groupEventId  Group event ID

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -7,13 +7,13 @@ class StageModel extends BaseModel {
      * Construct a StageModel object
      * @method constructor
      * @param  {Object}    config
+     * @param  {Object}    config.createTime    Create time
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
-     * @param  {String}    [config.color]       Hex color for stage
      * @param  {String}    [config.description] Stage description
+     * @param  {Number}    config.groupEventId  Group event ID
      * @param  {Array}     [config.jobIds=[]]   Job Ids that belong to this stage
      * @param  {String}    config.name          Name of the stage
-     * @param  {String}    config.pipelineId    Pipeline the stage belongs to
-     * @param  {String}    [config.state='ACTIVE'] Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
+     * @param  {Number}    config.pipelineId    Pipeline the stage belongs to
      */
     constructor(config) {
         super('stage', config);

--- a/lib/stageFactory.js
+++ b/lib/stageFactory.js
@@ -28,12 +28,11 @@ class StageFactory extends BaseFactory {
     /**
      * Create a Stage model
      * @param {Object}      config
-     * @param {String}      [config.color]       Hex color for stage
      * @param {String}      [config.description] Stage description
+     * @param {Number}      config.groupEventId  Group event Id for stage
      * @param {Array}       [config.jobIds=[]]   Job Ids that belong to this stage
      * @param {String}      config.name          Name of the stage
      * @param {String}      config.pipelineId    Pipeline the stage belongs to
-     * @param {String}      [config.state='ACTIVE'] Current state of the stage (e.g. ARCHIVED, ACTIVE, etc)
      * @memberof StageFactory
      */
     create(config) {
@@ -41,9 +40,7 @@ class StageFactory extends BaseFactory {
             config.jobIds = [];
         }
 
-        if (!config.state) {
-            config.state = 'ACTIVE';
-        }
+        config.createTime = new Date().toISOString();
 
         return super.create(config);
     }

--- a/lib/stageFactory.js
+++ b/lib/stageFactory.js
@@ -40,8 +40,6 @@ class StageFactory extends BaseFactory {
             config.jobIds = [];
         }
 
-        config.createTime = new Date().toISOString();
-
         return super.create(config);
     }
 

--- a/test/data/parserWithStages.json
+++ b/test/data/parserWithStages.json
@@ -100,8 +100,6 @@
     },
     "stages": {
         "canary": {
-            "state": "ACTIVE",
-            "color": "#FFFF00",
             "description": "Canary deployment",
             "jobs": ["main", "publish"]
         }

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1975,8 +1975,7 @@ describe('Event Factory', () => {
                     pipelineId: 8765,
                     description: 'Canary deployment',
                     jobs: [1, 2],
-                    groupEventId: 'xzy1234',
-                    createTime: nowTime
+                    groupEventId: 'xzy1234'
                 }
             ]);
             config.startFrom = 'main';

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -18,7 +18,6 @@ const PROVIDER_YAML = '../data/provider.yaml';
 const PARSED_YAML_WITH_PROVIDER = require('../data/parserWithProvider.json');
 const PARSED_YAML = require('../data/parser.json');
 const PARSED_YAML_WITH_REQUIRES = require('../data/parserWithRequires.json');
-const PARSED_YAML_WITH_STAGES = require('../data/parserWithStages.json');
 const PARSED_YAML_PR = require('../data/parserWithWorkflowGraphPR.json');
 const PARSED_YAML_WITH_ERRORS = require('../data/parserWithErrors.json');
 const PARSED_YAML_WITH_SUBSCRIBE = require('../data/parserWithSubscribedScms.json');
@@ -69,7 +68,6 @@ describe('Pipeline Model', () => {
     let buildFactoryMock;
     let templateFactoryMock;
     let buildClusterFactoryMock;
-    let stageFactoryMock;
     let triggerFactoryMock;
     let pipelineFactoryMock;
     let collectionFactoryMock;
@@ -242,10 +240,6 @@ describe('Pipeline Model', () => {
         secretFactoryMock = {
             list: sinon.stub()
         };
-        stageFactoryMock = {
-            list: sinon.stub(),
-            create: sinon.stub()
-        };
         templateFactoryMock = {};
         triggerFactoryMock = {
             list: sinon.stub(),
@@ -324,9 +318,6 @@ describe('Pipeline Model', () => {
         });
         mockery.registerMock('./secretFactory', {
             getInstance: sinon.stub().returns(secretFactoryMock)
-        });
-        mockery.registerMock('./stageFactory', {
-            getInstance: sinon.stub().returns(stageFactoryMock)
         });
         mockery.registerMock('./templateFactory', {
             getInstance: sinon.stub().returns(templateFactoryMock)
@@ -551,8 +542,6 @@ describe('Pipeline Model', () => {
             pipelineFactoryMock.create.resolves({ id: '98765', sync: sinon.stub().resolves({ id: '98765' }) });
             triggerFactoryMock.list.resolves([]);
             triggerFactoryMock.create.resolves(null);
-            stageFactoryMock.list.resolves([]);
-            stageFactoryMock.create.resolves(null);
 
             mainModelMock = {
                 isPR: sinon.stub().returns(false),
@@ -695,77 +684,6 @@ describe('Pipeline Model', () => {
             return pipeline.sync().then(() => {
                 assert.notCalled(triggerMock.remove);
                 assert.notCalled(triggerFactoryMock.create);
-            });
-        });
-
-        it('create stage in datastore for new stages', () => {
-            sinon.spy(pipeline, 'update');
-            parserMock.withArgs(parserConfig).resolves(PARSED_YAML_WITH_STAGES);
-            jobFactoryMock.list.resolves([mainModelMock, publishModelMock]);
-            mainModelMock.update.resolves(mainModelMock);
-            publishModelMock.update.resolves(publishModelMock);
-
-            return pipeline.sync().then(() => {
-                assert.calledOnce(pipeline.update);
-                assert.calledOnce(stageFactoryMock.create);
-                assert.calledWith(stageFactoryMock.create, {
-                    pipelineId: 123,
-                    name: 'canary',
-                    description: 'Canary deployment',
-                    jobIds: [1, 2],
-                    state: 'ACTIVE',
-                    color: '#FFFF00'
-                });
-            });
-        });
-
-        it('updates stage as ARCHIVED in datastore for removed stages', () => {
-            const stageMock = {
-                name: 'production',
-                state: 'ACTIVE',
-                color: '#00FFFF',
-                description: 'Some random placeholder',
-                jobIds: [1],
-                update: sinon.stub().resolves(null),
-                pipelineId: 123
-            };
-
-            sinon.spy(pipeline, 'update');
-
-            parserMock.withArgs(parserConfig).resolves(PARSED_YAML_WITH_REQUIRES);
-            jobFactoryMock.list.resolves([mainModelMock, publishModelMock]);
-            mainModelMock.update.resolves(mainModelMock);
-            publishModelMock.update.resolves(publishModelMock);
-            stageFactoryMock.list.resolves([stageMock]);
-
-            return pipeline.sync().then(() => {
-                assert.calledOnce(pipeline.update);
-                assert.calledOnce(stageMock.update);
-            });
-        });
-
-        it('updates stage in datastore for existing stages', () => {
-            const stageMock = {
-                name: 'canary',
-                state: 'ACTIVE',
-                color: '#00FFFF',
-                description: 'Some random placeholder',
-                jobIds: [1],
-                update: sinon.stub().resolves(null),
-                pipelineId: 123
-            };
-
-            sinon.spy(pipeline, 'update');
-            parserMock.withArgs(parserConfig).resolves(PARSED_YAML_WITH_STAGES);
-            jobFactoryMock.list.resolves([mainModelMock, publishModelMock]);
-            mainModelMock.update.resolves(mainModelMock);
-            publishModelMock.update.resolves(publishModelMock);
-            stageFactoryMock.list.resolves([stageMock]);
-
-            return pipeline.sync().then(() => {
-                assert.calledOnce(pipeline.update);
-                assert.calledOnce(stageMock.update);
-                assert.notCalled(stageFactoryMock.create);
             });
         });
 

--- a/test/lib/stageFactory.test.js
+++ b/test/lib/stageFactory.test.js
@@ -10,12 +10,10 @@ describe('Stage Factory', () => {
     const pipelineId = 8765;
     const name = 'deploy';
     const jobIds = [1, 2, 3];
-    const state = 'ACTIVE';
     const metaData = {
         pipelineId,
         name,
-        jobIds,
-        state
+        jobIds
     };
     const generatedId = 1234135;
     let StageFactory;
@@ -71,8 +69,7 @@ describe('Stage Factory', () => {
                 id: generatedId,
                 pipelineId,
                 name,
-                jobIds,
-                state
+                jobIds
             };
         });
 
@@ -89,6 +86,23 @@ describe('Stage Factory', () => {
                     assert.instanceOf(model, Stage);
                     Object.keys(expected).forEach(key => {
                         assert.strictEqual(model[key], expected[key]);
+                    });
+                });
+        });
+
+        it('creates a Stage given pipelineId and name', () => {
+            expected.jobIds = [];
+            datastore.save.resolves(expected);
+
+            return factory
+                .create({
+                    pipelineId,
+                    name
+                })
+                .then(model => {
+                    assert.instanceOf(model, Stage);
+                    Object.keys(expected).forEach(key => {
+                        assert.deepEqual(model[key], expected[key]);
                     });
                 });
         });


### PR DESCRIPTION
## Context

Since the UI needs to show old stage information in current and past events, it would be better to keep track of stages based off of `name`, `pipelineId`, and `groupEventId` in order to determine a unique row.
There was also feedback to keep user UI settings such as `color` from the screwdriver.yaml config file.
Adding `createTime` will help keep track of "latest" stages.

Since stages will be more tied to events, we no longer need `state` to keep track of "active" or "archived" stages, they will always be created if they are new or we will refer to an older entry if they are not. We will no longer update stage entries in the DB.

See design doc for more info: https://github.com/screwdriver-cd/screwdriver/pull/2733

## Objective

This PR moves stage creation to event create and removes from pipeline sync. Also removes `color` and `state` fields from stage.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
