### PR TITLE
fix: Do not start periodic for PR job update

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -252,6 +252,7 @@ class Job extends BaseModel {
             const isSettingUpdated = newPeriodic ? newPeriodic !== oldPeriodic : !!oldPeriodic;
 
             if (
+                !this.isPR() &&
                 newPeriodic &&
                 (isSettingUpdated || !isOldJobEnabled || isOldJobArchived) &&
                 isNewJobEnabled &&

--- a/test/lib/job.test.js
+++ b/test/lib/job.test.js
@@ -502,6 +502,27 @@ describe('Job Model', () => {
             });
         });
 
+        it('does not start periodic when job is PR', () => {
+            job.state = 'ENABLED';
+            job.permutations = [
+                {
+                    annotations: {
+                        'screwdriver.cd/buildPeriodically': 'H * * * *'
+                    },
+                    provider
+                }
+            ];
+            job.name = 'PR-142:main';
+
+            datastore.update.resolves(null);
+
+            return job.update().then(() => {
+                assert.notCalled(executorMock.stopPeriodic);
+                assert.notCalled(executorMock.startPeriodic);
+                assert.calledOnce(datastore.update);
+            });
+        });
+
         it('removes periodic when new and old settings are undefined and job is disabled', () => {
             const oldJob = { ...job };
 


### PR DESCRIPTION
## Context

PR jobs are still running periodic builds when the PR is closed/reopened.

## Objective

This PR adds a check so PR will not start periodic for job update.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1441

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
