### PR TITLE
fix(2862): Set templateType filter while fetching template tag from DB

### DIFF
--- a/lib/templateTagFactory.js
+++ b/lib/templateTagFactory.js
@@ -58,7 +58,8 @@ class TemplateTagFactory extends BaseFactory {
                 .list({
                     params: {
                         namespace: 'default',
-                        name: parsedTemplate.name
+                        name: parsedTemplate.name,
+                        templateType: this.getTemplateType()
                     }
                 })
                 .then(namespaceExists => {
@@ -77,7 +78,8 @@ class TemplateTagFactory extends BaseFactory {
             .list({
                 params: {
                     namespace,
-                    name
+                    name,
+                    templateType: this.getTemplateType()
                 }
             })
             .then(namespaceExists => {
@@ -88,6 +90,16 @@ class TemplateTagFactory extends BaseFactory {
 
                 return parsedTemplate;
             });
+    }
+
+    getTemplateType() {
+        return this._getTemplateType();
+    }
+
+    _getTemplateType() {
+        // Note: To keep it backward compatible, returning 'JOB'.
+        // TODO: After PR screwdriver-cd/models#585 is merged https://github.com/screwdriver-cd/models/pull/585 and the code refactored to use jobTemplateTagFactory, this needs to be updated
+        return 'JOB';
     }
 
     /**
@@ -133,7 +145,12 @@ class TemplateTagFactory extends BaseFactory {
      * @return {Promise}
      */
     list(config) {
-        if (config.params && config.params.name && !config.params.namespace) {
+        if (!config.params) {
+            config.params = {};
+        }
+        config.params.templateType = this.getTemplateType();
+
+        if (config.params.name && !config.params.namespace) {
             // eslint-disable-next-line no-underscore-dangle
             return this._getNameAndNamespace(config.params.name).then(parsedTemplateName => {
                 const { namespace, name } = parsedTemplateName;
@@ -160,6 +177,8 @@ class TemplateTagFactory extends BaseFactory {
      * @return {Promise}
      */
     get(config) {
+        config.templateType = this.getTemplateType();
+
         if (config.name && !config.namespace) {
             // eslint-disable-next-line no-underscore-dangle
             return this._getNameAndNamespace(config.name).then(parsedTemplateName => {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "screwdriver-config-parser": "^8.0.0",
-    "screwdriver-data-schema": "^22.3.0",
+    "screwdriver-data-schema": "^22.6.1",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-workflow-parser": "^4.0.0"
   }

--- a/test/lib/templateTagFactory.test.js
+++ b/test/lib/templateTagFactory.test.js
@@ -217,12 +217,10 @@ describe('TemplateTag Factory', () => {
             expected = { ...expected };
 
             return factory.get(config).then(model => {
-                assert.calledWith(
-                    datastore.get,
-                    sinon.match({
-                        params: { name, namespace: 'default', tag }
-                    })
-                );
+                assert.calledWith(datastore.get, {
+                    table: 'templateTags',
+                    params: { name, namespace: 'default', tag, templateType: 'JOB' }
+                });
                 assert.instanceOf(model, TemplateTag);
                 Object.keys(expected).forEach(key => {
                     assert.strictEqual(model[key], expected[key]);
@@ -237,12 +235,10 @@ describe('TemplateTag Factory', () => {
             config.name = fullTemplateName;
 
             return factory.get(config).then(model => {
-                assert.calledWith(
-                    datastore.get,
-                    sinon.match({
-                        params: { name: fullTemplateName, namespace: null, tag }
-                    })
-                );
+                assert.calledWith(datastore.get, {
+                    table: 'templateTags',
+                    params: { name: fullTemplateName, namespace: null, tag, templateType: 'JOB' }
+                });
                 assert.instanceOf(model, TemplateTag);
                 Object.keys(expected).forEach(key => {
                     assert.strictEqual(model[key], expected[key]);
@@ -257,12 +253,10 @@ describe('TemplateTag Factory', () => {
             config.name = fullTemplateName;
 
             return factory.get(config).then(model => {
-                assert.calledWith(
-                    datastore.get,
-                    sinon.match({
-                        params: { name, namespace, tag }
-                    })
-                );
+                assert.calledWith(datastore.get, {
+                    table: 'templateTags',
+                    params: { name, namespace, tag, templateType: 'JOB' }
+                });
                 assert.instanceOf(model, TemplateTag);
                 Object.keys(expected).forEach(key => {
                     assert.strictEqual(model[key], expected[key]);
@@ -277,12 +271,10 @@ describe('TemplateTag Factory', () => {
             config.namespace = namespace;
 
             return factory.get(config).then(model => {
-                assert.calledWith(
-                    datastore.get,
-                    sinon.match({
-                        params: { name, namespace, tag }
-                    })
-                );
+                assert.calledWith(datastore.get, {
+                    table: 'templateTags',
+                    params: { name, namespace, tag, templateType: 'JOB' }
+                });
                 assert.instanceOf(model, TemplateTag);
                 Object.keys(expected).forEach(key => {
                     assert.strictEqual(model[key], expected[key]);
@@ -318,6 +310,15 @@ describe('TemplateTag Factory', () => {
 
             return factory.list(config).then(model => {
                 assert.instanceOf(model[0], TemplateTag);
+                assert.callCount(datastore.scan, 2);
+                assert.calledWith(datastore.scan.firstCall, {
+                    table: 'templateTags',
+                    params: { name, namespace: 'default', templateType: 'JOB' }
+                });
+                assert.calledWith(datastore.scan.secondCall, {
+                    table: 'templateTags',
+                    params: { name, namespace: 'default', templateType: 'JOB' }
+                });
             });
         });
 
@@ -329,6 +330,16 @@ describe('TemplateTag Factory', () => {
 
             return factory.list(config).then(model => {
                 assert.instanceOf(model[0], TemplateTag);
+
+                assert.callCount(datastore.scan, 2);
+                assert.calledWith(datastore.scan.firstCall, {
+                    table: 'templateTags',
+                    params: { name, namespace: 'default', templateType: 'JOB' }
+                });
+                assert.calledWith(datastore.scan.secondCall, {
+                    table: 'templateTags',
+                    params: { name, templateType: 'JOB' }
+                });
             });
         });
 
@@ -339,6 +350,10 @@ describe('TemplateTag Factory', () => {
 
             return factory.list(config).then(model => {
                 assert.instanceOf(model[0], TemplateTag);
+                assert.calledWith(datastore.scan, {
+                    table: 'templateTags',
+                    params: { name, namespace, templateType: 'JOB' }
+                });
             });
         });
 
@@ -348,6 +363,10 @@ describe('TemplateTag Factory', () => {
 
             return factory.list(config).then(model => {
                 assert.instanceOf(model[0], TemplateTag);
+                assert.calledWith(datastore.scan, {
+                    table: 'templateTags',
+                    params: { name, namespace, templateType: 'JOB' }
+                });
             });
         });
     });


### PR DESCRIPTION
## Context
If a Screwdriver pipeline has a job using a template by tag, the `config-parser` throws an error while synchronizing the pipeline when an event is started.

Related to https://github.com/screwdriver-cd/screwdriver/pull/2922
`config-parser` also uses `TemplateTagFactory` to get the template used by the jobs, but the value of `templateType` filter is not set.

https://cd.screwdriver.cd/pipelines/1/events/766942
<img width="1656" alt="image" src="https://github.com/screwdriver-cd/models/assets/2124590/8cc30444-925e-4b19-9570-44896aa78822">

## Objective
Moving the fix made in https://github.com/screwdriver-cd/screwdriver/pull/2922 to the factory so that it gets applied to all the flow using to fetch tags.


## References

https://github.com/screwdriver-cd/screwdriver/issues/2135

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
