### PR TITLE
fix(2669): Add more logs to stage creation

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -493,6 +493,10 @@ async function createStages({ pipeline, groupEventId }) {
 
     // Stages already exist, skip stage creation
     if (records.length !== 0) {
+        logger.info(
+            `Stages with pipelineId:${pipelineId} and groupEventId:${groupEventId} already exist, skipping stage creation.`
+        );
+
         return Promise.resolve();
     }
 
@@ -500,8 +504,10 @@ async function createStages({ pipeline, groupEventId }) {
     const parsedYaml = await pipeline.getConfiguration({});
     const stages = parsedYaml.stages || {};
 
-    // No new stages in yaml
+    // No stages in yaml, skip creation
     if (Object.keys(stages).length === 0) {
+        logger.info(`No stages for pipelineId:${pipelineId}, skipping stage creation.`);
+
         return Promise.resolve();
     }
 
@@ -510,6 +516,7 @@ async function createStages({ pipeline, groupEventId }) {
 
     // Create new stages
     newStages.forEach(stage => {
+        logger.info(`Stage:${JSON.stringify(stage)}`);
         processed.push(stageFactory.create(stage));
     });
 


### PR DESCRIPTION
## Context

Stage creation is failing in open source after the first groupEvent is created with ` Validation error`.

## Objective

This PR adds more logs around stage creation to help debug.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
