### PR TITLE
fix(2669): Pull in latest data-schema removing old stage unique constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "async": "^3.2.2",
     "base64url": "^3.0.1",
     "compare-versions": "^3.6.0",
-    "dayjs": "^1.11.4",
+    "dayjs": "^1.11.5",
     "deepcopy": "^2.0.0",
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
     "screwdriver-config-parser": "^7.5.5",
-    "screwdriver-data-schema": "^21.28.2",
+    "screwdriver-data-schema": "^21.28.3",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"
   }


### PR DESCRIPTION
## Context

After changing the stages schema, a new unique constraint was added: https://github.com/screwdriver-cd/data-schema/blob/master/migrations/20220705-upd-stage-color-eventId-createTime.js#L27, https://github.com/screwdriver-cd/data-schema/blob/master/models/stage.js#L71

So we no longer need the old unique constraint: https://github.com/screwdriver-cd/data-schema/blob/master/migrations/20220607-initdb-stages.js#L43

## Objective

This PR pulls in latest data-schema with migration file that removes the old unique constraint through a migration file.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
