### PR TITLE
fix(2767): Create stageBuild during build create

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -226,12 +226,12 @@ class BuildFactory extends BaseFactory {
                     });
 
                     // Create stage build if current job is stage setup
-                    const nextJobIsStageSetup = job.name.match(STAGE_SETUP_PATTERN);
+                    const stageSetupJob = job.name.match(STAGE_SETUP_PATTERN);
 
-                    if (nextJobIsStageSetup) {
+                    if (stageSetupJob) {
                         const stage = await stageFactory.get({
                             pipelineId: pipeline.id,
-                            name: nextJobIsStageSetup[1]
+                            name: stageSetupJob[1]
                         });
 
                         await stageBuildFactory.create({

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -7,6 +7,8 @@ const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const { STATUS_QUERY, LATEST_BUILD_QUERY, getQueries } = require('./rawQueries');
 const helper = require('./helper');
+const STAGE_SETUP_PATTERN = /^stage@([\w-]+)(?::setup)$/;
+
 let instance;
 
 /**
@@ -191,11 +193,15 @@ class BuildFactory extends BaseFactory {
         /* eslint-disable global-require */
         const JobFactory = require('./jobFactory');
         const StepFactory = require('./stepFactory');
+        const StageFactory = require('./stageFactory');
+        const StageBuildFactory = require('./stageBuildFactory');
         /* eslint-enable global-require */
-        const factory = JobFactory.getInstance();
+        const jobFactory = JobFactory.getInstance();
         const stepFactory = StepFactory.getInstance();
+        const stageFactory = StageFactory.getInstance();
+        const stageBuildFactory = StageBuildFactory.getInstance();
 
-        return factory.get(jobId).then(job => {
+        return jobFactory.get(jobId).then(job => {
             if (!job) {
                 throw new Error('Job does not exist');
             }
@@ -219,6 +225,23 @@ class BuildFactory extends BaseFactory {
                         provider
                     });
 
+                    // Create stage build if current job is stage setup
+                    const nextJobIsStageSetup = job.name.match(STAGE_SETUP_PATTERN);
+
+                    if (nextJobIsStageSetup) {
+                        const stage = await stageFactory.get({
+                            pipelineId: pipeline.id,
+                            name: nextJobIsStageSetup[1]
+                        });
+
+                        await stageBuildFactory.create({
+                            stageId: stage.id,
+                            eventId: config.eventId,
+                            status: 'CREATED'
+                        });
+                    }
+
+                    // Set correct bookend key
                     const bookendKey = await helper.getBookendKey({
                         buildClusterName,
                         annotations,


### PR DESCRIPTION
## Context

We should create stageBuild during build create to avoid duplication in multiple places.

## Objective

This PR checks if build to be created is stage setup build, then create stageBuild if it is.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2870#discussion_r1448110743, https://github.com/screwdriver-cd/screwdriver/pull/2870

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
