### PR TITLE
fix(2911): Fixing raw query mapping to MySQL DB to get pipeline usage for job templates

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -8,7 +8,7 @@ const Queries = {
         WHERE "templateId" IN (:templateIds)
         GROUP BY "templateId"`,
 
-    getPipelineUsageCountForJobTemplatesQueryMysql: (
+    getPipelineUsageCountForJobTemplatesQueryMySql: (
         tablePrefix = ''
     ) => `SELECT COUNT(DISTINCT pipelineId) as count, templateId
         FROM \`${tablePrefix}jobs\`
@@ -126,8 +126,8 @@ const getQueries = (tablePrefix, querylabel) => {
         case QUERY_MAPPINGS.PIPELINE_USAGE_COUNT:
             return [
                 { dbType: 'postgres', query: Queries.getPipelineUsageCountForJobTemplatesQuery(tablePrefix) },
-                { dbType: 'sqlite', query: Queries.getPipelineUsageCountForJobTemplatesQueryMysql(tablePrefix) },
-                { dbType: 'mysql', query: Queries.getPipelineUsageCountForJobTemplatesQuery(tablePrefix) }
+                { dbType: 'sqlite', query: Queries.getPipelineUsageCountForJobTemplatesQuery(tablePrefix) },
+                { dbType: 'mysql', query: Queries.getPipelineUsageCountForJobTemplatesQueryMySql(tablePrefix) }
             ];
         default:
             throw new Error('Unsupported Raw Query');


### PR DESCRIPTION
## Context

Raw queries introduced in https://github.com/screwdriver-cd/models/pull/588 to get pipeline usage count for templates have  been incorrectly mapped to `MySql` and `SQLite` databases.

## Objective

Bug fix

## References

https://github.com/screwdriver-cd/screwdriver/issues/2911

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
