### PR TITLE
fix(2817): jobDisabledByDefault in the case of PR job

### DIFF
--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -59,7 +59,7 @@ class JobFactory extends BaseFactory {
             getAnnotations(c.permutations[0], 'screwdriver.cd/jobDisabledByDefault')
         );
 
-        c.state = (jobDisabledByDefault === true && !/^PR-/.test(c.name)) ? 'DISABLED' : 'ENABLED';
+        c.state = jobDisabledByDefault === true && !/^PR-/.test(c.name) ? 'DISABLED' : 'ENABLED';
         c.archived = false;
 
         // eslint-disable-next-line global-require

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -59,7 +59,7 @@ class JobFactory extends BaseFactory {
             getAnnotations(c.permutations[0], 'screwdriver.cd/jobDisabledByDefault')
         );
 
-        c.state = jobDisabledByDefault === true ? 'DISABLED' : 'ENABLED';
+        c.state = (jobDisabledByDefault === true && !/^PR-/.test(c.name)) ? 'DISABLED' : 'ENABLED';
         c.archived = false;
 
         // eslint-disable-next-line global-require

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -184,6 +184,51 @@ describe('Job Factory', () => {
                 });
         });
 
+        it('creates a new DISABLED job in the datastore', () => {
+            const permutationsWithAnnotation = [
+                {
+                    commands: [
+                        { command: 'npm install', name: 'init' },
+                        { command: 'npm test', name: 'test' }
+                    ],
+                    image: 'node:4',
+                    annotations: {
+                        'screwdriver.cd/jobDisabledByDefault': 'true'
+                    }
+                }
+            ];
+            const expected = {
+                name: 'PR-1:main',
+                pipelineId,
+                state: 'ENABLED',
+                archived: false,
+                id: jobId,
+                permutations: permutationsWithAnnotation
+            };
+
+            datastore.save.resolves(expected);
+
+            return factory
+                .create({
+                    pipelineId,
+                    name: 'PR-1:main',
+                    permutations: permutationsWithAnnotation
+                })
+                .then(model => {
+                    assert.calledWith(datastore.save, {
+                        table: 'jobs',
+                        params: {
+                            name: 'PR-1:main',
+                            pipelineId,
+                            state: 'ENABLED',
+                            archived: false,
+                            permutations: permutationsWithAnnotation
+                        }
+                    });
+                    assert.instanceOf(model, Job);
+                });
+        });
+
         it('calls executor to create a periodic job', () => {
             const tokenGenFunc = () => 'bar';
             const periodicPermutations = [

--- a/test/lib/jobFactory.test.js
+++ b/test/lib/jobFactory.test.js
@@ -184,7 +184,7 @@ describe('Job Factory', () => {
                 });
         });
 
-        it('creates a new DISABLED job in the datastore', () => {
+        it('creates a new ENABLED job in the datastore', () => {
             const permutationsWithAnnotation = [
                 {
                     commands: [


### PR DESCRIPTION
## Context
If `jobDisabledByDefault` is `true`, the PR job does not run , even if the job is set to `ENABLED` in the UI. This is because the status of the PR job itself does not change with `DISABLED`, and the builds stop [here](https://github.com/screwdriver-cd/queue-service/blob/698204ff8edd9e446a1550acaff1b2c1175f70ba/plugins/queue/scheduler.js#L312-L314) in queue-service.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
The status of PR job is set `ENABLED` even if `jobDisabledByDefault` is `true`.
If the original job is `DISABLED`, the PR job will not run regardless of its own status, so this change is OK.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2817
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
