### PR TITLE
fix: always check scmOrganizations unless it's empty

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -180,7 +180,7 @@ function hasClusterAccess(pipelineName, buildCluster) {
     if (buildCluster.scmOrganizations && buildCluster.scmOrganizations.length > 0) {
         const matched = pipelineName.match(SCM_ORG_REGEX);
         const org = matched ? matched[1] : '';
-    
+
         return buildCluster.scmOrganizations.includes(org);
     }
 
@@ -271,10 +271,7 @@ async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpd
         );
     }
 
-    if (
-        buildCluster.scmContext !== pipeline.scmContext ||
-        !hasClusterAccess(pipeline.name, buildCluster))
-    ) {
+    if (buildCluster.scmContext !== pipeline.scmContext || !hasClusterAccess(pipeline.name, buildCluster)) {
         throw new Error('This pipeline is not authorized to use this build cluster.');
     }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -177,10 +177,14 @@ async function listBuildClustersByGroup() {
 function hasClusterAccess(pipelineName, buildCluster) {
     // Check if this pipeline's org is authorized to use the build cluster
     // pipeline name example: screwdriver-cd/ui
-    const matched = pipelineName.match(SCM_ORG_REGEX);
-    const org = matched ? matched[1] : '';
+    if (buildCluster.scmOrganizations && buildCluster.scmOrganizations.length > 0) {
+        const matched = pipelineName.match(SCM_ORG_REGEX);
+        const org = matched ? matched[1] : '';
+    
+        return buildCluster.scmOrganizations.includes(org);
+    }
 
-    return buildCluster.scmOrganizations.includes(org);
+    return true;
 }
 
 /**
@@ -269,7 +273,7 @@ async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpd
 
     if (
         buildCluster.scmContext !== pipeline.scmContext ||
-        (buildCluster.managedByScrewdriver === false && !hasClusterAccess(pipeline.name, buildCluster))
+        !hasClusterAccess(pipeline.name, buildCluster))
     ) {
         throw new Error('This pipeline is not authorized to use this build cluster.');
     }

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -813,7 +813,7 @@ describe('Build Factory', () => {
             const user = { unsealToken: sinon.stub().resolves('foo') };
             const jobMock = {
                 permutations: permutations3,
-                pipeline: Promise.resolve({ name: 'screwdriver/ui', scmUri, scmRepo, scmContext })
+                pipeline: Promise.resolve({ name: 'screwdriver-cd/ui', scmUri, scmRepo, scmContext })
             };
 
             const sdBuildClustersCopy = sdBuildClusters.slice();


### PR DESCRIPTION
always check the pipeline scm org with build cluster's scmOrganizations as long as it's not empty