### PR TITLE
fix: refactor getWithMetadata in pipelineTemplateVersionFactory

### DIFF
--- a/lib/pipelineTemplateVersionFactory.js
+++ b/lib/pipelineTemplateVersionFactory.js
@@ -5,6 +5,7 @@ const BaseFactory = require('./baseFactory');
 const PipelineTemplateVersionModel = require('./pipelineTemplateVersion');
 
 const EXACT_VERSION_REGEX = schema.config.regex.EXACT_VERSION;
+const TEMPLATE_TAG_NAME_REGEX = schema.config.regex.TEMPLATE_TAG_NAME;
 const VERSION_REGEX = schema.config.regex.VERSION;
 let instance;
 
@@ -203,38 +204,48 @@ class PipelineTemplateVersionFactory extends BaseFactory {
     /**
      * Get a version of a pipeline template and template meta based on the criteria
      * @method getWithMetadata
-     * @param  {Object}     config               Config object
-     * @param  {Datastore}  config.datastore     Object that will perform operations on the datastore
-     * @param  {String}     [config.templateId]  The template id
-     * @param  {String}     config.name          The template name
-     * @param  {String}     config.namespace     The template namespace
-     * @param  {String}     config.version       The template version
-     * @param  {Factory}   templateMetaFactory  Template meta factory
-     * @return {Promise}                         {PipelineTemplateVersionModel, PipelineTemplateMetaModel}
+     * @param  {Object}     config                Config object
+     * @param  {String}     config.name           The template name
+     * @param  {String}     config.namespace      The template namespace
+     * @param  {String}     [config.version]      The template version
+     * @param  {String}     [config.versionOrTag] The template version or tag
+     * @param  {Factory}    templateMetaFactory   Template meta factory
+     * @param  {Factory}    [templateTagFactory]  Template tag factory
+     * @return {Promise}                          {PipelineTemplateVersionModel, PipelineTemplateMetaModel}
      */
-    async getWithMetadata(config, templateMetaFactory) {
+    async getWithMetadata(config, templateMetaFactory, templateTagFactory) {
         let pipelineTemplateMeta = {};
+        let templateVersion = config.version;
 
-        if (config.templateId) {
-            pipelineTemplateMeta = await templateMetaFactory.get({
-                id: config.templateId
-            });
-        } else {
-            pipelineTemplateMeta = await templateMetaFactory.get({
-                name: config.name,
-                namespace: config.namespace
-            });
-
-            if (pipelineTemplateMeta) {
-                config.templateId = pipelineTemplateMeta.id;
-            }
-        }
+        pipelineTemplateMeta = await templateMetaFactory.get({
+            name: config.name,
+            namespace: config.namespace
+        });
 
         if (!pipelineTemplateMeta) {
             return null;
         }
 
-        const pipelineTemplateVersion = await super.get(config);
+        if (config.versionOrTag && EXACT_VERSION_REGEX.test(config.versionOrTag)) {
+            templateVersion = config.versionOrTag;
+        } else if (config.versionOrTag && TEMPLATE_TAG_NAME_REGEX.test(config.versionOrTag)) {
+            const templateTag = await templateTagFactory.get({
+                name: config.name,
+                namespace: config.namespace,
+                tag: config.versionOrTag
+            });
+
+            if (!templateTag) {
+                return null;
+            }
+
+            templateVersion = templateTag.version;
+        }
+
+        const pipelineTemplateVersion = await super.get({
+            templateId: pipelineTemplateMeta.id,
+            version: templateVersion
+        });
 
         return { ...pipelineTemplateVersion, ...pipelineTemplateMeta };
     }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
getWithMetadata was used in https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/pipelines/templates/getVersion.js

but it would throw error because parameter `versionOrTag` was not handled
## Objective

refactored getWithMetadata, removed `templatedId` parameter because it was not being used anywhere
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
