### PR TITLE
fix: Only add template info and prNum to executor start if it exists

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -490,7 +490,7 @@ class BuildModel extends BaseModel {
     async start(startConfig = {}) {
         const { causeMessage } = startConfig;
 
-        let template = {};
+        const template = {};
 
         // Get template info
         if (this.templateId) {
@@ -502,13 +502,21 @@ class BuildModel extends BaseModel {
 
             const { id, name, namespace, version } = await templateFactory.get(this.templateId);
 
-            template = {
-                id,
-                fullName: `${namespace}/${name}`,
-                name,
-                namespace,
-                version
-            };
+            if (id) {
+                template.id = id;
+            }
+            if (name) {
+                template.name = name;
+            }
+            if (namespace) {
+                template.namespace = namespace;
+            }
+            if (namespace && name) {
+                template.fullName = `${namespace}/${name}`;
+            }
+            if (version) {
+                template.version = version;
+            }
         }
 
         // Make sure that a pipeline and job is associated with the build
@@ -534,7 +542,6 @@ class BuildModel extends BaseModel {
                                     scmContext: pipeline.scmContext,
                                     configPipelineId: pipeline.configPipelineId
                                 },
-                                template,
                                 causeMessage: causeMessage || '',
                                 freezeWindows: hoek.reach(job.permutations[0], 'freezeWindows', { default: [] }),
                                 apiUri: this[apiUri],
@@ -542,9 +549,16 @@ class BuildModel extends BaseModel {
                                 tokenGen: this[tokenGen],
                                 token: getToken(this, job, pipeline),
                                 isPR: job.isPR(),
-                                prNum,
                                 prParentJobId: job.prParentJobId
                             };
+
+                            if (template && !hoek.deepEqual(template, {})) {
+                                config.template = template;
+                            }
+
+                            if (prNum) {
+                                config.prNum = prNum;
+                            }
 
                             if (this.buildClusterName) {
                                 config.buildClusterName = this.buildClusterName;

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -131,8 +131,7 @@ describe('Build Model', () => {
         templateMock = {
             id: 8888,
             name: 'docker',
-            namespace: 'sd',
-            version: '1.0.0'
+            namespace: 'sd'
         };
         tokenGen = sinon.stub().returns(token);
         const uF = {
@@ -1179,8 +1178,6 @@ describe('Build Model', () => {
                 tokenGen,
                 pipelineId,
                 isPR: false,
-                prNum: null,
-                template: {},
                 prParentJobId
             };
             expectedUpdateCommitStatusConfig = {
@@ -1229,8 +1226,7 @@ describe('Build Model', () => {
                 id: templateMock.id,
                 fullName: `${templateMock.namespace}/${templateMock.name}`,
                 name: templateMock.name,
-                namespace: templateMock.namespace,
-                version: templateMock.version
+                namespace: templateMock.namespace
             };
 
             return build.start().then(() => {


### PR DESCRIPTION
## Context

Template and prNum does not always exist. We should not pass it to executor is that is the case.

## Objective

This PR checks if template info and prNum exist before passing to executor start.

## References

Related to https://github.com/screwdriver-cd/models/pull/592

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
