### PR TITLE
feat(2767): Remove 'workflowGraph' from stageBuilds

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -50,9 +50,6 @@ class EventModel extends BaseModel {
 
             if (stage) {
                 stageBuild.stageName = stage.name;
-                stageBuild.workflowGraph.nodes.forEach(node => {
-                    node.stageName = stage.name;
-                });
             }
             stageBuildsWithName.push(stageBuild);
         });


### PR DESCRIPTION
## Context
Per changes in https://github.com/screwdriver-cd/data-schema/pull/529, `stageBuilds` no longer stores stage level workflow graph.

## Objective

Remove any references to `stageBuilds` workflow graph.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2767
https://github.com/screwdriver-cd/data-schema/pull/530

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
