### PR TITLE
fix(2740): Pull Request sync shows PRs not relevant to the pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -594,13 +594,18 @@ class PipelineModel extends BaseModel {
         const prJobsForOpenPrs = await this.pullRequestJobs;
         const prJobs = prJobsForOpenPrs.filter(j => j.name.startsWith(`PR-${prNum}:`));
         const { workflowGraph } = parsedConfig;
+        let nextJobNames = [];
 
         // Get next jobs for when startFrom is ~pr
-        let nextJobNames = workflowParser.getNextJobs(workflowGraph, {
-            trigger: '~pr',
-            prNum,
-            chainPR: this.chainPR
-        });
+        if (branch === this.scmRepo.branch) {
+            nextJobNames = nextJobNames.concat(
+                workflowParser.getNextJobs(workflowGraph, {
+                    trigger: '~pr',
+                    prNum,
+                    chainPR: this.chainPR
+                })
+            );
+        }
 
         // Get next jobs for when startFrom is ~pr:branchName
         nextJobNames = nextJobNames.concat(

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1263,7 +1263,7 @@ describe('Pipeline Model', () => {
             };
             datastore.update.resolves(null);
             scmMock.getFile.resolves(SCM_CONTEXT_GITHUB);
-            scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge', baseBranch: 'testBranch' });
+            scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge', baseBranch: 'branch' });
             scmMock.getReadOnlyInfo
                 .withArgs({ scmContext: SCM_CONTEXT_GITLAB })
                 .returns({ enabled: true, username: 'sd-buildbot', accessToken: 'tokenRO' });
@@ -1311,7 +1311,7 @@ describe('Pipeline Model', () => {
             return pipeline.syncPR(1).then(() => {
                 assert.calledWith(scmMock.getFile, expectedGetFile);
                 assert.calledOnce(prJob.update);
-                assert.calledThrice(jobFactoryMock.create);
+                assert.calledTwice(jobFactoryMock.create);
                 assert.calledWith(jobFactoryMock.create.firstCall, {
                     name: 'PR-1:test',
                     permutations: [
@@ -1329,13 +1329,6 @@ describe('Pipeline Model', () => {
                     sinon.match({
                         pipelineId: testId,
                         name: 'PR-1:new_pr_job'
-                    })
-                );
-                assert.calledWith(
-                    jobFactoryMock.create.thirdCall,
-                    sinon.match({
-                        pipelineId: testId,
-                        name: 'PR-1:pr_specific_branch'
                     })
                 );
                 assert.deepEqual(prJob.permutations, clonedYAML.jobs.main);
@@ -1432,7 +1425,7 @@ describe('Pipeline Model', () => {
                     }
                 });
                 assert.calledOnce(prJob.update);
-                assert.callCount(jobFactoryMock.create, 4);
+                assert.callCount(jobFactoryMock.create, 3);
                 assert.calledWith(jobFactoryMock.create.firstCall, {
                     name: 'PR-1:test',
                     permutations: [
@@ -1460,7 +1453,7 @@ describe('Pipeline Model', () => {
                     })
                 );
                 assert.calledWith(
-                    jobFactoryMock.create.lastCall,
+                    jobFactoryMock.create.thirdCall,
                     sinon.match({
                         name: 'PR-1:publish',
                         permutations: [
@@ -1513,6 +1506,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.getPullRequestJobsForPipelineSync.resolves(prJobs); // pull request jobs
 
             scmMock.getOpenedPRs.resolves([{ name: 'PR-1', ref: 'abc' }]);
+            scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge', baseBranch: 'testBranch' });
             parserMock.withArgs(parserConfig).resolves(clonedYAML);
 
             return pipeline.syncPR(1).then(() => {
@@ -1637,7 +1631,7 @@ describe('Pipeline Model', () => {
                 .withArgs({ scmContext: SCM_CONTEXT_GITLAB })
                 .returns({ enabled: true, username: 'sd-buildbot', accessToken: 'tokenRO' });
             parserMock.withArgs(parserConfig).resolves(PARSED_YAML);
-            scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge', baseBranch: 'testBranch' });
+            scmMock.getPrInfo.resolves({ ref: 'pulls/1/merge', baseBranch: 'branch' });
             getUserPermissionMocks({ username: 'batman', push: true });
             getUserPermissionMocks({ username: 'robin', push: true });
             pipeline.admins = { batman: true, robin: true };


### PR DESCRIPTION
## Context

Pull request sync creates jobs/events for pull requests that are made against a branch that is neither pipeline's branch nor allowed via [branch filtering](https://docs.screwdriver.cd/user-guide/configuration/workflow#branch-filtering).

## Objective
This PR only consider the pull requests that are either made against pipeline's branch or specific branches that are allowed via [branch filtering](https://docs.screwdriver.cd/user-guide/configuration/workflow#branch-filtering).

## References

https://github.com/screwdriver-cd/screwdriver/issues/2740

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
