### PR TITLE
fix(2767): Remove associated stage and stageBuilds when deleting pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1688,9 +1688,10 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     * Remove all jobs & builds associated with this pipeline,
-     * remove id from all associated collection and the pipeline itself
-     * @return {Promise}        Resolves to null if remove successfully
+     * Remove all jobs & builds and stages and stageBuilds (if applicable)
+     * associated with this pipeline, remove pipeline ID from all associated
+     * collections, and remove the pipeline itself
+     * @return {Promise}        Resolves to null if removed successfully
      */
     remove() {
         const pipelineFactory = this._getPipelineFactory();
@@ -1779,6 +1780,30 @@ class PipelineModel extends BaseModel {
             });
         };
 
+        const removeStagesAndStageBuilds = async () => {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const StageFactory = require('./stageFactory');
+            const StageBuildFactory = require('./stageBuildFactory');
+            /* eslint-enable global-require */
+
+            const stageFactory = StageFactory.getInstance();
+            const stageBuildFactory = StageBuildFactory.getInstance();
+
+            const stages = await stageFactory.list({ params: { pipelineId: this.id } });
+
+            logger.info(`pipelineId:${this.id}: Removing stages and stageBuilds.`);
+
+            stages.map(async s => {
+                const stageBuilds = await stageBuildFactory.list({ params: { stageId: s.id } });
+
+                await Promise.all(stageBuilds.map(sb => sb.remove()));
+            });
+
+            await Promise.all(stages.map(s => s.remove()));
+        };
+
         const removeFromCollections = () => {
             // Lazy load factory dependency to prevent circular dependency issues
             // https://nodejs.org/api/modules.html#modules_cycles
@@ -1826,6 +1851,7 @@ class PipelineModel extends BaseModel {
             .then(() => removeEvents('pipeline')) // remove pipeline events
             .then(() => removeEvents('pr')) // remove pr events
             .then(() => removeChildPipelines()) // remove pr events
+            .then(() => removeStagesAndStageBuilds()) // remove stages and stageBuilds
             .then(() => removeFromCollections())
             .then(() => super.remove()) // remove pipeline
             .catch(err => {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1752,6 +1752,15 @@ class PipelineModel extends BaseModel {
                 return Promise.all(tokens.map(t => t.remove()));
             });
 
+        const removeSecrets = () =>
+            this.secrets.then(secrets => {
+                const filteredSecrets = secrets.filter(secret => secret.pipelineId === this.id);
+
+                logger.info(`pipelineId:${this.id}: Removing secrets.`);
+
+                return Promise.all(filteredSecrets.map(secret => secret.remove()));
+            });
+
         const removeTriggers = () => {
             // Lazy load factory dependency to prevent circular dependency issues
             // https://nodejs.org/api/modules.html#modules_cycles
@@ -1790,17 +1799,14 @@ class PipelineModel extends BaseModel {
 
             const stageFactory = StageFactory.getInstance();
             const stageBuildFactory = StageBuildFactory.getInstance();
-
             const stages = await stageFactory.list({ params: { pipelineId: this.id } });
+            const stageIds = stages.map(s => s.id);
+            const stageBuilds = await stageBuildFactory.list({ params: { stageId: stageIds } });
 
             logger.info(`pipelineId:${this.id}: Removing stages and stageBuilds.`);
 
-            stages.map(async s => {
-                const stageBuilds = await stageBuildFactory.list({ params: { stageId: s.id } });
-
-                await Promise.all(stageBuilds.map(sb => sb.remove()));
-            });
-
+            // Remove all stageBuilds and stages
+            await Promise.all(stageBuilds.map(sb => sb.remove()));
             await Promise.all(stages.map(s => s.remove()));
         };
 
@@ -1835,15 +1841,7 @@ class PipelineModel extends BaseModel {
             });
         };
 
-        return this.secrets
-            .then(secrets => {
-                // remove secrets
-                const filteredSecrets = secrets.filter(secret => secret.pipelineId === this.id);
-
-                logger.info(`pipelineId:${this.id}: Removing secrets.`);
-
-                return Promise.all(filteredSecrets.map(secret => secret.remove()));
-            })
+        return removeSecrets() // remove secrets
             .then(() => removeTokens()) // remove tokens
             .then(() => removeTriggers()) // remove triggers
             .then(() => removeJobs(true)) // remove archived jobs

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -78,6 +78,7 @@ describe('Pipeline Model', () => {
     let childPipelineMock;
     let buildClusterFactory;
     let stageFactoryMock;
+    let stageBuildFactoryMock;
 
     const dateNow = 1111111111;
     const scmUri = 'github.com:12345:master';
@@ -128,6 +129,7 @@ describe('Pipeline Model', () => {
     };
 
     let stageMocks;
+    let stageBuildMocks;
 
     const decorateJobMock = job => {
         const decorated = hoek.clone(job);
@@ -151,9 +153,8 @@ describe('Pipeline Model', () => {
     const decorateStageMock = stage => {
         const decorated = hoek.clone(stage);
 
-        sinon.stub(decorated, 'update').callsFake(async () => {
-            return decorated;
-        });
+        decorated.update = sinon.stub().returns(decorated);
+        decorated.remove = sinon.stub().resolves(null);
 
         return decorated;
     };
@@ -164,6 +165,22 @@ describe('Pipeline Model', () => {
         }
 
         return decorateStageMock(s);
+    };
+
+    const decorateStageBuildMock = stageBuild => {
+        const decorated = hoek.clone(stageBuild);
+
+        decorated.remove = sinon.stub().resolves(null);
+
+        return decorated;
+    };
+
+    const getStageBuildMocks = sb => {
+        if (Array.isArray(sb)) {
+            return sb.map(decorateStageBuildMock);
+        }
+
+        return decorateStageBuildMock(sb);
     };
 
     before(() => {
@@ -323,8 +340,7 @@ describe('Pipeline Model', () => {
                 pipelineId: 123,
                 description: 'Old stage',
                 jobIds: [1, 2],
-                archived: false,
-                update() {}
+                archived: false
             },
             {
                 id: 8888,
@@ -332,8 +348,20 @@ describe('Pipeline Model', () => {
                 pipelineId: 123,
                 description: 'Canary deployment',
                 jobIds: [3, 4],
-                archived: false,
-                update() {}
+                archived: false
+            }
+        ]);
+
+        stageBuildMocks = getStageBuildMocks([
+            {
+                id: 555,
+                stageId: 123,
+                eventId: 888
+            },
+            {
+                id: 8888,
+                stageId: 123,
+                eventId: 888
             }
         ]);
 
@@ -348,6 +376,9 @@ describe('Pipeline Model', () => {
             get: sinon.stub().resolves({ id: 8888, name: 'canary' }),
             list: sinon.stub().resolves(stageMocks),
             create: sinon.stub().resolves({ id: 8889, name: 'deploy' })
+        };
+        stageBuildFactoryMock = {
+            list: sinon.stub().resolves(stageBuildMocks)
         };
         buildClusterFactory = {
             getInstance: sinon.stub().returns(buildClusterFactoryMock)
@@ -388,6 +419,9 @@ describe('Pipeline Model', () => {
         mockery.registerMock('./buildClusterFactory', buildClusterFactory);
         mockery.registerMock('./stageFactory', {
             getInstance: sinon.stub().returns(stageFactoryMock)
+        });
+        mockery.registerMock('./stageBuildFactory', {
+            getInstance: sinon.stub().returns(stageBuildFactoryMock)
         });
 
         // eslint-disable-next-line global-require
@@ -991,7 +1025,8 @@ describe('Pipeline Model', () => {
                     description: 'Old stage',
                     jobIds: [1, 2],
                     archived: true,
-                    update: stageMocks[0].update
+                    update: stageMocks[0].update,
+                    remove: stageMocks[0].remove
                 });
                 assert.calledOnce(stageMocks[1].update);
                 assert.deepEqual(stageMocks[1], {
@@ -1004,7 +1039,8 @@ describe('Pipeline Model', () => {
                     teardown: 6,
                     archived: false,
                     requires: ['~pr', '~commit', '~sd@12345:test'],
-                    update: stageMocks[1].update
+                    update: stageMocks[1].update,
+                    remove: stageMocks[1].remove
                 });
             });
         });
@@ -1560,10 +1596,6 @@ describe('Pipeline Model', () => {
                 archived: false,
                 parsePRJobName: sinon.stub().returns('main')
             };
-        });
-
-        afterEach(() => {
-            prJob.update.reset();
         });
 
         it('update PR config', () => {
@@ -3068,35 +3100,14 @@ describe('Pipeline Model', () => {
             triggerFactoryMock.list.resolves([trigger]);
         });
 
-        afterEach(() => {
-            eventFactoryMock.list.reset();
-            jobFactoryMock.list.reset();
-            secretFactoryMock.list.reset();
-            tokenFactoryMock.list.reset();
-            collectionFactoryMock.list.reset();
-            triggerFactoryMock.list.reset();
-            publishJob.remove.reset();
-            mainJob.remove.reset();
-            blahJob.remove.reset();
-            secret.remove.reset();
-            token.remove.reset();
-            trigger.remove.reset();
-        });
-
-        it('remove secrets', () =>
+        it('removes secrets, stages and stageBuilds, tokens, and triggers', () =>
             pipeline.remove().then(() => {
                 assert.calledOnce(secretFactoryMock.list);
                 assert.calledOnce(secret.remove);
-            }));
-
-        it('remove tokens', () =>
-            pipeline.remove().then(() => {
+                assert.calledOnce(stageFactoryMock.list);
+                assert.calledTwice(stageBuildFactoryMock.list);
                 assert.calledOnce(tokenFactoryMock.list);
                 assert.calledOnce(token.remove);
-            }));
-
-        it('remove triggers', () =>
-            pipeline.remove().then(() => {
                 assert.calledWith(triggerFactoryMock.list, { params: { dest: [] } });
                 assert.calledThrice(jobFactoryMock.list);
                 assert.calledOnce(triggerFactoryMock.list);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1598,6 +1598,10 @@ describe('Pipeline Model', () => {
             };
         });
 
+        afterEach(() => {
+            prJob.update.reset();
+        });
+
         it('update PR config', () => {
             jobFactoryMock.list.resolves([mainJob]); // pipeline jobs
             jobFactoryMock.getPullRequestJobsForPipelineSync.resolves([prJob]); // pull request jobs
@@ -3100,12 +3104,27 @@ describe('Pipeline Model', () => {
             triggerFactoryMock.list.resolves([trigger]);
         });
 
+        afterEach(() => {
+            eventFactoryMock.list.reset();
+            jobFactoryMock.list.reset();
+            secretFactoryMock.list.reset();
+            tokenFactoryMock.list.reset();
+            collectionFactoryMock.list.reset();
+            triggerFactoryMock.list.reset();
+            publishJob.remove.reset();
+            mainJob.remove.reset();
+            blahJob.remove.reset();
+            secret.remove.reset();
+            token.remove.reset();
+            trigger.remove.reset();
+        });
+
         it('removes secrets, stages and stageBuilds, tokens, and triggers', () =>
             pipeline.remove().then(() => {
                 assert.calledOnce(secretFactoryMock.list);
                 assert.calledOnce(secret.remove);
                 assert.calledOnce(stageFactoryMock.list);
-                assert.calledTwice(stageBuildFactoryMock.list);
+                assert.calledOnce(stageBuildFactoryMock.list);
                 assert.calledOnce(tokenFactoryMock.list);
                 assert.calledOnce(token.remove);
                 assert.calledWith(triggerFactoryMock.list, { params: { dest: [] } });


### PR DESCRIPTION
## Context

When a pipeline is deleted, the stages and the builds associated to the stages should be removed as well.

## Objective

This PR removes related stages and stageBuilds when pipeline is deleted.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3025

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
