### PR TITLE
fix(2767): Pipeline workflow graph should only contain job nodes

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -913,13 +913,15 @@ class PipelineModel extends BaseModel {
     /**
      * Sync stages
      * 1. Convert new stages into correct format, prepopulate with jobIds
-     * 2. Create the stages if it is defined and was not in the database yet
-     * @method createStages
+     * 2.a. Create the stages if it is defined and was not in the database yet
+     * 2.b. Update the existing stages with the new configuration
+     * 2.c. Archive then existing stages if they no longer exist in the configuration
+     * @method _createOrUpdateStages
      * @param  {Object}     config              config
      * @param  {Object}     config.pipeline     Pipeline
      * @return {Promise}
      */
-    async _createStages({ parsedConfig, pipelineId, stageFactory, pipelineJobs }) {
+    async _createOrUpdateStages({ parsedConfig, pipelineId, stageFactory, pipelineJobs }) {
         // Get new stages
         const stages = parsedConfig.stages || {};
         const jobs = parsedConfig.jobs || {};
@@ -1111,7 +1113,7 @@ class PipelineModel extends BaseModel {
         }
 
         // Sync stages
-        const stages = await this._createStages({
+        await this._createOrUpdateStages({
             parsedConfig,
             pipelineId,
             stageFactory,
@@ -1157,12 +1159,6 @@ class PipelineModel extends BaseModel {
                 // Handle internal nodes
                 if (job) {
                     node.id = job.id;
-                    // Add stage id
-                } else if (/^(?:~)?(stage@)/.test(node.name)) {
-                    const stage = stages.find(s => s.name === node.name.split('@')[1]);
-
-                    node.id = stage.id;
-                    node.type = 'stage';
                 }
 
                 return node;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -913,9 +913,9 @@ class PipelineModel extends BaseModel {
     /**
      * Sync stages
      * 1. Convert new stages into correct format, prepopulate with jobIds
-     * 2.a. Create the stages if it is defined and was not in the database yet
-     * 2.b. Update the existing stages with the new configuration
-     * 2.c. Archive then existing stages if they no longer exist in the configuration
+     * 2.a. Create stages if they are defined and were not already in the database
+     * 2.b. Update existing stages with the new configuration
+     * 2.c. Archive existing stages if they no longer exist in the configuration
      * @method _createOrUpdateStages
      * @param  {Object}     config              config
      * @param  {Object}     config.pipeline     Pipeline

--- a/test/data/parserWithStages.json
+++ b/test/data/parserWithStages.json
@@ -17,7 +17,7 @@
                     "NODE_ENV": "test",
                     "NODE_VERSION": "4"
                 },
-                "requires": ["~pr", "~commit", "~sd@12345:test", "stage@canary:setup"]
+                "requires": ["stage@canary:setup"]
             },
             {
                 "image": "node:5",
@@ -35,7 +35,7 @@
                     "NODE_ENV": "test",
                     "NODE_VERSION": "5"
                 },
-                "requires": ["~pr", "~commit", "~sd@12345:test", "stage@canary:setup"]
+                "requires": ["stage@canary:setup"]
             },
             {
                 "image": "node:6",
@@ -53,7 +53,7 @@
                     "NODE_ENV": "test",
                     "NODE_VERSION": "6"
                 },
-                "requires": ["~pr", "~commit", "~sd@12345:test", "stage@canary:setup"]
+                "requires": ["stage@canary:setup"]
             }
         ],
         "publish": [
@@ -112,7 +112,8 @@
                         "name": "announce",
                         "command": "post banner"
                     }
-                ]
+                ],
+                "requires": ["~pr", "~commit", "~sd@12345:test"]
             }
         ],
         "stage@canary:teardown": [
@@ -123,7 +124,8 @@
                         "name": "publish",
                         "command": "publish blog"
                     }
-                ]
+                ],
+                "requires": ["publish"]
             }
         ],
         "stage@deploy:setup": [
@@ -145,7 +147,8 @@
                         "name": "publish",
                         "command": "publish blog"
                     }
-                ]
+                ],
+                "requires": ["B"]
             }
         ]
     },
@@ -154,12 +157,24 @@
         "nodes": [
             { "name": "~pr" },
             { "name": "~commit" },
-            { "name": "stage@canary" },
-            { "name": "stage@deploy" }
+            { "name": "stage@canary:setup" },
+            { "name": "main" },
+            { "name": "publish" },
+            { "name": "stage@canary:teardown" },
+            { "name": "stage@deploy:setup" },
+            { "name": "A" },
+            { "name": "B" },
+            { "name": "stage@deploy:teardown" }
         ],
         "edges": [
-            { "src": "~pr", "dest": "stage@canary" },
-            { "src": "~commit", "dest": "stage@canary" }
+            { "src": "~pr", "dest": "stage@canary:setup" },
+            { "src": "~commit", "dest": "stage@canary:setup" },
+            { "src": "stage@canary:setup", "dest": "main" },
+            { "src": "main", "dest": "publish" },
+            { "src": "publish", "dest": "stage@canary:teardown" },
+            { "src": "stage@deploy:setup", "dest": "A" },
+            { "src": "A", "dest": "B" },
+            { "src": "B", "dest": "stage@deploy:teardown" }
         ]
     },
     "annotations": {
@@ -168,7 +183,8 @@
     "stages": {
         "canary": {
             "description": "Canary deployment",
-            "jobs": ["main", "publish"]
+            "jobs": ["main", "publish"],
+            "requires": ["~pr", "~commit", "~sd@12345:test"]
         },
         "deploy": {
             "description": "Prod deployment",

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -971,18 +971,7 @@ describe('Pipeline Model', () => {
 
             return pipeline.sync().then(() => {
                 assert.calledOnce(pipeline.update);
-                assert.deepEqual(pipeline.workflowGraph, {
-                    nodes: [
-                        { name: '~pr' },
-                        { name: '~commit' },
-                        { name: 'stage@canary', id: 8888, type: 'stage' },
-                        { name: 'stage@deploy', id: 8889, type: 'stage' }
-                    ],
-                    edges: [
-                        { src: '~pr', dest: 'stage@canary' },
-                        { src: '~commit', dest: 'stage@canary' }
-                    ]
-                });
+                assert.deepEqual(pipeline.workflowGraph, PARSED_YAML_WITH_STAGES.workflowGraph);
                 assert.calledWith(stageFactoryMock.create, {
                     name: 'deploy',
                     pipelineId: 123,
@@ -1011,6 +1000,7 @@ describe('Pipeline Model', () => {
                     setup: 5,
                     teardown: 6,
                     archived: false,
+                    requires: ['~pr', '~commit', '~sd@12345:test'],
                     update: stageMocks[1].update
                 });
             });


### PR DESCRIPTION
## Context

Unified workflow graph would always contain nodes representing jobs. Stage will never be represented as nodes in the unified workflow graph.

## Objective

Remove the logic that add nodes for stages

## References

https://github.com/screwdriver-cd/screwdriver/issues/2767

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
