### PR TITLE
feat(2465): Prevent event's baseBranch from being null

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -709,8 +709,7 @@ class EventFactory extends BaseFactory {
             creator: config.creator || null,
             meta: config.meta || {},
             pr: {},
-            prNum,
-            baseBranch: config.baseBranch || null
+            prNum
         };
         let prevChainPR = '';
         let decoratedCommit;
@@ -770,6 +769,16 @@ class EventFactory extends BaseFactory {
                         if (prInfo.prBranchName) {
                             modelConfig.pr.prBranchName = prInfo.prBranchName;
                         }
+                    }
+
+                    if (config.baseBranch) {
+                        modelConfig.baseBranch = config.baseBranch;
+                    }
+                    else if(prInfo && prInfo.baseBranch) {
+                        modelConfig.baseBranch = prInfo.baseBranch;
+                    }
+                    else if(p.scmRepo && p.scmRepo.branch) {
+                        modelConfig.baseBranch = p.scmRepo.branch;
                     }
 
                     if (prTitle) {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -774,11 +774,11 @@ class EventFactory extends BaseFactory {
                     if (config.baseBranch) {
                         // cases triggered by webhook or when there is a parentEvent such as restart
                         modelConfig.baseBranch = config.baseBranch;
-                    } else if (prInfo && prInfo.baseBranch) {
+                    } else if (prInfo?.baseBranch) {
                         // cases of PR events created from the Start button
                         modelConfig.baseBranch = prInfo.baseBranch;
-                    } else if (p.scmRepo && p.scmRepo.branch) {
-                        // cases of commit events created from the Start button
+                    } else if (p.scmRepo?.branch) {
+                        // cases triggered by remote trigger and commit events created from the Start button
                         modelConfig.baseBranch = p.scmRepo.branch;
                     }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -772,10 +772,13 @@ class EventFactory extends BaseFactory {
                     }
 
                     if (config.baseBranch) {
+                        // cases triggered by webhook or when there is a parentEvent such as restart
                         modelConfig.baseBranch = config.baseBranch;
                     } else if (prInfo && prInfo.baseBranch) {
+                        // cases of PR events created from the Start button
                         modelConfig.baseBranch = prInfo.baseBranch;
                     } else if (p.scmRepo && p.scmRepo.branch) {
+                        // cases of commit events created from the Start button
                         modelConfig.baseBranch = p.scmRepo.branch;
                     }
 

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -774,10 +774,10 @@ class EventFactory extends BaseFactory {
                     if (config.baseBranch) {
                         // cases triggered by webhook or when there is a parentEvent such as restart
                         modelConfig.baseBranch = config.baseBranch;
-                    } else if (prInfo?.baseBranch) {
+                    } else if (prInfo && prInfo.baseBranch) {
                         // cases of PR events created from the Start button
                         modelConfig.baseBranch = prInfo.baseBranch;
-                    } else if (p.scmRepo?.branch) {
+                    } else if (p.scmRepo && p.scmRepo.branch) {
                         // cases triggered by remote trigger and commit events created from the Start button
                         modelConfig.baseBranch = p.scmRepo.branch;
                     }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -773,11 +773,9 @@ class EventFactory extends BaseFactory {
 
                     if (config.baseBranch) {
                         modelConfig.baseBranch = config.baseBranch;
-                    }
-                    else if(prInfo && prInfo.baseBranch) {
+                    } else if (prInfo && prInfo.baseBranch) {
                         modelConfig.baseBranch = prInfo.baseBranch;
-                    }
-                    else if(p.scmRepo && p.scmRepo.branch) {
+                    } else if (p.scmRepo && p.scmRepo.branch) {
                         modelConfig.baseBranch = p.scmRepo.branch;
                     }
 


### PR DESCRIPTION
## Context
There are instances where the `baseBranch` of the DB is `null` in the event table. In such cases, the branch that the event refers to does not get displayed in the UI.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
I made changes so that the `baseBranch` is also set for events created through remote triggers and the UI.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2465#issuecomment-1276827077
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
