### PR TITLE
feat: add reset in user settings

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -124,6 +124,16 @@ class UserModel extends BaseModel {
             return user.settings;
         });
     }
+
+    /**
+     * Remove user settings
+     * @method removeSettings
+     * @return {Promise}
+     */
+     removeSettings(){
+
+        return super.remove();
+    }
 }
 
 module.exports = UserModel;

--- a/lib/user.js
+++ b/lib/user.js
@@ -130,9 +130,12 @@ class UserModel extends BaseModel {
      * @method removeSettings
      * @return {Promise}
      */
-     removeSettings(){
+    removeSettings() {
+        this.settings = {};
 
-        return super.remove();
+        return super.update().then(user => {
+            return user.settings;
+        });
     }
 }
 

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -242,6 +242,20 @@ describe('User Model', () => {
         });
     });
 
+    describe('removeSettings', () => {
+        beforeEach(() => {
+            user.settings = {};
+        });
+
+        it('Remove user settings', () => {
+            datastore.update.resolves({});
+
+            return user.removeSettings(settings).then(data => {
+                assert.deepEqual(data, {});
+            });
+        });
+    });
+
     describe('get tokens', () => {
         it('has a tokens getter', () => {
             const listConfig = {

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -244,7 +244,15 @@ describe('User Model', () => {
 
     describe('removeSettings', () => {
         beforeEach(() => {
-            user.settings = {};
+            user.settings = {
+                1: {
+                    showPRJobs: true
+                },
+                11: {
+                    showPRJobs: false
+                },
+                displayJobNameLength: 25
+            };
         });
 
         it('Remove user settings', () => {

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -258,7 +258,7 @@ describe('User Model', () => {
         it('Remove user settings', () => {
             datastore.update.resolves({});
 
-            return user.removeSettings(settings).then(data => {
+            return user.removeSettings().then(data => {
                 assert.deepEqual(data, {});
             });
         });


### PR DESCRIPTION
## Context

add a feature to reset in user settings.

## Objective

User can reset his details in user settings.

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
