### PR TITLE
fix(2767): Remove stage build in build remove

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -16,6 +16,7 @@ const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
 const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
 const TEMPORAL_JWT_TIMEOUT = 12 * 60; // 12 hours in minutes
+const STAGE_SETUP_PATTERN = /^stage@([\w-]+)(?::setup)$/; // stage@jobName:setup;
 
 /**
  * Get the array of ids for jobs that match the names passed in
@@ -646,15 +647,43 @@ class BuildModel extends BaseModel {
     }
 
     /**
-     * Remove all steps associated with this build and the build itself
+     * Remove all steps associated with this build, any stageBuild associated
+     * with this build, and the build itself
      * @return {Promise}        Resolves to null if remove successfully
      */
-    remove() {
+    async remove() {
         // eslint-disable-next-line global-require
-        const stepFactory = require('./stepFactory');
-        const factory = stepFactory.getInstance();
+        const StepFactory = require('./stepFactory');
+        const stepFactory = StepFactory.getInstance();
+        const job = await this.job;
+        const jobIsStageSetup = STAGE_SETUP_PATTERN.test(job.name);
 
-        return factory.removeSteps({ buildId: this.id }).then(() => super.remove());
+        // Delete stageBuild if current build is from a stage setup job
+        if (jobIsStageSetup) {
+            /* eslint-disable global-require */
+            const StageFactory = require('./stageFactory');
+            const StageBuildFactory = require('./stageBuildFactory');
+            /* eslint-enable global-require */
+            const stageFactory = StageFactory.getInstance();
+            const stageBuildFactory = StageBuildFactory.getInstance();
+            const pipeline = await this.pipeline;
+
+            const [, nextStageName] = job.name.match(STAGE_SETUP_PATTERN);
+            const nextStage = await stageFactory.get({
+                name: nextStageName,
+                pipelineId: pipeline.id
+            });
+
+            const nextStageBuild = await stageBuildFactory.get({
+                stageId: nextStage.id,
+                eventId: this.eventId
+            });
+
+            await nextStageBuild.remove();
+        }
+
+        // Remove steps
+        return stepFactory.removeSteps({ buildId: this.id }).then(() => super.remove());
     }
 
     /**

--- a/lib/build.js
+++ b/lib/build.js
@@ -8,6 +8,7 @@ const logger = require('screwdriver-logger');
 const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const { SCM_STATE_MAP, SCM_STATUSES } = require('screwdriver-data-schema').plugins.scm;
 const BaseModel = require('./base');
+const { getStageFromSetupJobName } = require('./helper');
 
 // Symbols for private members
 const executor = Symbol('executor');
@@ -16,7 +17,6 @@ const tokenGen = Symbol('tokenGen');
 const uiUri = Symbol('uiUri');
 const ABORT_CODE = 130; // 128 + SIGINT 2 (^C)
 const TEMPORAL_JWT_TIMEOUT = 12 * 60; // 12 hours in minutes
-const STAGE_SETUP_PATTERN = /^stage@([\w-]+)(?::setup)$/; // stage@jobName:setup;
 
 /**
  * Get the array of ids for jobs that match the names passed in
@@ -656,10 +656,10 @@ class BuildModel extends BaseModel {
         const StepFactory = require('./stepFactory');
         const stepFactory = StepFactory.getInstance();
         const job = await this.job;
-        const jobIsStageSetup = STAGE_SETUP_PATTERN.test(job.name);
+        const nextStageName = getStageFromSetupJobName(job.name);
 
         // Delete stageBuild if current build is from a stage setup job
-        if (jobIsStageSetup) {
+        if (nextStageName) {
             /* eslint-disable global-require */
             const StageFactory = require('./stageFactory');
             const StageBuildFactory = require('./stageBuildFactory');
@@ -667,13 +667,10 @@ class BuildModel extends BaseModel {
             const stageFactory = StageFactory.getInstance();
             const stageBuildFactory = StageBuildFactory.getInstance();
             const pipeline = await this.pipeline;
-
-            const [, nextStageName] = job.name.match(STAGE_SETUP_PATTERN);
             const nextStage = await stageFactory.get({
                 name: nextStageName,
                 pipelineId: pipeline.id
             });
-
             const nextStageBuild = await stageBuildFactory.get({
                 stageId: nextStage.id,
                 eventId: this.eventId

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -6,8 +6,7 @@ const logger = require('screwdriver-logger');
 const BaseFactory = require('./baseFactory');
 const Build = require('./build');
 const { STATUS_QUERY, LATEST_BUILD_QUERY, getQueries } = require('./rawQueries');
-const helper = require('./helper');
-const STAGE_SETUP_PATTERN = /^stage@([\w-]+)(?::setup)$/;
+const { getBuildClusterName, getBookendKey, getStageFromSetupJobName } = require('./helper');
 
 let instance;
 
@@ -218,7 +217,7 @@ class BuildFactory extends BaseFactory {
                         provider = permutation.provider;
                     }
 
-                    const buildClusterName = await helper.getBuildClusterName({
+                    const buildClusterName = await getBuildClusterName({
                         annotations,
                         pipeline,
                         multiBuildClusterEnabled: String(this.multiBuildClusterEnabled) === 'true',
@@ -226,12 +225,12 @@ class BuildFactory extends BaseFactory {
                     });
 
                     // Create stage build if current job is stage setup
-                    const stageSetupJob = job.name.match(STAGE_SETUP_PATTERN);
+                    const nextStageName = getStageFromSetupJobName(job.name);
 
-                    if (stageSetupJob) {
+                    if (nextStageName) {
                         const stage = await stageFactory.get({
                             pipelineId: pipeline.id,
-                            name: stageSetupJob[1]
+                            name: nextStageName
                         });
 
                         await stageBuildFactory.create({
@@ -242,7 +241,7 @@ class BuildFactory extends BaseFactory {
                     }
 
                     // Set correct bookend key
-                    const bookendKey = await helper.getBookendKey({
+                    const bookendKey = await getBookendKey({
                         buildClusterName,
                         annotations,
                         pipeline,

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -11,6 +11,7 @@ const EXECUTOR_ANNOTATION = 'screwdriver.cd/executor';
 const EXECUTOR_ANNOTATION_BETA = 'beta.screwdriver.cd/executor';
 const SCM_ORG_REGEX = /^([^/]+)\/.*/;
 const STAGE_PREFIX = 'stage@';
+const STAGE_SETUP_PATTERN = /^stage@([\w-]+)(?::setup)$/; // stage@jobName:setup;
 
 /**
  * Get the value of the annotation that matches name
@@ -409,6 +410,17 @@ function getFullStageJobName({ stageName, jobName }) {
     return `${STAGE_PREFIX}${stageName}:${jobName}`;
 }
 
+/**
+ * Check if next job is stage setup job, get stage name from that name
+ * @param  {String} jobName               Job name
+ * @return {String}                       Stage name
+ */
+function getStageFromSetupJobName(jobName) {
+    const stageSetupJobName = jobName.match(STAGE_SETUP_PATTERN);
+
+    return stageSetupJobName ? stageSetupJobName[1] : null;
+}
+
 module.exports = {
     getAnnotations,
     convertToBool,
@@ -417,5 +429,6 @@ module.exports = {
     getBuildClusterName,
     getToken,
     getBookendKey,
-    getFullStageJobName
+    getFullStageJobName,
+    getStageFromSetupJobName
 };


### PR DESCRIPTION
## Context

Would be good to remove associated stage build during build remove.

## Objective

This PR removes stage build if current build getting removed is a build for a stage setup job.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2870, https://github.com/screwdriver-cd/screwdriver/pull/2870/files#r1448092703

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
