### PR TITLE
fix: Add template and prNum info to executor start config [1]

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -487,38 +487,62 @@ class BuildModel extends BaseModel {
      * @param startConfig.causeMessage  Message that describes why the event was created
      * @return {Promise}
      */
-    start(startConfig = {}) {
+    async start(startConfig = {}) {
         const { causeMessage } = startConfig;
+
+        let template = {};
+
+        // Get template info
+        if (this.templateId) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const TemplateFactory = require('./templateFactory');
+            const templateFactory = TemplateFactory.getInstance();
+
+            const { id, name, namespace, version } = await templateFactory.get(this.templateId);
+
+            template = {
+                id,
+                fullName: `${namespace}/${name}`,
+                name,
+                namespace,
+                version
+            };
+        }
 
         // Make sure that a pipeline and job is associated with the build
         return this.job.then(job =>
-            job.pipeline
-                .then(pipeline =>
+            Promise.all([job.pipeline, job.prNum])
+                .then(([pipeline, prNum]) =>
                     getBlockedByIds(pipeline, job)
                         .then(blockedBy => {
                             const config = {
                                 build: this,
+                                buildId: this.id,
+                                eventId: this.eventId,
                                 jobId: job.id,
                                 jobState: job.state,
                                 jobArchived: job.archived,
                                 jobName: job.name,
                                 annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
                                 blockedBy,
+                                pipelineId: pipeline.id,
                                 pipeline: {
                                     id: pipeline.id,
+                                    name: pipeline.name,
                                     scmContext: pipeline.scmContext,
                                     configPipelineId: pipeline.configPipelineId
                                 },
+                                template,
                                 causeMessage: causeMessage || '',
                                 freezeWindows: hoek.reach(job.permutations[0], 'freezeWindows', { default: [] }),
                                 apiUri: this[apiUri],
-                                buildId: this.id,
-                                eventId: this.eventId,
                                 container: this.container,
                                 tokenGen: this[tokenGen],
                                 token: getToken(this, job, pipeline),
-                                pipelineId: pipeline.id,
                                 isPR: job.isPR(),
+                                prNum,
                                 prParentJobId: job.prParentJobId
                             };
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -58,10 +58,12 @@ describe('Build Model', () => {
     let jobFactoryMock;
     let pipelineFactoryMock;
     let stepFactoryMock;
+    let templateFactoryMock;
     let scmMock;
     let tokenGen;
     let pipelineMock;
     let jobMock;
+    let templateMock;
 
     before(() => {
         mockery.enable({
@@ -102,6 +104,9 @@ describe('Build Model', () => {
             list: sinon.stub().resolves([]),
             removeSteps: sinon.stub().resolves([])
         };
+        templateFactoryMock = {
+            get: sinon.stub()
+        };
 
         pipelineMock = {
             id: pipelineId,
@@ -123,6 +128,12 @@ describe('Build Model', () => {
             updateCommitStatus: sinon.stub().resolves(null),
             addPrComment: sinon.stub().resolves(null)
         };
+        templateMock = {
+            id: 8888,
+            name: 'docker',
+            namespace: 'sd',
+            version: '1.0.0'
+        };
         tokenGen = sinon.stub().returns(token);
         const uF = {
             getInstance: sinon.stub().returns(userFactoryMock)
@@ -136,11 +147,15 @@ describe('Build Model', () => {
         const sF = {
             getInstance: sinon.stub().returns(stepFactoryMock)
         };
+        const tF = {
+            getInstance: sinon.stub().returns(templateFactoryMock)
+        };
 
         mockery.registerMock('./pipelineFactory', pF);
         mockery.registerMock('./userFactory', uF);
         mockery.registerMock('./jobFactory', jF);
         mockery.registerMock('./stepFactory', sF);
+        mockery.registerMock('./templateFactory', tF);
         mockery.registerMock('screwdriver-hashr', hashaMock);
 
         // eslint-disable-next-line global-require
@@ -1091,6 +1106,7 @@ describe('Build Model', () => {
         const prParentJobId = 1000;
         let pipelineMockB = {
             id: pipelineId,
+            name: 'd2lam/test',
             configPipelineId,
             scmUri,
             scmContext,
@@ -1120,6 +1136,8 @@ describe('Build Model', () => {
             isPR: () => false,
             parsePRJobName: sinon.stub().returns(null)
         };
+        let expectedExecutorStartConfig;
+        let expectedUpdateCommitStatusConfig;
 
         beforeEach(() => {
             sandbox = sinon.createSandbox();
@@ -1133,8 +1151,48 @@ describe('Build Model', () => {
                 name: 'main',
                 pipeline: Promise.resolve(pipelineMockB),
                 permutations: [{ annotations, freezeWindows, provider }],
-                isPR: () => false
+                isPR: () => false,
+                prNum: Promise.resolve(null)
             });
+            expectedExecutorStartConfig = {
+                build,
+                causeMessage,
+                eventId,
+                jobId,
+                jobName,
+                jobState,
+                jobArchived,
+                annotations,
+                provider,
+                freezeWindows,
+                blockedBy: [jobId],
+                apiUri,
+                buildId,
+                container,
+                token,
+                pipeline: {
+                    id: pipelineMockB.id,
+                    name: pipelineMockB.name,
+                    scmContext: pipelineMockB.scmContext,
+                    configPipelineId: pipelineMockB.configPipelineId
+                },
+                tokenGen,
+                pipelineId,
+                isPR: false,
+                prNum: null,
+                template: {},
+                prParentJobId
+            };
+            expectedUpdateCommitStatusConfig = {
+                token: 'foo',
+                scmUri,
+                scmContext,
+                sha,
+                jobName: 'main',
+                buildStatus: SCM_STATE_MAP.QUEUED,
+                url,
+                pipelineId
+            };
         });
 
         afterEach(() => {
@@ -1143,32 +1201,7 @@ describe('Build Model', () => {
 
         it('promises to start a build', () =>
             build.start().then(() => {
-                assert.calledWith(executorMock.start, {
-                    build,
-                    causeMessage,
-                    eventId,
-                    jobId,
-                    jobName,
-                    jobState,
-                    jobArchived,
-                    annotations,
-                    provider,
-                    freezeWindows,
-                    blockedBy: [jobId],
-                    apiUri,
-                    buildId,
-                    container,
-                    token,
-                    pipeline: {
-                        id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext,
-                        configPipelineId: pipelineMockB.configPipelineId
-                    },
-                    tokenGen,
-                    pipelineId,
-                    isPR: false,
-                    prParentJobId
-                });
+                assert.calledWith(executorMock.start, expectedExecutorStartConfig);
 
                 assert.calledWith(
                     tokenGen,
@@ -1185,49 +1218,23 @@ describe('Build Model', () => {
                     TEMPORAL_JWT_TIMEOUT
                 );
 
-                assert.calledWith(scmMock.updateCommitStatus, {
-                    token: 'foo',
-                    scmUri,
-                    scmContext,
-                    sha,
-                    jobName: 'main',
-                    buildStatus: SCM_STATE_MAP.QUEUED,
-                    url,
-                    pipelineId
-                });
+                assert.calledWith(scmMock.updateCommitStatus, expectedUpdateCommitStatusConfig);
             }));
 
-        it('passes buildClusterName to executor if it exists', () => {
-            build.buildClusterName = 'sd';
+        it('passes template info to executor if it exists', () => {
+            templateFactoryMock.get.resolves(templateMock);
+
+            build.templateId = templateMock.id;
+            expectedExecutorStartConfig.template = {
+                id: templateMock.id,
+                fullName: `${templateMock.namespace}/${templateMock.name}`,
+                name: templateMock.name,
+                namespace: templateMock.namespace,
+                version: templateMock.version
+            };
 
             return build.start().then(() => {
-                assert.calledWith(executorMock.start, {
-                    build,
-                    causeMessage,
-                    jobId,
-                    jobName,
-                    jobState,
-                    jobArchived,
-                    eventId,
-                    annotations,
-                    provider,
-                    freezeWindows,
-                    blockedBy: [jobId],
-                    apiUri,
-                    buildId,
-                    buildClusterName: 'sd',
-                    container,
-                    token,
-                    tokenGen,
-                    pipeline: {
-                        id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext,
-                        configPipelineId: pipelineMockB.configPipelineId
-                    },
-                    pipelineId,
-                    isPR: false,
-                    prParentJobId
-                });
+                assert.calledWith(executorMock.start, expectedExecutorStartConfig);
 
                 assert.calledWith(
                     tokenGen,
@@ -1244,51 +1251,45 @@ describe('Build Model', () => {
                     TEMPORAL_JWT_TIMEOUT
                 );
 
-                assert.calledWith(scmMock.updateCommitStatus, {
-                    token: 'foo',
-                    scmUri,
-                    scmContext,
-                    sha,
-                    jobName: 'main',
-                    buildStatus: SCM_STATE_MAP.QUEUED,
-                    url,
-                    pipelineId
-                });
+                assert.calledWith(scmMock.updateCommitStatus, expectedUpdateCommitStatusConfig);
             });
         });
 
-        it('passes causeMessage to executor if it exists', () =>
-            build
+        it('passes buildClusterName to executor if it exists', () => {
+            build.buildClusterName = 'sd';
+            expectedExecutorStartConfig.buildClusterName = 'sd';
+
+            return build.start().then(() => {
+                assert.calledWith(executorMock.start, expectedExecutorStartConfig);
+
+                assert.calledWith(
+                    tokenGen,
+                    buildId,
+                    {
+                        isPR: false,
+                        jobId,
+                        pipelineId,
+                        configPipelineId,
+                        eventId,
+                        prParentJobId
+                    },
+                    scmContext,
+                    TEMPORAL_JWT_TIMEOUT
+                );
+
+                assert.calledWith(scmMock.updateCommitStatus, expectedUpdateCommitStatusConfig);
+            });
+        });
+
+        it('passes causeMessage to executor if it exists', () => {
+            expectedExecutorStartConfig.causeMessage = '[force start] Push out hotfix';
+
+            return build
                 .start({
                     causeMessage: '[force start] Push out hotfix'
                 })
                 .then(() => {
-                    assert.calledWith(executorMock.start, {
-                        build,
-                        causeMessage: '[force start] Push out hotfix',
-                        jobId,
-                        jobName,
-                        jobState,
-                        jobArchived,
-                        eventId,
-                        annotations,
-                        provider,
-                        freezeWindows,
-                        blockedBy: [jobId],
-                        apiUri,
-                        buildId,
-                        container,
-                        token,
-                        tokenGen,
-                        pipeline: {
-                            id: pipelineMockB.id,
-                            scmContext: pipelineMockB.scmContext,
-                            configPipelineId: pipelineMockB.configPipelineId
-                        },
-                        pipelineId,
-                        isPR: false,
-                        prParentJobId
-                    });
+                    assert.calledWith(executorMock.start, expectedExecutorStartConfig);
 
                     assert.calledWith(
                         tokenGen,
@@ -1305,17 +1306,9 @@ describe('Build Model', () => {
                         TEMPORAL_JWT_TIMEOUT
                     );
 
-                    assert.calledWith(scmMock.updateCommitStatus, {
-                        token: 'foo',
-                        scmUri,
-                        scmContext,
-                        sha,
-                        jobName: 'main',
-                        buildStatus: SCM_STATE_MAP.QUEUED,
-                        url,
-                        pipelineId
-                    });
-                }));
+                    assert.calledWith(scmMock.updateCommitStatus, expectedUpdateCommitStatusConfig);
+                });
+        });
 
         it('get internal blockedby job Ids and pass to executor start', () => {
             const blocking1 = {
@@ -1339,6 +1332,7 @@ describe('Build Model', () => {
 
             pipelineMockB = {
                 id: pipelineId,
+                name: 'd2lam/test',
                 scmUri,
                 scmContext,
                 admin: Promise.resolve(adminUser),
@@ -1374,36 +1368,14 @@ describe('Build Model', () => {
                 ],
                 isPR: () => true,
                 prParentJobId,
-                parsePRJobName: sinon.stub().returns('main')
+                parsePRJobName: sinon.stub().returns('main'),
+                prNum: Promise.resolve(null)
             });
+            expectedExecutorStartConfig.blockedBy = [jobId, blocking1.id, blocking2.id, prJob.id];
+            expectedExecutorStartConfig.isPR = true;
 
             return build.start().then(() => {
-                assert.calledWith(executorMock.start, {
-                    build,
-                    causeMessage,
-                    jobId,
-                    jobName,
-                    jobState,
-                    jobArchived,
-                    eventId,
-                    blockedBy: [jobId, blocking1.id, blocking2.id, prJob.id],
-                    annotations,
-                    provider,
-                    freezeWindows,
-                    apiUri,
-                    buildId,
-                    container,
-                    token,
-                    tokenGen,
-                    pipeline: {
-                        id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext,
-                        configPipelineId: pipelineMockB.configPipelineId
-                    },
-                    pipelineId,
-                    isPR: true,
-                    prParentJobId
-                });
+                assert.calledWith(executorMock.start, expectedExecutorStartConfig);
             });
         });
 
@@ -1469,36 +1441,15 @@ describe('Build Model', () => {
                     }
                 ],
                 isPR: () => false,
-                parsePRJobName: sinon.stub().returns(null)
+                parsePRJobName: sinon.stub().returns(null),
+                prNum: Promise.resolve(null)
             });
 
+            expectedExecutorStartConfig.blockedBy = [jobId, internalJob.id, externalJob1.id, externalJob2.id];
+            expectedExecutorStartConfig.prParentJobId = undefined;
+
             return build.start().then(() => {
-                assert.calledWith(executorMock.start, {
-                    build,
-                    causeMessage,
-                    jobId,
-                    jobName,
-                    jobState,
-                    jobArchived,
-                    eventId,
-                    blockedBy: [jobId, internalJob.id, externalJob1.id, externalJob2.id],
-                    annotations,
-                    provider,
-                    freezeWindows,
-                    apiUri,
-                    buildId,
-                    container,
-                    token,
-                    tokenGen,
-                    pipeline: {
-                        id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext,
-                        configPipelineId: pipelineMockB.configPipelineId
-                    },
-                    pipelineId: pipelineMockB.id,
-                    isPR: false,
-                    prParentJobId: undefined
-                });
+                assert.calledWith(executorMock.start, expectedExecutorStartConfig);
             });
         });
 
@@ -1544,36 +1495,14 @@ describe('Build Model', () => {
                     }
                 ],
                 isPR: () => false,
-                parsePRJobName: sinon.stub().returns(null)
+                parsePRJobName: sinon.stub().returns(null),
+                prNum: Promise.resolve(null)
             });
+            expectedExecutorStartConfig.blockedBy = [jobId, internalJob.id, externalJob1.id];
+            expectedExecutorStartConfig.prParentJobId = undefined;
 
             return build.start().then(() => {
-                assert.calledWith(executorMock.start, {
-                    build,
-                    causeMessage,
-                    jobId,
-                    jobName,
-                    jobState,
-                    jobArchived,
-                    eventId,
-                    blockedBy: [jobId, internalJob.id, externalJob1.id],
-                    annotations,
-                    provider,
-                    freezeWindows,
-                    apiUri,
-                    buildId,
-                    container,
-                    token,
-                    tokenGen,
-                    pipeline: {
-                        id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext,
-                        configPipelineId: pipelineMockB.configPipelineId
-                    },
-                    pipelineId: pipelineMockB.id,
-                    isPR: false,
-                    prParentJobId: undefined
-                });
+                assert.calledWith(executorMock.start, expectedExecutorStartConfig);
             });
         });
 
@@ -1594,36 +1523,15 @@ describe('Build Model', () => {
                 archived: false,
                 pipeline: Promise.resolve(pipelineMockB),
                 permutations: [{ annotations: { 'beta.screwdriver.cd/executor:': 'k8s-vm' }, provider }],
-                isPR: () => false
+                isPR: () => false,
+                prNum: Promise.resolve(null)
             });
+            expectedExecutorStartConfig.annotations = { 'beta.screwdriver.cd/executor:': 'k8s-vm' };
+            expectedExecutorStartConfig.prParentJobId = undefined;
+            expectedExecutorStartConfig.freezeWindows = [];
 
             return build.start().then(() => {
-                assert.calledWith(executorMock.start, {
-                    build,
-                    causeMessage,
-                    jobId,
-                    jobName,
-                    jobState,
-                    jobArchived,
-                    eventId,
-                    annotations: { 'beta.screwdriver.cd/executor:': 'k8s-vm' },
-                    provider,
-                    freezeWindows: [],
-                    blockedBy: [jobId],
-                    apiUri,
-                    buildId,
-                    container,
-                    token,
-                    tokenGen,
-                    pipeline: {
-                        id: pipelineMockB.id,
-                        scmContext: pipelineMockB.scmContext,
-                        configPipelineId: pipelineMockB.configPipelineId
-                    },
-                    pipelineId: pipelineMockB.id,
-                    isPR: false,
-                    prParentJobId: undefined
-                });
+                assert.calledWith(executorMock.start, expectedExecutorStartConfig);
 
                 assert.calledWith(
                     tokenGen,
@@ -1639,16 +1547,7 @@ describe('Build Model', () => {
                     TEMPORAL_JWT_TIMEOUT
                 );
 
-                assert.calledWith(scmMock.updateCommitStatus, {
-                    token: 'foo',
-                    scmUri,
-                    scmContext,
-                    sha,
-                    jobName: 'main',
-                    buildStatus: SCM_STATE_MAP.QUEUED,
-                    url,
-                    pipelineId
-                });
+                assert.calledWith(scmMock.updateCommitStatus, expectedUpdateCommitStatusConfig);
             });
         });
 


### PR DESCRIPTION
## Context

Pods might need more information.

## Objective

This PR adds template and prNum info to executor start config.

## References
Blocked by https://github.com/screwdriver-cd/data-schema/pull/536

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
