### PR TITLE
fix(2669): Refactor syncStages to fail early

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -426,25 +426,25 @@ function createBuilds(config) {
  *     { "name2": { "jobs": ["job4", "job5"] } }
  *
  * We will convert it to a more standard format:
- *  - [{ "name": "name", "jobs": ["job1", "job2", "job3"], "description": "value" },
- *     { "name": "name2", "jobs": ["job4", "job5"] }]
+ *  - [{ "name": "name", "jobs": [1, 2, 3], "pipelineId": 123, "groupEventId": 555, "description": "value" },
+ *     { "name": "name2", "jobs": [4, 5], "pipelineId": 123, "groupEventId": 555 }]
  * @method convertStages
  * @param  {Object}     config              config
  * @param  {Number}     config.groupEventId Group event ID
- * @param  {Array}      config.pipelineJobs Pipeline jobs
- * @param  {Number}     config.pipelineId   pipelineId belongs to this job
+ * @param  {Object}     config.pipeline     Pipeline
  * @param  {Object}     config.stages       Pipeline stages
  * @return {Array}                New array with stages after up-converting
  */
-function convertStages(config) {
-    const { pipelineId, stages, pipelineJobs, groupEventId } = config;
+async function convertStages(config) {
+    const { pipeline, stages, groupEventId } = config;
+    const pipelineJobs = await pipeline.pipelineJobs;
     const newStages = [];
 
     // Convert stages from object to array of objects
     Object.entries(stages).forEach(([key, value]) => {
         const newStage = {
             name: key,
-            pipelineId,
+            pipelineId: pipeline.id,
             groupEventId,
             ...value
         };
@@ -472,12 +472,13 @@ function convertStages(config) {
  * Sync stages
  * 1. Convert new stages into correct format, prepopulate with jobIds
  * 2. Create the stages if it is defined and was not in the database yet
- * @method syncStages
+ * @method createStages
  * @param  {Object}     config              config
- * @param  {Array}      config.pipeline     Pipeline
+ * @param  {Number}     config.groupEventId Group event ID
+ * @param  {Object}     config.pipeline     Pipeline
  * @return {Promise}
  */
-async function syncStages({ pipeline, groupEventId }) {
+async function createStages({ pipeline, groupEventId }) {
     // Lazy load factory dependency to prevent circular dependency issues
     // https://nodejs.org/api/modules.html#modules_cycles
     /* eslint-disable global-require */
@@ -487,32 +488,32 @@ async function syncStages({ pipeline, groupEventId }) {
     const stageFactory = StageFactory.getInstance();
     const { id: pipelineId } = pipeline;
 
-    // Get pipeline jobs
-    const pipelineJobs = await pipeline.pipelineJobs;
+    // list records that would trigger this job
+    const records = await stageFactory.list({ params: { pipelineId, groupEventId } });
+
+    // Stages already exist, skip stage creation
+    if (records.length !== 0) {
+        return Promise.resolve();
+    }
+
     // Get new stages
     const parsedYaml = await pipeline.getConfiguration({});
     const stages = parsedYaml.stages || {};
 
+    // No new stages in yaml
     if (Object.keys(stages).length === 0) {
         return Promise.resolve();
     }
 
-    const newStages = convertStages({ pipelineJobs, pipelineId, stages, groupEventId });
-
+    const newStages = await convertStages({ pipeline, stages, groupEventId });
     const processed = [];
 
-    // list records that would trigger this job
-    return stageFactory.list({ params: { pipelineId, groupEventId } }).then(records => {
-        // if the stage is not in the old stages list, then create in datastore
-        const oldStagesNamesList = records.map(r => r.name); // get the old stage names list
-        const toCreate = newStages.filter(s => !oldStagesNamesList.includes(s.name));
-
-        toCreate.forEach(stage => {
-            processed.push(stageFactory.create(stage));
-        });
-
-        return Promise.all(processed);
+    // Create new stages
+    newStages.forEach(stage => {
+        processed.push(stageFactory.create(stage));
     });
+
+    return Promise.all(processed);
 }
 
 /**
@@ -973,8 +974,8 @@ class EventFactory extends BaseFactory {
                             return Promise.resolve(event);
                         })
                         .then(event => {
-                            // Sync pipeline stages
-                            return syncStages({ pipeline, groupEventId: event.groupEventId }).then(() => event);
+                            // Create pipeline stages if they don't exist
+                            return createStages({ pipeline, groupEventId: event.groupEventId }).then(() => event);
                         })
                         .then(event => {
                             if (modelConfig.type === 'pipeline') {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "async": "^3.2.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.6.0",
-    "dayjs": "^1.11.3",
+    "dayjs": "^1.11.4",
     "deepcopy": "^2.0.0",
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Context

POST /events is failing with 500 Validation error.

## Objective

This PR refactors syncStages to avoid making more calls to the DB/git than necessary if we do not need to.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
