### PR TITLE
fix(3024): template usage and metrics reporting to exclude archived jobs

### DIFF
--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -131,12 +131,12 @@ class JobFactory extends BaseFactory {
         return instance;
     }
 
-    getPipelineUsageCountForTemplates(templateIds) {
+    getPipelineUsageCountForTemplates(templateIds, jobIds) {
         const jobsQueryConfig = {
             queries: getQueries(this.datastore.prefix, PIPELINE_USAGE_COUNT_FOR_JOB_TEMPLATES),
             readOnly: true,
             replacements: {
-                templateIds
+                templateIds, jobIds
             },
             rawResponse: true
         };

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -136,7 +136,8 @@ class JobFactory extends BaseFactory {
             queries: getQueries(this.datastore.prefix, PIPELINE_USAGE_COUNT_FOR_JOB_TEMPLATES),
             readOnly: true,
             replacements: {
-                templateIds, jobIds
+                templateIds,
+                jobIds
             },
             rawResponse: true
         };

--- a/lib/jobFactory.js
+++ b/lib/jobFactory.js
@@ -131,13 +131,12 @@ class JobFactory extends BaseFactory {
         return instance;
     }
 
-    getPipelineUsageCountForTemplates(templateIds, jobIds) {
+    getPipelineUsageCountForTemplates(templateIds) {
         const jobsQueryConfig = {
             queries: getQueries(this.datastore.prefix, PIPELINE_USAGE_COUNT_FOR_JOB_TEMPLATES),
             readOnly: true,
             replacements: {
-                templateIds,
-                jobIds
+                templateIds
             },
             rawResponse: true
         };

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -3,17 +3,17 @@
 const Queries = {
     getPipelineUsageCountForJobTemplatesQuery: (
         tablePrefix = ''
-    ) => `SELECT COUNT(DISTINCT "pipelineId") as count, "templateId"
+    ) => `SELECT COUNT(DISTINCT "pipelineId") as count, "templateId", "id"
         FROM "${tablePrefix}jobs"
-        WHERE "templateId" IN (:templateIds)
-        GROUP BY "templateId"`,
+        WHERE "templateId" IN (:templateIds) AND "id" IN (:jobIds)
+        GROUP BY "templateId", "id"`,
 
     getPipelineUsageCountForJobTemplatesQueryMySql: (
         tablePrefix = ''
-    ) => `SELECT COUNT(DISTINCT pipelineId) as count, templateId
+    ) => `SELECT COUNT(DISTINCT pipelineId) as count, templateId, id
         FROM \`${tablePrefix}jobs\`
-        WHERE templateId IN (:templateIds)
-        GROUP BY templateId`,
+        WHERE templateId IN (:templateIds) AND id IN (:jobIds)
+        GROUP BY templateId, id`,
     // getBuildStatuses()
     getStatusesQuery: (tablePrefix = '') => `SELECT "id", "jobId", "status", "startTime", "endTime", "meta"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime", "meta",

--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -3,17 +3,17 @@
 const Queries = {
     getPipelineUsageCountForJobTemplatesQuery: (
         tablePrefix = ''
-    ) => `SELECT COUNT(DISTINCT "pipelineId") as count, "templateId", "id"
+    ) => `SELECT COUNT(DISTINCT "pipelineId") as count, "templateId"
         FROM "${tablePrefix}jobs"
-        WHERE "templateId" IN (:templateIds) AND "id" IN (:jobIds)
-        GROUP BY "templateId", "id"`,
+        WHERE "templateId" IN (:templateIds) AND "archived" = false
+        GROUP BY "templateId"`,
 
     getPipelineUsageCountForJobTemplatesQueryMySql: (
         tablePrefix = ''
-    ) => `SELECT COUNT(DISTINCT pipelineId) as count, templateId, id
+    ) => `SELECT COUNT(DISTINCT pipelineId) as count, templateId
         FROM \`${tablePrefix}jobs\`
-        WHERE templateId IN (:templateIds) AND id IN (:jobIds)
-        GROUP BY templateId, id`,
+        WHERE templateId IN (:templateIds) AND archived = false
+        GROUP BY templateId`,
     // getBuildStatuses()
     getStatusesQuery: (tablePrefix = '') => `SELECT "id", "jobId", "status", "startTime", "endTime", "meta"
         FROM (SELECT "id", "jobId", "status", "startTime", "endTime", "meta",

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -6,7 +6,6 @@ const schema = require('screwdriver-data-schema');
 const BaseFactory = require('./baseFactory');
 const Template = require('./template');
 const { parseTemplateConfigName } = require('./helper');
-const { initial } = require('lodash');
 const TEMPLATE_NAME_REGEX = schema.config.regex.FULL_TEMPLATE_NAME;
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const EXACT_VERSION_REGEX = schema.config.regex.EXACT_VERSION;
@@ -77,6 +76,7 @@ class TemplateFactory extends BaseFactory {
         // Use regex to filter out possible version
         // Note: not sure if we should expect no version or handle case where version is passed in
         const [, nameWithNamespace] = TEMPLATE_NAME_REGEX.exec(fullTemplateName);
+        console.log('nameWithNamespace', nameWithNamespace);
         const parsedTemplate = {
             name: nameWithNamespace
         };
@@ -249,6 +249,7 @@ class TemplateFactory extends BaseFactory {
      */
     listWithMetrics(config) {
         const { startTime, endTime, ...templateListConfig } = config;
+        console.log('templateListConfig', templateListConfig);
 
         return this.list(templateListConfig).then(templates => {
             if (templates.length === 0) {
@@ -266,55 +267,59 @@ class TemplateFactory extends BaseFactory {
             const templateIds = templates.map(t => t.id);
 
             // first need to get the job ids for the templates that are not archived
-            return jobFactory.list({
-                params: { templateId: templateIds, archived: false },
-                readOnly: true,
-                aggregationField: 'id'
-            }).then(jobs => {
-                // then use the jobIds and templateIds as the filters to get the metrics
-                const jobIds = jobs.map(j => j.id);
-                
-                const metricJobsListConfig = {
-                    params: { templateId: templateIds, id: jobIds },
+            return jobFactory
+                .list({
+                    params: { templateId: templateIds, archived: false },
                     readOnly: true,
-                    aggregationField: 'templateId'
-                };
-    
-                const metricBuildsListConfig = { ...metricJobsListConfig };
-                metricBuildsListConfig.params = { templateId: templateIds, jobId: jobIds };
-                if (startTime) {
-                    metricBuildsListConfig.startTime = startTime;
-                }
-                if (endTime) {
-                    metricBuildsListConfig.endTime = endTime;
-                }
-                
-                return Promise.all([
-                    jobFactory.list(metricJobsListConfig),
-                    buildFactory.list(metricBuildsListConfig),
-                    jobFactory.getPipelineUsageCountForTemplates(templateIds, jobIds)
-                ])
-            }).then(([jCount, bCount, pCount]) => {
-                return templates.map(t => {
-                    const jobCount = jCount.find(j => j.templateId === t.id);
-                    const buildCount = bCount.find(b => b.templateId === t.id);
-                    const pipelineCount = pCount.find(p => p.templateId === t.id);
+                    aggregationField: 'id'
+                })
+                .then(jobs => {
+                    // then use the jobIds and templateIds as the filters to get the metrics
+                    const jobIds = jobs.map(j => j.id);
 
-                    t.metrics = {
-                        jobs: {
-                            count: jobCount ? jobCount.count : 0
-                        },
-                        builds: {
-                            count: buildCount ? buildCount.count : 0
-                        },
-                        pipelines: {
-                            count: pipelineCount ? pipelineCount.count : 0
-                        }
+                    const metricJobsListConfig = {
+                        params: { templateId: templateIds, id: jobIds },
+                        readOnly: true,
+                        aggregationField: 'templateId'
                     };
 
-                    return t;
+                    const metricBuildsListConfig = { ...metricJobsListConfig };
+
+                    metricBuildsListConfig.params = { templateId: templateIds, jobId: jobIds };
+                    if (startTime) {
+                        metricBuildsListConfig.startTime = startTime;
+                    }
+                    if (endTime) {
+                        metricBuildsListConfig.endTime = endTime;
+                    }
+
+                    return Promise.all([
+                        jobFactory.list(metricJobsListConfig),
+                        buildFactory.list(metricBuildsListConfig),
+                        jobFactory.getPipelineUsageCountForTemplates(templateIds, jobIds)
+                    ]);
                 })
-            }); 
+                .then(([jCount, bCount, pCount]) => {
+                    return templates.map(t => {
+                        const jobCount = jCount.find(j => j.templateId === t.id);
+                        const buildCount = bCount.find(b => b.templateId === t.id);
+                        const pipelineCount = pCount.find(p => p.templateId === t.id);
+
+                        t.metrics = {
+                            jobs: {
+                                count: jobCount ? jobCount.count : 0
+                            },
+                            builds: {
+                                count: buildCount ? buildCount.count : 0
+                            },
+                            pipelines: {
+                                count: pipelineCount ? pipelineCount.count : 0
+                            }
+                        };
+
+                        return t;
+                    });
+                });
         });
     }
 
@@ -352,6 +357,7 @@ class TemplateFactory extends BaseFactory {
      */
     async getPipelineUsage(fullTemplateName) {
         const template = await this.getTemplate(fullTemplateName);
+
         if (!template) {
             throw new Error('Template does not exist');
         }
@@ -367,11 +373,9 @@ class TemplateFactory extends BaseFactory {
         const JobFactory = require('./jobFactory');
         const jobFactory = JobFactory.getInstance();
 
-        const pipelineIds = await jobFactory
-            .list(metricJobCountByPipelineListConfig)
-            .then(pipelines => {
-                return pipelines.map(p => p.pipelineId);
-            });
+        const pipelineIds = await jobFactory.list(metricJobCountByPipelineListConfig).then(pipelines => {
+            return pipelines.map(p => p.pipelineId);
+        });
 
         if (pipelineIds.length === 0) {
             return Promise.resolve([]);

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -265,60 +265,49 @@ class TemplateFactory extends BaseFactory {
 
             const templateIds = templates.map(t => t.id);
 
-            // first need to get the job ids that are not archived for the templates
-            return jobFactory
-                .list({
-                    params: { templateId: templateIds, archived: false },
-                    readOnly: true,
-                    aggregationField: 'id'
-                })
-                .then(jobs => {
-                    // then use the jobIds and templateIds as the filters to get the metrics
-                    const jobIds = jobs.map(j => j.id);
+            const metricJobsListConfig = {
+                params: { templateId: templateIds, archived: false },
+                readOnly: true,
+                aggregationField: 'templateId'
+            };
 
-                    const metricJobsListConfig = {
-                        params: { templateId: templateIds, id: jobIds },
-                        readOnly: true,
-                        aggregationField: 'templateId'
+            const metricBuildsListConfig = { ...metricJobsListConfig };
+
+            // archived is not an attribute of build, so we need to filter it out
+            // builds are historical data so no need to filter out builds from archived jobs
+            metricBuildsListConfig.params = { templateId: templateIds };
+            if (startTime) {
+                metricBuildsListConfig.startTime = startTime;
+            }
+            if (endTime) {
+                metricBuildsListConfig.endTime = endTime;
+            }
+
+            return Promise.all([
+                jobFactory.list(metricJobsListConfig),
+                buildFactory.list(metricBuildsListConfig),
+                jobFactory.getPipelineUsageCountForTemplates(templateIds)
+            ]).then(([jCount, bCount, pCount]) => {
+                return templates.map(t => {
+                    const jobCount = jCount.find(j => j.templateId === t.id);
+                    const buildCount = bCount.find(b => b.templateId === t.id);
+                    const pipelineCount = pCount.find(p => p.templateId === t.id);
+
+                    t.metrics = {
+                        jobs: {
+                            count: jobCount ? jobCount.count : 0
+                        },
+                        builds: {
+                            count: buildCount ? buildCount.count : 0
+                        },
+                        pipelines: {
+                            count: pipelineCount ? pipelineCount.count : 0
+                        }
                     };
 
-                    const metricBuildsListConfig = { ...metricJobsListConfig };
-
-                    metricBuildsListConfig.params = { templateId: templateIds, jobId: jobIds };
-                    if (startTime) {
-                        metricBuildsListConfig.startTime = startTime;
-                    }
-                    if (endTime) {
-                        metricBuildsListConfig.endTime = endTime;
-                    }
-
-                    return Promise.all([
-                        jobFactory.list(metricJobsListConfig),
-                        buildFactory.list(metricBuildsListConfig),
-                        jobFactory.getPipelineUsageCountForTemplates(templateIds)
-                    ]);
-                })
-                .then(([jCount, bCount, pCount]) => {
-                    return templates.map(t => {
-                        const jobCount = jCount.find(j => j.templateId === t.id);
-                        const buildCount = bCount.find(b => b.templateId === t.id);
-                        const pipelineCount = pCount.find(p => p.templateId === t.id);
-
-                        t.metrics = {
-                            jobs: {
-                                count: jobCount ? jobCount.count : 0
-                            },
-                            builds: {
-                                count: buildCount ? buildCount.count : 0
-                            },
-                            pipelines: {
-                                count: pipelineCount ? pipelineCount.count : 0
-                            }
-                        };
-
-                        return t;
-                    });
+                    return t;
                 });
+            });
         });
     }
 

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -76,7 +76,7 @@ class TemplateFactory extends BaseFactory {
         // Use regex to filter out possible version
         // Note: not sure if we should expect no version or handle case where version is passed in
         const [, nameWithNamespace] = TEMPLATE_NAME_REGEX.exec(fullTemplateName);
-        console.log('nameWithNamespace', nameWithNamespace);
+
         const parsedTemplate = {
             name: nameWithNamespace
         };
@@ -249,7 +249,6 @@ class TemplateFactory extends BaseFactory {
      */
     listWithMetrics(config) {
         const { startTime, endTime, ...templateListConfig } = config;
-        console.log('templateListConfig', templateListConfig);
 
         return this.list(templateListConfig).then(templates => {
             if (templates.length === 0) {

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -295,7 +295,7 @@ class TemplateFactory extends BaseFactory {
                     return Promise.all([
                         jobFactory.list(metricJobsListConfig),
                         buildFactory.list(metricBuildsListConfig),
-                        jobFactory.getPipelineUsageCountForTemplates(templateIds, jobIds)
+                        jobFactory.getPipelineUsageCountForTemplates(templateIds)
                     ]);
                 })
                 .then(([jCount, bCount, pCount]) => {

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -265,7 +265,7 @@ class TemplateFactory extends BaseFactory {
 
             const templateIds = templates.map(t => t.id);
 
-            // first need to get the job ids for the templates that are not archived
+            // first need to get the job ids that are not archived for the templates
             return jobFactory
                 .list({
                     params: { templateId: templateIds, archived: false },
@@ -363,7 +363,7 @@ class TemplateFactory extends BaseFactory {
 
         const { id } = template;
         const metricJobCountByPipelineListConfig = {
-            params: { templateId: id, archived: false },
+            params: { templateId: id, archived: false }, // only count non-archived jobs
             readOnly: true,
             aggregationField: 'pipelineId'
         };

--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -6,6 +6,7 @@ const schema = require('screwdriver-data-schema');
 const BaseFactory = require('./baseFactory');
 const Template = require('./template');
 const { parseTemplateConfigName } = require('./helper');
+const { initial } = require('lodash');
 const TEMPLATE_NAME_REGEX = schema.config.regex.FULL_TEMPLATE_NAME;
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE = schema.config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 const EXACT_VERSION_REGEX = schema.config.regex.EXACT_VERSION;
@@ -264,27 +265,37 @@ class TemplateFactory extends BaseFactory {
 
             const templateIds = templates.map(t => t.id);
 
-            const metricJobsListConfig = {
-                params: { templateId: templateIds },
+            // first need to get the job ids for the templates that are not archived
+            return jobFactory.list({
+                params: { templateId: templateIds, archived: false },
                 readOnly: true,
-                aggregationField: 'templateId'
-            };
-
-            const metricBuildsListConfig = { ...metricJobsListConfig };
-
-            if (startTime) {
-                metricBuildsListConfig.startTime = startTime;
-            }
-            if (endTime) {
-                metricBuildsListConfig.endTime = endTime;
-            }
-
-            return Promise.all([
-                jobFactory.list(metricJobsListConfig),
-                buildFactory.list(metricBuildsListConfig),
-                jobFactory.getPipelineUsageCountForTemplates(templateIds)
-            ]).then(([jCount, bCount, pCount]) =>
-                templates.map(t => {
+                aggregationField: 'id'
+            }).then(jobs => {
+                // then use the jobIds and templateIds as the filters to get the metrics
+                const jobIds = jobs.map(j => j.id);
+                
+                const metricJobsListConfig = {
+                    params: { templateId: templateIds, id: jobIds },
+                    readOnly: true,
+                    aggregationField: 'templateId'
+                };
+    
+                const metricBuildsListConfig = { ...metricJobsListConfig };
+                metricBuildsListConfig.params = { templateId: templateIds, jobId: jobIds };
+                if (startTime) {
+                    metricBuildsListConfig.startTime = startTime;
+                }
+                if (endTime) {
+                    metricBuildsListConfig.endTime = endTime;
+                }
+                
+                return Promise.all([
+                    jobFactory.list(metricJobsListConfig),
+                    buildFactory.list(metricBuildsListConfig),
+                    jobFactory.getPipelineUsageCountForTemplates(templateIds, jobIds)
+                ])
+            }).then(([jCount, bCount, pCount]) => {
+                return templates.map(t => {
                     const jobCount = jCount.find(j => j.templateId === t.id);
                     const buildCount = bCount.find(b => b.templateId === t.id);
                     const pipelineCount = pCount.find(p => p.templateId === t.id);
@@ -303,7 +314,7 @@ class TemplateFactory extends BaseFactory {
 
                     return t;
                 })
-            );
+            }); 
         });
     }
 
@@ -341,13 +352,13 @@ class TemplateFactory extends BaseFactory {
      */
     async getPipelineUsage(fullTemplateName) {
         const template = await this.getTemplate(fullTemplateName);
-
         if (!template) {
             throw new Error('Template does not exist');
         }
+
         const { id } = template;
         const metricJobCountByPipelineListConfig = {
-            params: { templateId: id },
+            params: { templateId: id, archived: false },
             readOnly: true,
             aggregationField: 'pipelineId'
         };
@@ -358,7 +369,9 @@ class TemplateFactory extends BaseFactory {
 
         const pipelineIds = await jobFactory
             .list(metricJobCountByPipelineListConfig)
-            .then(pipelines => pipelines.map(p => p.pipelineId));
+            .then(pipelines => {
+                return pipelines.map(p => p.pipelineId);
+            });
 
         if (pipelineIds.length === 0) {
             return Promise.resolve([]);

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -1141,7 +1141,7 @@ describe('Template Factory', () => {
             expected = [returnValue[0], returnValue[1], returnValue[2]];
             datastore.scan.resolves(expected);
             jobFactoryMock.list.resolves(jobsCount);
-            buildFactoryMock.list.resolves(buildsCount);
+            buildFactoryMock.list.onFirstCall().resolves(buildsCount);
             jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
 
             return factory.listWithMetrics(config).then(templates => {
@@ -1180,7 +1180,7 @@ describe('Template Factory', () => {
             expected = [returnValue[3]];
             datastore.scan.resolves(expected);
             buildFactoryMock.list.resolves(buildsCount);
-            jobFactoryMock.list.resolves(jobsCount);
+            jobFactoryMock.list.onFirstCall().resolves(jobsCount);
             jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
 
             delete config.namespace;
@@ -1220,7 +1220,7 @@ describe('Template Factory', () => {
                 expected = [returnValue[0], returnValue[1]];
                 datastore.scan.resolves(expected);
                 buildFactoryMock.list.resolves(buildsCount);
-                jobFactoryMock.list.resolves(jobsCount);
+                jobFactoryMock.list.onFirstCall().resolves(jobsCount);
                 jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
             });
 

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -979,7 +979,6 @@ describe('Template Factory', () => {
         let config;
         let expected;
         let returnValue;
-        let jobsCountByIds;
         let jobsCount;
         let buildsCount;
         let pipelineJobs;
@@ -992,21 +991,6 @@ describe('Template Factory', () => {
                     version: '1.0.2'
                 }
             };
-
-            jobsCountByIds = [
-                {
-                    id: 1,
-                    count: 1
-                },
-                {
-                    id: 2,
-                    count: 1
-                },
-                {
-                    id: 3,
-                    count: 1
-                }
-            ];
 
             jobsCount = [
                 {
@@ -1156,8 +1140,7 @@ describe('Template Factory', () => {
         it('should list templates with metrics when namespace is passed in', () => {
             expected = [returnValue[0], returnValue[1], returnValue[2]];
             datastore.scan.resolves(expected);
-            jobFactoryMock.list.onFirstCall().resolves(jobsCountByIds);
-            jobFactoryMock.list.onSecondCall().resolves(jobsCount);
+            jobFactoryMock.list.resolves(jobsCount);
             buildFactoryMock.list.resolves(buildsCount);
             jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
 
@@ -1176,19 +1159,13 @@ describe('Template Factory', () => {
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [1, 3, 2], jobId: [1, 2, 3] },
+                        params: { templateId: [1, 3, 2] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
-                    assert.calledWith(jobFactoryMock.list.firstCall, {
+                    assert.calledWith(jobFactoryMock.list, {
                         params: { templateId: [1, 3, 2], archived: false },
-                        readOnly: true,
-                        aggregationField: 'id'
-                    });
-
-                    assert.calledWith(jobFactoryMock.list.secondCall, {
-                        params: { templateId: [1, 3, 2], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
@@ -1203,8 +1180,7 @@ describe('Template Factory', () => {
             expected = [returnValue[3]];
             datastore.scan.resolves(expected);
             buildFactoryMock.list.resolves(buildsCount);
-            jobFactoryMock.list.onFirstCall().resolves(jobsCountByIds);
-            jobFactoryMock.list.onSecondCall().resolves(jobsCount);
+            jobFactoryMock.list.resolves(jobsCount);
             jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
 
             delete config.namespace;
@@ -1221,19 +1197,13 @@ describe('Template Factory', () => {
                 });
 
                 assert.calledWith(buildFactoryMock.list, {
-                    params: { templateId: [4], jobId: [1, 2, 3] },
+                    params: { templateId: [4] },
                     readOnly: true,
                     aggregationField: 'templateId'
                 });
 
-                assert.calledWith(jobFactoryMock.list.firstCall, {
+                assert.calledWith(jobFactoryMock.list, {
                     params: { templateId: [4], archived: false },
-                    readOnly: true,
-                    aggregationField: 'id'
-                });
-
-                assert.calledWith(jobFactoryMock.list.secondCall, {
-                    params: { templateId: [4], id: [1, 2, 3] },
                     readOnly: true,
                     aggregationField: 'templateId'
                 });
@@ -1250,8 +1220,7 @@ describe('Template Factory', () => {
                 expected = [returnValue[0], returnValue[1]];
                 datastore.scan.resolves(expected);
                 buildFactoryMock.list.resolves(buildsCount);
-                jobFactoryMock.list.onFirstCall().resolves(jobsCountByIds);
-                jobFactoryMock.list.onSecondCall().resolves(jobsCount);
+                jobFactoryMock.list.resolves(jobsCount);
                 jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
             });
 
@@ -1279,20 +1248,14 @@ describe('Template Factory', () => {
                         }
                     });
 
-                    assert.calledWith(jobFactoryMock.list.firstCall, {
+                    assert.calledWith(jobFactoryMock.list, {
                         params: { templateId: [returnValue[0].id, returnValue[1].id], archived: false },
-                        readOnly: true,
-                        aggregationField: 'id'
-                    });
-
-                    assert.calledWith(jobFactoryMock.list.secondCall, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id], jobId: [1, 2, 3] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         startTime,
@@ -1305,7 +1268,7 @@ describe('Template Factory', () => {
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [1, 3], jobId: [1, 2, 3] },
+                        params: { templateId: [1, 3] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         startTime: '2023-04-01T14:08',
@@ -1314,12 +1277,6 @@ describe('Template Factory', () => {
 
                     assert.calledWith(jobFactoryMock.list, {
                         params: { templateId: [1, 3], archived: false },
-                        readOnly: true,
-                        aggregationField: 'id'
-                    });
-
-                    assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [1, 3], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
@@ -1354,17 +1311,11 @@ describe('Template Factory', () => {
                     assert.calledWith(jobFactoryMock.list, {
                         params: { templateId: [returnValue[0].id, returnValue[1].id], archived: false },
                         readOnly: true,
-                        aggregationField: 'id'
-                    });
-
-                    assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id], id: [1, 2, 3] },
-                        readOnly: true,
                         aggregationField: 'templateId'
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id], jobId: [1, 2, 3] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         startTime
@@ -1398,17 +1349,11 @@ describe('Template Factory', () => {
                     assert.calledWith(jobFactoryMock.list, {
                         params: { templateId: [returnValue[0].id, returnValue[1].id], archived: false },
                         readOnly: true,
-                        aggregationField: 'id'
-                    });
-
-                    assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id], id: [1, 2, 3] },
-                        readOnly: true,
                         aggregationField: 'templateId'
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id], jobId: [1, 2, 3] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         endTime

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -1193,7 +1193,7 @@ describe('Template Factory', () => {
                         aggregationField: 'templateId'
                     });
 
-                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3, 2], [1, 2, 3]);
+                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3, 2]);
                     i += 1;
                 });
             });
@@ -1238,7 +1238,7 @@ describe('Template Factory', () => {
                     aggregationField: 'templateId'
                 });
 
-                assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [4], [1, 2, 3]);
+                assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [4]);
             });
         });
 
@@ -1324,7 +1324,7 @@ describe('Template Factory', () => {
                         aggregationField: 'templateId'
                     });
 
-                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3], [1, 2, 3]);
+                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3]);
                 });
             });
 

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -979,6 +979,7 @@ describe('Template Factory', () => {
         let config;
         let expected;
         let returnValue;
+        let jobsCountByIds;
         let jobsCount;
         let buildsCount;
         let pipelineJobs;
@@ -992,10 +993,25 @@ describe('Template Factory', () => {
                 }
             };
 
+            jobsCountByIds = [
+                {
+                    id: 1,
+                    count: 1
+                },
+                {
+                    id: 2,
+                    count: 1
+                },
+                {
+                    id: 3,
+                    count: 1
+                }
+            ];
+
             jobsCount = [
                 {
                     templateId: 1,
-                    count: 3
+                    count: 1
                 },
                 {
                     templateId: 2,
@@ -1008,10 +1024,6 @@ describe('Template Factory', () => {
                 {
                     templateId: 4,
                     count: 2
-                },
-                {
-                    templateId: 5,
-                    count: 7
                 }
             ];
 
@@ -1065,7 +1077,7 @@ describe('Template Factory', () => {
                     version: '1.0.1',
                     metrics: {
                         jobs: {
-                            count: 3
+                            count: 1
                         },
                         builds: {
                             count: 4
@@ -1144,8 +1156,9 @@ describe('Template Factory', () => {
         it('should list templates with metrics when namespace is passed in', () => {
             expected = [returnValue[0], returnValue[1], returnValue[2]];
             datastore.scan.resolves(expected);
+            jobFactoryMock.list.onFirstCall().resolves(jobsCountByIds);
+            jobFactoryMock.list.onSecondCall().resolves(jobsCount);
             buildFactoryMock.list.resolves(buildsCount);
-            jobFactoryMock.list.onFirstCall().resolves(jobsCount);
             jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
 
             return factory.listWithMetrics(config).then(templates => {
@@ -1163,18 +1176,24 @@ describe('Template Factory', () => {
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [1, 3, 2] },
+                        params: { templateId: [1, 3, 2], jobId: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
-                    assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [1, 3, 2] },
+                    assert.calledWith(jobFactoryMock.list.firstCall, {
+                        params: { templateId: [1, 3, 2], archived: false },
+                        readOnly: true,
+                        aggregationField: 'id'
+                    });
+
+                    assert.calledWith(jobFactoryMock.list.secondCall, {
+                        params: { templateId: [1, 3, 2], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
-                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3, 2]);
+                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3, 2], [1, 2, 3]);
                     i += 1;
                 });
             });
@@ -1184,7 +1203,8 @@ describe('Template Factory', () => {
             expected = [returnValue[3]];
             datastore.scan.resolves(expected);
             buildFactoryMock.list.resolves(buildsCount);
-            jobFactoryMock.list.onFirstCall().resolves(jobsCount);
+            jobFactoryMock.list.onFirstCall().resolves(jobsCountByIds);
+            jobFactoryMock.list.onSecondCall().resolves(jobsCount);
             jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
 
             delete config.namespace;
@@ -1201,18 +1221,24 @@ describe('Template Factory', () => {
                 });
 
                 assert.calledWith(buildFactoryMock.list, {
-                    params: { templateId: [4] },
+                    params: { templateId: [4], jobId: [1, 2, 3] },
                     readOnly: true,
                     aggregationField: 'templateId'
                 });
 
-                assert.calledWith(jobFactoryMock.list, {
-                    params: { templateId: [4] },
+                assert.calledWith(jobFactoryMock.list.firstCall, {
+                    params: { templateId: [4], archived: false },
+                    readOnly: true,
+                    aggregationField: 'id'
+                });
+
+                assert.calledWith(jobFactoryMock.list.secondCall, {
+                    params: { templateId: [4], id: [1, 2, 3] },
                     readOnly: true,
                     aggregationField: 'templateId'
                 });
 
-                assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [4]);
+                assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [4], [1, 2, 3]);
             });
         });
 
@@ -1224,7 +1250,8 @@ describe('Template Factory', () => {
                 expected = [returnValue[0], returnValue[1]];
                 datastore.scan.resolves(expected);
                 buildFactoryMock.list.resolves(buildsCount);
-                jobFactoryMock.list.onFirstCall().resolves(jobsCount);
+                jobFactoryMock.list.onFirstCall().resolves(jobsCountByIds);
+                jobFactoryMock.list.onSecondCall().resolves(jobsCount);
                 jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
             });
 
@@ -1252,26 +1279,33 @@ describe('Template Factory', () => {
                         }
                     });
 
-                    assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                    assert.calledWith(jobFactoryMock.list.firstCall, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], archived: false },
+                        readOnly: true,
+                        aggregationField: 'id'
+                    });
+
+                    assert.calledWith(jobFactoryMock.list.secondCall, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], jobId: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         startTime,
                         endTime
                     });
+
                     assert.calledWith(datastore.scan, {
                         table: 'templates',
                         params: { name: 'testTemplate', namespace: 'namespace', version: '1.0.2' }
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [1, 3] },
+                        params: { templateId: [1, 3], jobId: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         startTime: '2023-04-01T14:08',
@@ -1279,12 +1313,18 @@ describe('Template Factory', () => {
                     });
 
                     assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [1, 3] },
+                        params: { templateId: [1, 3], archived: false },
+                        readOnly: true,
+                        aggregationField: 'id'
+                    });
+
+                    assert.calledWith(jobFactoryMock.list, {
+                        params: { templateId: [1, 3], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
-                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3]);
+                    assert.calledWith(jobFactoryMock.getPipelineUsageCountForTemplates, [1, 3], [1, 2, 3]);
                 });
             });
 
@@ -1312,13 +1352,19 @@ describe('Template Factory', () => {
                     });
 
                     assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], archived: false },
+                        readOnly: true,
+                        aggregationField: 'id'
+                    });
+
+                    assert.calledWith(jobFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], jobId: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         startTime
@@ -1350,13 +1396,19 @@ describe('Template Factory', () => {
                     });
 
                     assert.calledWith(jobFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], archived: false },
+                        readOnly: true,
+                        aggregationField: 'id'
+                    });
+
+                    assert.calledWith(jobFactoryMock.list, {
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], id: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId'
                     });
 
                     assert.calledWith(buildFactoryMock.list, {
-                        params: { templateId: [returnValue[0].id, returnValue[1].id] },
+                        params: { templateId: [returnValue[0].id, returnValue[1].id], jobId: [1, 2, 3] },
                         readOnly: true,
                         aggregationField: 'templateId',
                         endTime
@@ -1520,7 +1572,7 @@ describe('Template Factory', () => {
                     table: 'templates'
                 });
                 assert.calledWith(jobFactoryMock.list, {
-                    params: { templateId: 1 },
+                    params: { templateId: 1, archived: false },
                     readOnly: true,
                     aggregationField: 'pipelineId'
                 });
@@ -1555,7 +1607,7 @@ describe('Template Factory', () => {
                     table: 'templates'
                 });
                 assert.calledWith(jobFactoryMock.list, {
-                    params: { templateId: 1 },
+                    params: { templateId: 1, archived: false },
                     readOnly: true,
                     aggregationField: 'pipelineId'
                 });

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -1140,8 +1140,8 @@ describe('Template Factory', () => {
         it('should list templates with metrics when namespace is passed in', () => {
             expected = [returnValue[0], returnValue[1], returnValue[2]];
             datastore.scan.resolves(expected);
-            jobFactoryMock.list.resolves(jobsCount);
-            buildFactoryMock.list.onFirstCall().resolves(buildsCount);
+            buildFactoryMock.list.resolves(buildsCount);
+            jobFactoryMock.list.onFirstCall().resolves(jobsCount);
             jobFactoryMock.getPipelineUsageCountForTemplates.resolves(pipelineJobs);
 
             return factory.listWithMetrics(config).then(templates => {


### PR DESCRIPTION
## Context
The current implementation of tracking the job template usage and metrics include the archived jobs which leads to wrong reporting. 

## Objective
Exclude archived jobs from the usage and metrics implementation.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3024

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
