### PR TITLE
fix: Remove stage create from event creation

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -413,111 +413,6 @@ function createBuilds(config) {
 }
 
 /**
- * Converts the simplified stages into a more consistent format
- *
- * This is because the user can provide the stage information as:
- *  - {"name": { "jobs": ["job1", "job2", "job3"], "description": "Description" },
- *     { "name2": { "jobs": ["job4", "job5"] } }
- *
- * We will convert it to a more standard format:
- *  - [{ "name": "name", "jobs": [1, 2, 3], "pipelineId": 123, "groupEventId": 555, "description": "value" },
- *     { "name": "name2", "jobs": [4, 5], "pipelineId": 123, "groupEventId": 555 }]
- * @method convertStages
- * @param  {Object}     config              config
- * @param  {Number}     config.groupEventId Group event ID
- * @param  {Object}     config.pipeline     Pipeline
- * @param  {Object}     config.stages       Pipeline stages
- * @return {Array}                New array with stages after up-converting
- */
-async function convertStages(config) {
-    const { pipeline, stages, groupEventId } = config;
-    const pipelineJobs = await pipeline.pipelineJobs;
-    const newStages = [];
-
-    // Convert stages from object to array of objects
-    Object.entries(stages).forEach(([key, value]) => {
-        const newStage = {
-            name: key,
-            pipelineId: pipeline.id,
-            groupEventId,
-            ...value
-        };
-        const jobIds = [];
-
-        // Convert the jobNames to jobIds
-        value.jobs.forEach(jobName => {
-            const job = pipelineJobs.find(j => j.name === jobName);
-
-            if (job) {
-                jobIds.push(job.id);
-            }
-        });
-
-        newStage.jobIds = jobIds;
-        delete newStage.jobs; // extra field from yaml parser
-
-        newStages.push(newStage);
-    });
-
-    return newStages;
-}
-
-/**
- * Sync stages
- * 1. Convert new stages into correct format, prepopulate with jobIds
- * 2. Create the stages if it is defined and was not in the database yet
- * @method createStages
- * @param  {Object}     config              config
- * @param  {Number}     config.groupEventId Group event ID
- * @param  {Object}     config.pipeline     Pipeline
- * @return {Promise}
- */
-async function createStages({ pipeline, groupEventId }) {
-    // Lazy load factory dependency to prevent circular dependency issues
-    // https://nodejs.org/api/modules.html#modules_cycles
-    /* eslint-disable global-require */
-    const StageFactory = require('./stageFactory');
-    /* eslint-enable global-require */
-
-    const stageFactory = StageFactory.getInstance();
-    const { id: pipelineId } = pipeline;
-
-    // list records that would trigger this job
-    const records = await stageFactory.list({ params: { pipelineId, groupEventId } });
-
-    // Stages already exist, skip stage creation
-    if (records.length !== 0) {
-        logger.info(
-            `Stages with pipelineId:${pipelineId} and groupEventId:${groupEventId} already exist, skipping stage creation.`
-        );
-
-        return Promise.resolve();
-    }
-
-    // Get new stages
-    const parsedYaml = await pipeline.getConfiguration({});
-    const stages = parsedYaml.stages || {};
-
-    // No stages in yaml, skip creation
-    if (Object.keys(stages).length === 0) {
-        logger.info(`No stages for pipelineId:${pipelineId}, skipping stage creation.`);
-
-        return Promise.resolve();
-    }
-
-    const newStages = await convertStages({ pipeline, stages, groupEventId });
-    const processed = [];
-
-    // Create new stages
-    newStages.forEach(stage => {
-        logger.info(`Stage:${JSON.stringify(stage)}`);
-        processed.push(stageFactory.create(stage));
-    });
-
-    return Promise.all(processed);
-}
-
-/**
  * Get the latest workflowGraph
  * @method getLatestWorkflowGraph
  * @param  {Object}         config
@@ -969,10 +864,6 @@ class EventFactory extends BaseFactory {
                             }
 
                             return Promise.resolve(event);
-                        })
-                        .then(event => {
-                            // Create pipeline stages if they don't exist
-                            return createStages({ pipeline, groupEventId: event.groupEventId }).then(() => event);
                         })
                         .then(event => {
                             if (modelConfig.type === 'pipeline') {

--- a/lib/generateToken.js
+++ b/lib/generateToken.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const base64url = require('base64url');
 const crypto = require('crypto');
+const base64url = require('base64url');
 const nodeify = require('./nodeify');
 
 // Config for pbkdf2

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -9,7 +9,6 @@ class StageModel extends BaseModel {
      * @param  {Object}    config
      * @param  {Object}    config.datastore     Object that will perform operations on the datastore
      * @param  {String}    [config.description] Stage description
-     * @param  {Number}    config.groupEventId  Group event ID
      * @param  {Array}     [config.jobIds=[]]   Job Ids that belong to this stage
      * @param  {String}    config.name          Name of the stage
      * @param  {Number}    config.pipelineId    Pipeline the stage belongs to

--- a/lib/stageFactory.js
+++ b/lib/stageFactory.js
@@ -29,7 +29,6 @@ class StageFactory extends BaseFactory {
      * Create a Stage model
      * @param {Object}      config
      * @param {String}      [config.description] Stage description
-     * @param {Number}      config.groupEventId  Group event Id for stage
      * @param {Array}       [config.jobIds=[]]   Job Ids that belong to this stage
      * @param {String}      config.name          Name of the stage
      * @param {String}      config.pipelineId    Pipeline the stage belongs to

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const { assert } = require('chai');
 const mockery = require('mockery');
 const sinon = require('sinon');
@@ -7,8 +9,6 @@ const hoek = require('@hapi/hoek');
 const schema = require('screwdriver-data-schema');
 const rewire = require('rewire');
 const dayjs = require('dayjs');
-const fs = require('fs');
-const path = require('path');
 
 sinon.assert.expose(assert, { prefix: '' });
 const YAML_WITH_PROVIDER_FILE_PATH = '../data/yamlWithProviderPath.yaml';


### PR DESCRIPTION
## Context

API pipeline is failing with error 
```
19:02:27    ✖ When the "main" job is started # features/step_definitions/secrets.js:50
19:02:27        Error: 500 Reason "Invalid param "groupEventId""
19:02:27            at throwError (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:14:17)
19:02:27            at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:62:28
19:02:27            at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
https://cd.screwdriver.cd/pipelines/1/builds/888951/steps/test

## Objective

This PR temporarily removes stage create from event creation to fix the tests. It is also covered in another PR (https://github.com/screwdriver-cd/models/pull/570).

## References

Related to https://github.com/screwdriver-cd/data-schema/pull/524

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
