### PR TITLE
fix: bump up data-schema to 21.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.5.5",
-    "screwdriver-data-schema": "^21.26.0",
+    "screwdriver-data-schema": "^21.28.1",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }


### PR DESCRIPTION
## Context

As per PR:https://github.com/screwdriver-cd/data-schema/pull/503 release data-schema to be 21.28.1 bump up .

## Objective


## References


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
