### PR TITLE
fix(2728): add handling for PR jobs

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -98,7 +98,24 @@ function getJobsFromJobName(config) {
         return [];
     }
 
-    return jobs.filter(j => j.name === startFrom && j.state === 'ENABLED' && !j.archived);
+    return jobs.filter(j => {
+        if (j.name !== startFrom || j.archived) {
+            return false;
+        }
+
+        if (j.isPR()) {
+            // Make sure original job is also not disabled/archived
+            // If the original job does not exist, it will be enabled
+            const originalJobName = j.parsePRJobName('job');
+            const originalJob = jobs.find(o => o.name === originalJobName);
+            const originalJobEnabled = originalJob ? originalJob.state === 'ENABLED' : true;
+            const originalJobNotArchived = originalJob ? !originalJob.archived : true;
+
+            return originalJobEnabled && originalJobNotArchived;
+        }
+
+        return j.state === 'ENABLED';
+    });
 }
 
 /**
@@ -146,9 +163,9 @@ function getJobsFromPR(config) {
         const originalJobName = j.parsePRJobName('job');
         const originalJob = jobs.find(o => o.name === originalJobName);
         const originalJobEnabled = originalJob ? originalJob.state === 'ENABLED' : true;
-        const originalJobNotArchived = originalJob ? originalJob.archived !== 'true' : true;
+        const originalJobNotArchived = originalJob ? !originalJob.archived : true;
 
-        return !j.archived && !!originalJobEnabled && !!originalJobNotArchived;
+        return !j.archived && originalJobEnabled && originalJobNotArchived;
     });
 }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

PR builds are no longer executed when original jobs is disabled at https://github.com/screwdriver-cd/models/pull/537 .

However, disabled PR builds are executed from the restart button on the detail page (https://github.com/screwdriver-cd/screwdriver/issues/2728).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Check the original job state of the job triggered from the PR job name
  - This check should be the same as a normal PR build.

Click on the restart button to see the following image.

![fixed](https://user-images.githubusercontent.com/43719835/180143102-6e663e83-87be-4b39-ad30-9e6654c2c6b0.jpg)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issues
  - https://github.com/screwdriver-cd/screwdriver/issues/2728

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
