### PR TITLE
[2] feat(2763): call get setup/teardown command method of bookend plugin with cluster name

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -251,8 +251,8 @@ class BuildFactory extends BaseFactory {
                     }
 
                     const [setup, teardown] = await Promise.all([
-                        this.bookend.getSetupCommands(bookendConfig),
-                        this.bookend.getTeardownCommands(bookendConfig)
+                        this.bookend.getSetupCommands(bookendConfig, buildClusterName),
+                        this.bookend.getTeardownCommands(bookendConfig, buildClusterName)
                     ]);
 
                     modelConfig.createTime = new Date(number).toISOString();


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Different bookends can be executed on different build cluster.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR supports the following PR change.

https://github.com/screwdriver-cd/build-bookend/pull/18

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2763#:~:text=js%23L112%2DL151-,buildFactory,-When%20executing%20getSetupCommands

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
