### PR TITLE
fix: use template id to list pipeline template versions

### DIFF
--- a/lib/pipelineTemplateVersionFactory.js
+++ b/lib/pipelineTemplateVersionFactory.js
@@ -162,7 +162,11 @@ class PipelineTemplateVersionFactory extends BaseFactory {
             return [];
         }
 
-        config.params.templateId = pipelineTemplateMeta.id;
+        config = {
+            params: {
+                templateId: pipelineTemplateMeta.id
+            }
+        };
 
         return super.list(config);
     }

--- a/lib/pipelineTemplateVersionFactory.js
+++ b/lib/pipelineTemplateVersionFactory.js
@@ -162,13 +162,11 @@ class PipelineTemplateVersionFactory extends BaseFactory {
             return [];
         }
 
-        config = {
+        return super.list({
             params: {
                 templateId: pipelineTemplateMeta.id
             }
-        };
-
-        return super.list(config);
+        });
     }
 
     /**


### PR DESCRIPTION
## Context

attempting to list pipeline template version would throw `Error: Invalid param "namespace"`
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
## Objective
we only need template id to list pipeline template, name and namespace are not necessary 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
