### PR TITLE
feat: build cluster grouping

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -211,6 +211,7 @@ class BuildFactory extends BaseFactory {
                     if (hoek.reach(permutation, 'provider')) {
                         provider = permutation.provider;
                     }
+
                     const buildClusterName = await helper.getBuildClusterName({
                         annotations,
                         pipeline,

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -140,6 +140,34 @@ function getRandomCluster(clusters) {
 }
 
 /**
+ * List all build clusters and return them by group
+ */
+async function listBuildClustersByGroup() {
+    // Lazy load factory dependency to prevent circular dependency issues
+    // https://nodejs.org/api/modules.html#modules_cycles
+    // eslint-disable-next-line global-require
+    const BuildClusterFactory = require('./buildClusterFactory');
+    const buildClusterFactory = BuildClusterFactory.getInstance();
+
+    const allBuildClusters = await buildClusterFactory.list();
+
+    const allBuildClustersByGroup = allBuildClusters.reduce((acc, c) => {
+        const group = c.group || DEFAULT_KEY;
+
+        acc[group] = acc[group] || [];
+        acc[group].push(c);
+
+        return acc;
+    }, Object.create({}));
+
+    if (!allBuildClustersByGroup.default) {
+        allBuildClustersByGroup.default = [];
+    }
+
+    return allBuildClustersByGroup;
+}
+
+/**
  * Get managed build cluster name based on annotations
  * @method getManagedBuildClusterName
  * @param  {Object}             config
@@ -149,6 +177,8 @@ function getRandomCluster(clusters) {
  * @return {String}             Build cluster name
  */
 async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpdate }) {
+    const allBuildClustersByGroup = await listBuildClustersByGroup();
+
     const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
     const pipelineAnnotations = hoek.reach(pipeline, 'annotations', { default: {} });
     let buildClusterName;
@@ -161,21 +191,18 @@ async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpd
         buildClusterName = pipelineAnnotations[buildClusterAnnotation] || '';
     }
 
-    // Lazy load factory dependency to prevent circular dependency issues
-    // https://nodejs.org/api/modules.html#modules_cycles
-    // eslint-disable-next-line global-require
-    const BuildClusterFactory = require('./buildClusterFactory');
-    const buildClusterFactory = BuildClusterFactory.getInstance();
-    const allBuildClusters = await buildClusterFactory.list();
+    let groupName = buildClusterName ? buildClusterName.split('.')[0] : DEFAULT_KEY;
+
+    let allBuildClusters = allBuildClustersByGroup[groupName];
+
+    if (!allBuildClusters) {
+        allBuildClusters = allBuildClustersByGroup.default;
+        groupName = DEFAULT_KEY;
+    }
+
     const activeManagedBuildClusters = allBuildClusters.filter(
         cluster =>
             cluster.managedByScrewdriver === true &&
-            cluster.isActive === true &&
-            cluster.scmContext === pipeline.scmContext
-    );
-    const activeExternalBuildClusters = allBuildClusters.filter(
-        cluster =>
-            cluster.managedByScrewdriver === false &&
             cluster.isActive === true &&
             cluster.scmContext === pipeline.scmContext
     );
@@ -188,19 +215,17 @@ async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpd
         return getRandomCluster(activeManagedBuildClusters);
     }
 
-    let buildCluster = allBuildClusters.filter(
+    const buildCluster = allBuildClusters.find(
         cluster => cluster.name === buildClusterName && cluster.scmContext === pipeline.scmContext
     );
 
-    if (buildCluster.length === 0) {
-        // eslint-disable-next-line max-len
+    if (!buildCluster) {
         throw new Error(
             `Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} ` +
-                `for scmContext ${pipeline.scmContext} does not exist.`
+                `for scmContext ${pipeline.scmContext} and group ${groupName} does not exist.`
         );
     }
 
-    buildCluster = buildCluster[0];
     // Check if this pipeline's org is authorized to use the build cluster
     // pipeline name example: screwdriver-cd/ui
     const regex = /^([^/]+)\/.*/;
@@ -220,6 +245,13 @@ async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpd
         }
 
         if (!buildCluster.managedByScrewdriver) {
+            const activeExternalBuildClusters = allBuildClusters.filter(
+                cluster =>
+                    cluster.managedByScrewdriver === false &&
+                    cluster.isActive === true &&
+                    cluster.scmContext === pipeline.scmContext
+            );
+
             return getRandomCluster(activeExternalBuildClusters);
         }
     }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2696,7 +2696,7 @@ describe('Pipeline Model', () => {
                 assert.strictEqual(
                     err.message,
                     'Cluster specified in screwdriver.cd/buildCluster iOS ' +
-                        `for scmContext ${pipeline.scmContext} does not exist.`
+                        `for scmContext ${pipeline.scmContext} and group default does not exist.`
                 );
             });
         });


### PR DESCRIPTION
## Context

Group Build Cluster based on a group name like `aws` or `on-prem` or `gcp` and select cluster name from the  specified group
 
## Objective

This PR updates build cluster selection logic based on the group the build cluster belongs to and select default if no group is found.

## References

[<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->](https://github.com/screwdriver-cd/data-schema/pull/516)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
