### PR TITLE
fix: remove event.creator metadata

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -961,10 +961,6 @@ class EventFactory extends BaseFactory {
                                 modelConfig.meta.parameters = updatedParameters;
                             }
 
-                            if (modelConfig.creator) {
-                                modelConfig.meta.event = { creator: modelConfig.creator.username };
-                            }
-
                             if (!config.meta) {
                                 config.meta = modelConfig.meta;
                             }

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -228,7 +228,7 @@ describe('Event Factory', () => {
                 createTime: nowTime,
                 creator,
                 commit,
-                meta: { event: { creator: 'stjohn' } }
+                meta: {}
             };
 
             syncedPipelineMock = {
@@ -1741,7 +1741,6 @@ describe('Event Factory', () => {
 
             config.creator = creatorTest;
             expected.creator = creatorTest;
-            expected.meta.event.creator = creatorTest.username;
 
             return eventFactory.create(config).then(model => {
                 assert.instanceOf(model, Event);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The metadata `event.creator` will be set in launcher by [this PR](https://github.com/screwdriver-cd/launcher/pull/443).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Revert the following PR:
- https://github.com/screwdriver-cd/models/pull/532
- https://github.com/screwdriver-cd/models/pull/533

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- https://github.com/screwdriver-cd/launcher/pull/443

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
