### PR TITLE
fix: bump up data schema to 21.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.5.5",
-    "screwdriver-data-schema": "^21.23.1",
+    "screwdriver-data-schema": "^21.28.2",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }


### PR DESCRIPTION
## Context
PR:https://github.com/screwdriver-cd/data-schema/pull/504  release data-schema to be 21.28.2 bump up

## Objective

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
