### PR TITLE
fix(2669): Do not allow empty array for stage jobIds [2]

### DIFF
--- a/lib/stageFactory.js
+++ b/lib/stageFactory.js
@@ -36,10 +36,6 @@ class StageFactory extends BaseFactory {
      * @memberof StageFactory
      */
     create(config) {
-        if (!config.jobIds) {
-            config.jobIds = [];
-        }
-
         return super.create(config);
     }
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.20",
-    "screwdriver-config-parser": "^7.5.5",
+    "screwdriver-config-parser": "^7.6.1",
     "screwdriver-data-schema": "^21.28.3",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-workflow-parser": "^3.2.0"

--- a/test/lib/stageFactory.test.js
+++ b/test/lib/stageFactory.test.js
@@ -89,23 +89,6 @@ describe('Stage Factory', () => {
                     });
                 });
         });
-
-        it('creates a Stage given pipelineId and name', () => {
-            expected.jobIds = [];
-            datastore.save.resolves(expected);
-
-            return factory
-                .create({
-                    pipelineId,
-                    name
-                })
-                .then(model => {
-                    assert.instanceOf(model, Stage);
-                    Object.keys(expected).forEach(key => {
-                        assert.deepEqual(model[key], expected[key]);
-                    });
-                });
-        });
     });
 
     describe('getInstance', () => {


### PR DESCRIPTION
## Context

Should not allow empty jobs list for stage definitions.

## Objective

This PR removes empty array initialization for stage jobIds.
 
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
