### PR TITLE
fix(2767): Fix issues while parsing and creating/updating stage entities

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -901,34 +901,13 @@ class PipelineModel extends BaseModel {
             const setupJobExists = Object.keys(jobs).find(j => j === setupJobName || j === `~${setupJobName}`);
             const teardownJobExists = Object.keys(jobs).find(j => j === teardownJobName || j === `~${teardownJobName}`);
 
-            newStage.setup = [pipelineJobs.find(j => j.name === setupJobExists).id];
-            newStage.teardown = [pipelineJobs.find(j => j.name === teardownJobExists).id];
+            newStage.setup = pipelineJobs.find(j => j.name === setupJobExists).id;
+            newStage.teardown = pipelineJobs.find(j => j.name === teardownJobExists).id;
 
-            // Add workflow graph
             newStages.push(newStage);
         });
 
         return newStages;
-    }
-
-    /**
-     * Create stage model with stage metadata
-     * Create instance of a stage with stageId, workflowGraph, and status
-     * @method createStage
-     * @param  {Object}     config              config
-     * @param  {Object}     config.pipeline     Pipeline
-     * @return {Promise}
-     */
-    async _createStage({ stageFactory, stageConfig }) {
-        const stageCreateConfig = stageConfig;
-
-        delete stageCreateConfig.workflowGraph;
-
-        stageCreateConfig.archived = false;
-
-        const stage = await stageFactory.create(stageCreateConfig);
-
-        return stage;
     }
 
     /**
@@ -944,7 +923,6 @@ class PipelineModel extends BaseModel {
         // Get new stages
         const stages = parsedConfig.stages || {};
         const jobs = parsedConfig.jobs || {};
-        const stageNames = Object.keys(stages);
 
         // No stages in yaml, skip creation
         if (Object.keys(stages).length === 0) {
@@ -954,7 +932,7 @@ class PipelineModel extends BaseModel {
         }
 
         // list stage names from this pipeline that already exist
-        const existingStages = await stageFactory.list({ params: { pipelineId, name: stageNames } });
+        const existingStages = await stageFactory.list({ params: { pipelineId } });
         const existingStageNames = existingStages.map(stage => stage.name);
         // Format new stage data
         const convertedStages = await this._convertStages({ pipelineId, stages, jobs, pipelineJobs });
@@ -967,45 +945,29 @@ class PipelineModel extends BaseModel {
 
         // Archive outdated stages
         stagesToArchive.forEach(stage => {
-            const idToUpdate = existingStages.find(s => s.name === stage.name).id;
-            const updateStageConfig = { id: idToUpdate };
+            const existingStage = existingStages.find(s => s.name === stage.name);
 
-            updateStageConfig.archived = true;
+            existingStage.archived = true;
 
             logger.info(`Archiving stage:${JSON.stringify(stage)} for pipelineId:${pipelineId}.`);
-            processed.push(stageFactory.update(updateStageConfig));
+            processed.push(existingStage.update());
         });
 
         // Update existing stages
         stagesToUpdate.forEach(stage => {
-            const idToUpdate = existingStages.find(s => s.name === stage.name).id;
-            const updateStageConfig = { id: idToUpdate };
+            const existingStage = existingStages.find(s => s.name === stage.name);
 
-            if (stage.jobIds) {
-                updateStageConfig.jobIds = stage.jobIds;
-            }
-            if (stage.description) {
-                updateStageConfig.description = stage.description;
-            }
-            if (stage.setup) {
-                updateStageConfig.setup = stage.setup;
-            }
-            if (stage.teardown) {
-                updateStageConfig.teardown = stage.teardown;
-            }
-            if (stage.workflowGraph) {
-                updateStageConfig.workflowGraph = stage.workflowGraph;
-            }
-            updateStageConfig.archived = false;
+            Object.assign(existingStage, stage);
+            existingStage.archived = false;
 
             logger.info(`Updating stage:${JSON.stringify(stage)} for pipelineId:${pipelineId}.`);
-            processed.push(stageFactory.update(updateStageConfig));
+            processed.push(existingStage.update());
         });
 
         // Create new stages
         stagesToCreate.forEach(stage => {
             logger.info(`Creating stage:${JSON.stringify(stage)} for pipelineId:${pipelineId}.`);
-            processed.push(this._createStage({ stageFactory, stageConfig: stage }));
+            processed.push(stageFactory.create(stage));
         });
 
         return Promise.all(processed);
@@ -1153,7 +1115,7 @@ class PipelineModel extends BaseModel {
             parsedConfig,
             pipelineId,
             stageFactory,
-            pipelineJobs: existingJobs
+            pipelineJobs: updatedJobs
         });
 
         const { nodes } = this.workflowGraph;

--- a/lib/stageFactory.js
+++ b/lib/stageFactory.js
@@ -38,6 +38,8 @@ class StageFactory extends BaseFactory {
      * @memberof StageFactory
      */
     create(config) {
+        config.archived = false;
+
         return super.create(config);
     }
 

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "screwdriver-config-parser": "^8.0.2",
-    "screwdriver-data-schema": "^22.7.1",
+    "screwdriver-config-parser": "^8.0.3",
+    "screwdriver-data-schema": "^22.9.7",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-workflow-parser": "^4.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "screwdriver-config-parser": "^8.0.0",
-    "screwdriver-data-schema": "^22.6.1",
+    "screwdriver-config-parser": "^8.0.2",
+    "screwdriver-data-schema": "^22.7.1",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-workflow-parser": "^4.0.0"
+    "screwdriver-workflow-parser": "^4.1.0"
   }
 }

--- a/test/data/parserWithStages.json
+++ b/test/data/parserWithStages.json
@@ -167,36 +167,12 @@
     },
     "stages": {
         "canary": {
-            "startFrom": "main",
             "description": "Canary deployment",
-            "jobs": ["main", "publish"],
-            "workflowGraph": {
-                "nodes": [
-                    { "name": "main" },
-                    { "name": "publish" },
-                    { "name": "stage@canary:setup" },
-                    { "name": "stage@canary:teardown" }
-                ],
-                "edges": [
-                    { "src": "main", "dest": "publish" }
-                ]
-            }
+            "jobs": ["main", "publish"]
         },
         "deploy": {
-            "startFrom": "A",
             "description": "Prod deployment",
-            "jobs": ["A", "B"],
-            "workflowGraph": {
-                "nodes": [
-                    { "name": "A" },
-                    { "name": "B" },
-                    { "name": "stage@deploy:setup" },
-                    { "name": "stage@deploy:teardown" }
-                ],
-                "edges": [
-                    { "src": "A", "dest": "B" }
-                ]
-            }
+            "jobs": ["A", "B"]
         }
     }
 }


### PR DESCRIPTION
## Context

Noticed below issues during pipeline creation (and pipeline sync) involving stages

1. `id` of setup/teardown jobs are not available while creating a stage.
2. 'id' of setup/teardown jobs are set as an array in stage. This results DB error as it expects the value to be an integer.
3. Updating exiting stages invoked `update` method of stage factory  which does not exist. Update should always be performed by invoking `update` method of `stage` object retrieved from DB.
4. When a stage was removed from the pipeline configuration, it is not marked as `archived`. Only the stages present in the latest pipeline configuration were fetched from DB. Hence the obsolete stages were never fetched and archived.

## Objective
Fixed all the above mentioned issues.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2767

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
