### PR TITLE
fix(2767): Ensure stage exists before making call to stageBuildFactory in pipeline remove

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1801,13 +1801,16 @@ class PipelineModel extends BaseModel {
             const stageBuildFactory = StageBuildFactory.getInstance();
             const stages = await stageFactory.list({ params: { pipelineId: this.id } });
             const stageIds = stages.map(s => s.id);
-            const stageBuilds = await stageBuildFactory.list({ params: { stageId: stageIds } });
 
-            logger.info(`pipelineId:${this.id}: Removing stages and stageBuilds.`);
+            if (stageIds.length > 0) {
+                const stageBuilds = await stageBuildFactory.list({ params: { stageId: stageIds } });
 
-            // Remove all stageBuilds and stages
-            await Promise.all(stageBuilds.map(sb => sb.remove()));
-            await Promise.all(stages.map(s => s.remove()));
+                logger.info(`pipelineId:${this.id}: Removing stages and stageBuilds.`);
+
+                // Remove all stageBuilds and stages
+                await Promise.all(stageBuilds.map(sb => sb.remove()));
+                await Promise.all(stages.map(s => s.remove()));
+            }
         };
 
         const removeFromCollections = () => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -3108,6 +3108,8 @@ describe('Pipeline Model', () => {
             eventFactoryMock.list.reset();
             jobFactoryMock.list.reset();
             secretFactoryMock.list.reset();
+            stageFactoryMock.list.reset();
+            stageBuildFactoryMock.list.reset();
             tokenFactoryMock.list.reset();
             collectionFactoryMock.list.reset();
             triggerFactoryMock.list.reset();
@@ -3132,6 +3134,23 @@ describe('Pipeline Model', () => {
                 assert.calledOnce(triggerFactoryMock.list);
                 assert.calledOnce(trigger.remove);
             }));
+
+        it('does not remove stage or stageBuilds if stages does not exist', () => {
+            stageFactoryMock.list.resolves([]);
+
+            return pipeline.remove().then(() => {
+                assert.calledOnce(secretFactoryMock.list);
+                assert.calledOnce(secret.remove);
+                assert.calledOnce(stageFactoryMock.list);
+                assert.notCalled(stageBuildFactoryMock.list);
+                assert.calledOnce(tokenFactoryMock.list);
+                assert.calledOnce(token.remove);
+                assert.calledWith(triggerFactoryMock.list, { params: { dest: [] } });
+                assert.calledThrice(jobFactoryMock.list);
+                assert.calledOnce(triggerFactoryMock.list);
+                assert.calledOnce(trigger.remove);
+            });
+        });
 
         it('remove jobs recursively', () => {
             const nonArchivedMatcher = sinon.match(function (value) {


### PR DESCRIPTION
## Context

Should check if pipeline has any stages before making a call to fetch stageBuilds.

## Objective

This PR adds a check to make sure stage exists before making call to stageBuildFactory in pipeline remove.

## References

Related to https://github.com/screwdriver-cd/models/pull/613/files#r1491815680, https://github.com/screwdriver-cd/screwdriver/issues/3025

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
