### PR TITLE
feat(2822): Extend normal job fields to pr job

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -658,11 +658,11 @@ class PipelineModel extends BaseModel {
             j => !j.name.startsWith(`PR-${prNum}:`) && jobsToCreate.includes(j.name)
         );
 
-        // create a map for PR Parent Jobs like: {main: 1, publish: 2}
+        // create a map for PR Parent Jobs like: {main: {id: 1}, publish: {id: 2}}
         const prParentJobIdMap = {};
 
         prFromPipelineJobs.forEach(j => {
-            prParentJobIdMap[j.name] = j.id;
+            prParentJobIdMap[j.name] = j;
         });
 
         // Create missing PR jobs
@@ -677,7 +677,9 @@ class PipelineModel extends BaseModel {
 
                     // If there is a pr parent
                     if (prParentJobIdMap[jobName]) {
-                        jobModel.prParentJobId = prParentJobIdMap[jobName];
+                        jobModel.prParentJobId = prParentJobIdMap[jobName].id;
+                        jobModel.templateId = prParentJobIdMap[jobName].templateId;
+                        jobModel.description = prParentJobIdMap[jobName].description;
                     }
 
                     // Create jobs

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -94,7 +94,6 @@ describe('Pipeline Model', () => {
     let mainJob;
     let blahJob;
     let testJob;
-    let templateJob;
     let pr10;
     let pr3;
     let pr3Info;
@@ -1567,7 +1566,7 @@ describe('Pipeline Model', () => {
         });
 
         it('update PR config', () => {
-            jobFactoryMock.list.resolves([templateJob]); // pipeline jobs
+            jobFactoryMock.list.resolves([mainJob]); // pipeline jobs
             jobFactoryMock.getPullRequestJobsForPipelineSync.resolves([prJob]); // pull request jobs
 
             scmMock.getOpenedPRs.resolves([{ name: 'PR-1', ref: 'abc' }]);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -94,6 +94,7 @@ describe('Pipeline Model', () => {
     let mainJob;
     let blahJob;
     let testJob;
+    let templateJob;
     let pr10;
     let pr3;
     let pr3Info;
@@ -182,6 +183,8 @@ describe('Pipeline Model', () => {
         testJob = getJobMocks({
             id: 100,
             name: 'test',
+            description: 'test job',
+            templateId: 5,
             archived: false
         });
 
@@ -1564,7 +1567,7 @@ describe('Pipeline Model', () => {
         });
 
         it('update PR config', () => {
-            jobFactoryMock.list.resolves([mainJob]); // pipeline jobs
+            jobFactoryMock.list.resolves([templateJob]); // pipeline jobs
             jobFactoryMock.getPullRequestJobsForPipelineSync.resolves([prJob]); // pull request jobs
 
             scmMock.getOpenedPRs.resolves([{ name: 'PR-1', ref: 'abc' }]);
@@ -1600,7 +1603,9 @@ describe('Pipeline Model', () => {
                         }
                     ],
                     pipelineId: testId,
-                    prParentJobId: 100
+                    prParentJobId: 100,
+                    templateId: 5,
+                    description: 'test job'
                 });
                 assert.calledWith(
                     jobFactoryMock.create.secondCall,
@@ -1714,7 +1719,9 @@ describe('Pipeline Model', () => {
                         }
                     ],
                     pipelineId: testId,
-                    prParentJobId: 100
+                    prParentJobId: 100,
+                    templateId: 5,
+                    description: 'test job'
                 });
                 assert.calledWith(
                     jobFactoryMock.create.secondCall,
@@ -1951,7 +1958,9 @@ describe('Pipeline Model', () => {
                     permutations: PARSED_YAML.jobs.main,
                     pipelineId: testId,
                     name: 'PR-2:main',
-                    prParentJobId: 99998
+                    prParentJobId: 99998,
+                    templateId: undefined,
+                    description: undefined
                 });
             });
         });


### PR DESCRIPTION
## Context
You can view the template being used in the build detail page, but it was not viewable in PR build detail page. This is because the PR job lacks template information.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Implement inheritance of necessary information from the original job to the PR job.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2822
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
