### PR TITLE
feat(2862): Template metrics - Support date/time filter while fetching build count

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -236,10 +236,14 @@ class TemplateFactory extends BaseFactory {
      * @param  {Object}   config.paginate         Pagination parameters
      * @param  {Number}   config.paginate.count   Number of items per page
      * @param  {Number}   config.paginate.page    Specific page of the set to return
+     * @param  {Number}   config.startTime        (Optional) Count only the builds that got started on or after startTime
+     * @param  {Number}   config.endTime          (Optional) Count only the builds that got ended on or before endTime
      * @return {Promise}
      */
     listWithMetrics(config) {
-        return this.list(config).then(templates => {
+        const { startTime, endTime, ...templateListConfig } = config;
+
+        return this.list(templateListConfig).then(templates => {
             if (templates.length === 0) {
                 return templates;
             }
@@ -254,29 +258,39 @@ class TemplateFactory extends BaseFactory {
 
             const templateIds = templates.map(t => t.id);
 
-            const listConfig = {
+            const metricJobsListConfig = {
                 params: { templateId: templateIds },
                 readOnly: true,
                 aggregationField: 'templateId'
             };
 
-            return Promise.all([jobFactory.list(listConfig), buildFactory.list(listConfig)]).then(([jCount, bCount]) =>
-                templates.map(t => {
-                    const jobCount = jCount.find(j => j.templateId === t.id);
+            const metricBuildsListConfig = { ...metricJobsListConfig };
 
-                    const buildCount = bCount.find(b => b.templateId === t.id);
+            if (startTime) {
+                metricBuildsListConfig.startTime = startTime;
+            }
+            if (endTime) {
+                metricBuildsListConfig.endTime = endTime;
+            }
 
-                    t.metrics = {
-                        jobs: {
-                            count: jobCount ? jobCount.count : 0
-                        },
-                        builds: {
-                            count: buildCount ? buildCount.count : 0
-                        }
-                    };
+            return Promise.all([jobFactory.list(metricJobsListConfig), buildFactory.list(metricBuildsListConfig)]).then(
+                ([jCount, bCount]) =>
+                    templates.map(t => {
+                        const jobCount = jCount.find(j => j.templateId === t.id);
 
-                    return t;
-                })
+                        const buildCount = bCount.find(b => b.templateId === t.id);
+
+                        t.metrics = {
+                            jobs: {
+                                count: jobCount ? jobCount.count : 0
+                            },
+                            builds: {
+                                count: buildCount ? buildCount.count : 0
+                            }
+                        };
+
+                        return t;
+                    })
             );
         });
     }

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -236,8 +236,8 @@ class TemplateFactory extends BaseFactory {
      * @param  {Object}   config.paginate         Pagination parameters
      * @param  {Number}   config.paginate.count   Number of items per page
      * @param  {Number}   config.paginate.page    Specific page of the set to return
-     * @param  {Number}   config.startTime        (Optional) Count only the builds that got started on or after startTime
-     * @param  {Number}   config.endTime          (Optional) Count only the builds that got ended on or before endTime
+     * @param  {Number}   [config.startTime]      Count only the builds that got started on or after startTime
+     * @param  {Number}   [config.endTime]        Count only the builds that got ended on or before endTime
      * @return {Promise}
      */
     listWithMetrics(config) {

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -1122,6 +1122,131 @@ describe('Template Factory', () => {
                 assert.deepEqual(templates[0].metrics.builds.count, expected[0].metrics.builds.count);
             });
         });
+
+        describe('should list templates with metrics when startTime/endTime are passed in', () => {
+            const startTime = '2023-04-01T14:08';
+            const endTime = '2023-04-30T14:08';
+
+            beforeEach(() => {
+                expected = [returnValue[0], returnValue[1]];
+                datastore.scan.resolves(expected);
+                buildFactoryMock.list.resolves(buildsCount);
+                jobFactoryMock.list.resolves(jobsCount);
+            });
+
+            it('should list templates with metrics when both startTime and endTime are passed in', () => {
+                config.startTime = startTime;
+                config.endTime = endTime;
+
+                return factory.listWithMetrics(config).then(templates => {
+                    let i = 0;
+
+                    templates.forEach(t => {
+                        assert.deepEqual(t.id, expected[i].id);
+                        assert.deepEqual(t.metrics.jobs.count, expected[i].metrics.jobs.count);
+                        assert.deepEqual(t.metrics.builds.count, expected[i].metrics.builds.count);
+                        i += 1;
+                    });
+
+                    assert.calledWith(datastore.scan, {
+                        table: 'templates',
+                        params: {
+                            name,
+                            namespace,
+                            version: '1.0.2'
+                        }
+                    });
+
+                    assert.calledWith(jobFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        readOnly: true,
+                        aggregationField: 'templateId'
+                    });
+
+                    assert.calledWith(buildFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        readOnly: true,
+                        aggregationField: 'templateId',
+                        startTime,
+                        endTime
+                    });
+                });
+            });
+
+            it('should list templates with metrics when only startTime is passed in', () => {
+                config.startTime = startTime;
+
+                return factory.listWithMetrics(config).then(templates => {
+                    let i = 0;
+
+                    templates.forEach(t => {
+                        assert.deepEqual(t.id, expected[i].id);
+                        assert.deepEqual(t.metrics.jobs.count, expected[i].metrics.jobs.count);
+                        assert.deepEqual(t.metrics.builds.count, expected[i].metrics.builds.count);
+                        i += 1;
+                    });
+
+                    assert.calledWith(datastore.scan, {
+                        table: 'templates',
+                        params: {
+                            name,
+                            namespace,
+                            version: '1.0.2'
+                        }
+                    });
+
+                    assert.calledWith(jobFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        readOnly: true,
+                        aggregationField: 'templateId'
+                    });
+
+                    assert.calledWith(buildFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        readOnly: true,
+                        aggregationField: 'templateId',
+                        startTime
+                    });
+                });
+            });
+
+            it('should list templates with metrics when only endTime is passed in', () => {
+                config.endTime = endTime;
+
+                return factory.listWithMetrics(config).then(templates => {
+                    let i = 0;
+
+                    templates.forEach(t => {
+                        assert.deepEqual(t.id, expected[i].id);
+                        assert.deepEqual(t.metrics.jobs.count, expected[i].metrics.jobs.count);
+                        assert.deepEqual(t.metrics.builds.count, expected[i].metrics.builds.count);
+                        i += 1;
+                    });
+
+                    assert.calledWith(datastore.scan, {
+                        table: 'templates',
+                        params: {
+                            name,
+                            namespace,
+                            version: '1.0.2'
+                        }
+                    });
+
+                    assert.calledWith(jobFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        readOnly: true,
+                        aggregationField: 'templateId'
+                    });
+
+                    assert.calledWith(buildFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        readOnly: true,
+                        aggregationField: 'templateId',
+                        endTime
+                    });
+                });
+            });
+        });
     });
 
     describe('getTemplate', () => {


### PR DESCRIPTION
## Context

The API to fetch all the versions of a template along with their usage metrics, returns all time usage by builds for each version.
We need ability to compute build usage metric for each version within a specified date/time interval

## Objective

Enhance the API to support an optional date/time filter while computing usage by builds for each version.
Related PR: https://github.com/screwdriver-cd/screwdriver/pull/2865

## References

https://github.com/screwdriver-cd/screwdriver/issues/2862

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
