### PR TITLE
fix: remove mockery usage in test

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "mocha": "^10.1.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "mockery": "^2.1.0",
     "nyc": "^15.1.0",
     "path": "^0.12.7",
     "rewire": "^6.0.0",
+    "rewiremock": "^3.14.4",
     "sinon": "^15.0.0"
   },
   "dependencies": {

--- a/test/lib/banner.test.js
+++ b/test/lib/banner.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -15,10 +14,6 @@ describe('Banner Model', () => {
     let banner;
 
     before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
         datastore = {
             update: sinon.stub(),
             remove: sinon.stub().resolves(null)
@@ -39,11 +34,6 @@ describe('Banner Model', () => {
             message: 'Screwdriver banner message'
         };
         banner = new BannerModel(createConfig);
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/bannerFactory.test.js
+++ b/test/lib/bannerFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -23,13 +22,6 @@ describe('Banner Factory', () => {
     let factory;
     let Banner;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -42,15 +34,6 @@ describe('Banner Factory', () => {
         /* eslint-disable global-require */
 
         factory = new BannerFactory({ datastore });
-    });
-
-    afterEach(() => {
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -169,6 +152,10 @@ describe('Banner Factory', () => {
             /* eslint-enable global-require */
         });
 
+        it('should throw an error when config not supplied', () => {
+            assert.throws(() => BannerFactory.getInstance(), 'No datastore provided to BannerFactory');
+        });
+
         it('should get an instance', () => {
             const f1 = BannerFactory.getInstance(config);
             const f2 = BannerFactory.getInstance(config);
@@ -177,10 +164,6 @@ describe('Banner Factory', () => {
             assert.instanceOf(f2, BannerFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw an error when config not supplied', () => {
-            assert.throw(BannerFactory.getInstance, Error, 'No datastore provided to BannerFactory');
         });
     });
 });

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
+const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -14,13 +14,6 @@ describe('Base Model', () => {
     let config;
     let scm;
     let multiBuildClusterEnabled;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         scm = {
@@ -42,10 +35,10 @@ describe('Base Model', () => {
                 }
             }
         };
-        mockery.registerMock('screwdriver-data-schema', schemaMock);
 
-        // eslint-disable-next-line global-require
-        BaseModel = require('../../lib/base');
+        BaseModel = rewiremock.proxy('../../lib/base', {
+            'screwdriver-data-schema': schemaMock
+        });
 
         config = {
             datastore,
@@ -61,12 +54,6 @@ describe('Base Model', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     describe('constructor', () => {

--- a/test/lib/baseFactory.test.js
+++ b/test/lib/baseFactory.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
+const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
 
 /* eslint max-classes-per-file: ["error", 2] */
@@ -24,13 +24,6 @@ describe('Base Factory', () => {
     let factory;
     let schema;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         scm = {};
         datastore = {
@@ -49,22 +42,15 @@ describe('Base Factory', () => {
             }
         };
 
-        mockery.registerMock('screwdriver-data-schema', schema);
-
-        // eslint-disable-next-line global-require
-        BaseFactory = require('../../lib/baseFactory');
+        BaseFactory = rewiremock.proxy('../../lib/baseFactory', {
+            'screwdriver-data-schema': schema
+        });
 
         factory = new BaseFactory('base', { datastore, scm });
     });
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     describe('createClass', () => {

--- a/test/lib/buildCluster.test.js
+++ b/test/lib/buildCluster.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -15,10 +14,6 @@ describe('BuildCluster Model', () => {
     let buildCluster;
 
     before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
         datastore = {
             update: sinon.stub(),
             remove: sinon.stub().resolves(null)
@@ -42,11 +37,6 @@ describe('BuildCluster Model', () => {
             managedByScrewdriver: true
         };
         buildCluster = new BuildClusterModel(createConfig);
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/buildClusterFactory.test.js
+++ b/test/lib/buildClusterFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -31,13 +30,6 @@ describe('BuildCluster Factory', () => {
     let factory;
     let BuildCluster;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -50,15 +42,6 @@ describe('BuildCluster Factory', () => {
         /* eslint-disable global-require */
 
         factory = new BuildClusterFactory({ datastore });
-    });
-
-    afterEach(() => {
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -145,6 +128,10 @@ describe('BuildCluster Factory', () => {
             /* eslint-enable global-require */
         });
 
+        it('should throw an error when config not supplied', () => {
+            assert.throw(BuildClusterFactory.getInstance, Error, 'No datastore provided to BuildClusterFactory');
+        });
+
         it('should get an instance', () => {
             const f1 = BuildClusterFactory.getInstance(config);
             const f2 = BuildClusterFactory.getInstance(config);
@@ -153,10 +140,6 @@ describe('BuildCluster Factory', () => {
             assert.instanceOf(f2, BuildClusterFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw an error when config not supplied', () => {
-            assert.throw(BuildClusterFactory.getInstance, Error, 'No datastore provided to BuildClusterFactory');
         });
     });
 });

--- a/test/lib/collection.test.js
+++ b/test/lib/collection.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -15,10 +14,6 @@ describe('Collection Model', () => {
     let collection;
 
     before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
         datastore = {
             update: sinon.stub(),
             remove: sinon.stub().resolves(null)
@@ -42,11 +37,6 @@ describe('Collection Model', () => {
             pipelineIds: [12, 34, 56]
         };
         collection = new CollectionModel(createConfig);
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/collectionFactory.test.js
+++ b/test/lib/collectionFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -34,13 +33,6 @@ describe('Collection Factory', () => {
     let factory;
     let Collection;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -53,15 +45,6 @@ describe('Collection Factory', () => {
         /* eslint-disable global-require */
 
         factory = new CollectionFactory({ datastore });
-    });
-
-    afterEach(() => {
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -156,6 +139,10 @@ describe('Collection Factory', () => {
             /* eslint-enable global-require */
         });
 
+        it('should throw an error when config not supplied', () => {
+            assert.throw(CollectionFactory.getInstance, Error, 'No datastore provided to CollectionFactory');
+        });
+
         it('should get an instance', () => {
             const f1 = CollectionFactory.getInstance(config);
             const f2 = CollectionFactory.getInstance(config);
@@ -164,10 +151,6 @@ describe('Collection Factory', () => {
             assert.instanceOf(f2, CollectionFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw an error when config not supplied', () => {
-            assert.throw(CollectionFactory.getInstance, Error, 'No datastore provided to CollectionFactory');
         });
     });
 });

--- a/test/lib/command.test.js
+++ b/test/lib/command.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 const schema = require('screwdriver-data-schema');
 
@@ -13,13 +12,6 @@ describe('Command Model', () => {
     let command;
     let BaseModel;
     let createConfig;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {};
@@ -53,16 +45,6 @@ describe('Command Model', () => {
             pipelineId: '8765'
         };
         command = new CommandModel(createConfig);
-    });
-
-    afterEach(() => {
-        datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/commandFactory.test.js
+++ b/test/lib/commandFactory.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
+const rewiremock = require('rewiremock/node');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -37,13 +37,6 @@ describe('Command Factory', () => {
     let factory;
     let Command;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -55,9 +48,10 @@ describe('Command Factory', () => {
             get: sinon.stub()
         };
 
-        mockery.registerMock('./commandTagFactory', {
+        rewiremock('../../lib/commandTagFactory').with({
             getInstance: sinon.stub().returns(commandTagFactoryMock)
         });
+        rewiremock.enable();
 
         /* eslint-disable global-require */
         Command = require('../../lib/command');
@@ -69,12 +63,7 @@ describe('Command Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
+        rewiremock.disable();
     });
 
     describe('createClass', () => {

--- a/test/lib/commandTag.test.js
+++ b/test/lib/commandTag.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -13,13 +12,6 @@ describe('CommandTag Model', () => {
     let datastore;
     let createConfig;
     let commandTag;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {
@@ -45,12 +37,6 @@ describe('CommandTag Model', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/commandTagFactory.test.js
+++ b/test/lib/commandTagFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -22,13 +21,6 @@ describe('CommandTag Factory', () => {
     let factory;
     let CommandTag;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -46,12 +38,6 @@ describe('CommandTag Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -102,6 +88,10 @@ describe('CommandTag Factory', () => {
             config = { datastore };
         });
 
+        it('should throw when config not supplied', () => {
+            assert.throw(CommandTagFactory.getInstance, Error, 'No datastore provided to CommandTagFactory');
+        });
+
         it('should get an instance', () => {
             const f1 = CommandTagFactory.getInstance(config);
             const f2 = CommandTagFactory.getInstance(config);
@@ -110,10 +100,6 @@ describe('CommandTag Factory', () => {
             assert.instanceOf(f2, CommandTagFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw when config not supplied', () => {
-            assert.throw(CommandTagFactory.getInstance, Error, 'No datastore provided to CommandTagFactory');
         });
     });
 });

--- a/test/lib/pipelineTemplateVersionFactory.test.js
+++ b/test/lib/pipelineTemplateVersionFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -22,13 +21,6 @@ describe('PipelineTemplateVersion Factory', () => {
     let PipelineTemplateVersion;
     let PipelineTemplateMeta;
     let templateMetaFactoryMock;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {
@@ -54,12 +46,6 @@ describe('PipelineTemplateVersion Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -485,6 +471,14 @@ describe('PipelineTemplateVersion Factory', () => {
             config = { datastore };
         });
 
+        it('should throw when config not supplied', () => {
+            assert.throw(
+                PipelineTemplateVersionFactory.getInstance,
+                Error,
+                'No datastore provided to PipelineTemplateVersionFactory'
+            );
+        });
+
         it('should get an instance', () => {
             const f1 = PipelineTemplateVersionFactory.getInstance(config);
             const f2 = PipelineTemplateVersionFactory.getInstance(config);
@@ -493,14 +487,6 @@ describe('PipelineTemplateVersion Factory', () => {
             assert.instanceOf(f2, PipelineTemplateVersionFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw when config not supplied', () => {
-            assert.throw(
-                PipelineTemplateVersionFactory.getInstance,
-                Error,
-                'No datastore provided to PipelineTemplateVersionFactory'
-            );
         });
     });
 });

--- a/test/lib/secret.test.js
+++ b/test/lib/secret.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { assert } = require('chai');
+const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -16,13 +16,6 @@ describe('Secret Model', () => {
     let createConfig;
     let secret;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             update: sinon.stub()
@@ -33,13 +26,12 @@ describe('Secret Model', () => {
             defaults: {}
         };
 
-        mockery.registerMock('@hapi/iron', ironMock);
-
         // eslint-disable-next-line global-require
         BaseModel = require('../../lib/base');
 
-        // eslint-disable-next-line global-require
-        SecretModel = require('../../lib/secret');
+        SecretModel = rewiremock.proxy('../../lib/secret', {
+            '@hapi/iron': ironMock
+        });
 
         createConfig = {
             datastore,
@@ -55,12 +47,6 @@ describe('Secret Model', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/stage.test.js
+++ b/test/lib/stage.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -13,13 +12,6 @@ describe('Stage Model', () => {
     let datastore;
     let createConfig;
     let stage;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {
@@ -43,12 +35,6 @@ describe('Stage Model', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/stageFactory.test.js
+++ b/test/lib/stageFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -21,13 +20,6 @@ describe('Stage Factory', () => {
     let factory;
     let Stage;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -45,12 +37,6 @@ describe('Stage Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -98,6 +84,10 @@ describe('Stage Factory', () => {
             config = { datastore };
         });
 
+        it('should throw when config not supplied', () => {
+            assert.throw(StageFactory.getInstance, Error, 'No datastore provided to StageFactory');
+        });
+
         it('should get an instance', () => {
             const f1 = StageFactory.getInstance(config);
             const f2 = StageFactory.getInstance(config);
@@ -106,10 +96,6 @@ describe('Stage Factory', () => {
             assert.instanceOf(f2, StageFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw when config not supplied', () => {
-            assert.throw(StageFactory.getInstance, Error, 'No datastore provided to StageFactory');
         });
     });
 });

--- a/test/lib/step.test.js
+++ b/test/lib/step.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -15,10 +14,6 @@ describe('Step Model', () => {
     let step;
 
     before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
         datastore = {
             update: sinon.stub(),
             remove: sinon.stub().resolves(null)
@@ -39,11 +34,6 @@ describe('Step Model', () => {
             message: 'Screwdriver step message'
         };
         step = new StepModel(createConfig);
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/stepFactory.test.js
+++ b/test/lib/stepFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 const { DELETE_STEPS_QUERY, getQueries } = require('../../lib/rawQueries');
 
@@ -24,13 +23,6 @@ describe('Step Factory', () => {
     let factory;
     let Step;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -44,15 +36,6 @@ describe('Step Factory', () => {
         /* eslint-disable global-require */
 
         factory = new StepFactory({ datastore });
-    });
-
-    afterEach(() => {
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -108,6 +91,10 @@ describe('Step Factory', () => {
             /* eslint-enable global-require */
         });
 
+        it('should throw an error when config not supplied', () => {
+            assert.throw(StepFactory.getInstance, Error, 'No datastore provided to StepFactory');
+        });
+
         it('should get an instance', () => {
             const f1 = StepFactory.getInstance(config);
             const f2 = StepFactory.getInstance(config);
@@ -116,10 +103,6 @@ describe('Step Factory', () => {
             assert.instanceOf(f2, StepFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw an error when config not supplied', () => {
-            assert.throw(StepFactory.getInstance, Error, 'No datastore provided to StepFactory');
         });
     });
 

--- a/test/lib/template.test.js
+++ b/test/lib/template.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -13,13 +12,6 @@ describe('Template Model', () => {
     let datastore;
     let createConfig;
     let template;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {
@@ -48,12 +40,6 @@ describe('Template Model', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert, expect } = require('chai');
-const mockery = require('mockery');
+const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -34,13 +34,6 @@ describe('Template Factory', () => {
     let pipelineFactoryMock;
     let eventFactoryMock;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -65,21 +58,22 @@ describe('Template Factory', () => {
             list: sinon.stub()
         };
 
-        mockery.registerMock('./templateTagFactory', {
+        rewiremock('../../lib/templateTagFactory').with({
             getInstance: sinon.stub().returns(templateTagFactoryMock)
         });
-        mockery.registerMock('./jobFactory', {
+        rewiremock('../../lib/jobFactory').with({
             getInstance: sinon.stub().returns(jobFactoryMock)
         });
-        mockery.registerMock('./buildFactory', {
+        rewiremock('../../lib/buildFactory').with({
             getInstance: sinon.stub().returns(buildFactoryMock)
         });
-        mockery.registerMock('./pipelineFactory', {
+        rewiremock('../../lib/pipelineFactory').with({
             getInstance: sinon.stub().returns(pipelineFactoryMock)
         });
-        mockery.registerMock('./eventFactory', {
+        rewiremock('../../lib/eventFactory').with({
             getInstance: sinon.stub().returns(eventFactoryMock)
         });
+        rewiremock.enable();
 
         /* eslint-disable global-require */
         Template = require('../../lib/template');
@@ -91,12 +85,7 @@ describe('Template Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
+        rewiremock.disable();
     });
 
     describe('createClass', () => {

--- a/test/lib/templateTag.test.js
+++ b/test/lib/templateTag.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -13,13 +12,6 @@ describe('TemplateTag Model', () => {
     let datastore;
     let createConfig;
     let templateTag;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {
@@ -44,12 +36,6 @@ describe('TemplateTag Model', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/templateTagFactory.test.js
+++ b/test/lib/templateTagFactory.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -22,13 +21,6 @@ describe('TemplateTag Factory', () => {
     let factory;
     let TemplateTag;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -46,12 +38,6 @@ describe('TemplateTag Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     describe('createClass', () => {
@@ -378,6 +364,10 @@ describe('TemplateTag Factory', () => {
             config = { datastore };
         });
 
+        it('should throw when config not supplied', () => {
+            assert.throw(TemplateTagFactory.getInstance, Error, 'No datastore provided to TemplateTagFactory');
+        });
+
         it('should get an instance', () => {
             const f1 = TemplateTagFactory.getInstance(config);
             const f2 = TemplateTagFactory.getInstance(config);
@@ -386,10 +376,6 @@ describe('TemplateTag Factory', () => {
             assert.instanceOf(f2, TemplateTagFactory);
 
             assert.equal(f1, f2);
-        });
-
-        it('should throw when config not supplied', () => {
-            assert.throw(TemplateTagFactory.getInstance, Error, 'No datastore provided to TemplateTagFactory');
         });
     });
 });

--- a/test/lib/tokenFactory.test.js
+++ b/test/lib/tokenFactory.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
+const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -36,10 +36,6 @@ describe('Token Factory', () => {
     let Token;
 
     before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
         generateTokenMock = {
             generateValue: sinon.stub(),
             hashValue: sinon.stub()
@@ -47,8 +43,6 @@ describe('Token Factory', () => {
 
         generateTokenMock.generateValue.resolves(randomBytes);
         generateTokenMock.hashValue.resolves(hash);
-
-        mockery.registerMock('./generateToken', generateTokenMock);
     });
 
     beforeEach(() => {
@@ -56,7 +50,8 @@ describe('Token Factory', () => {
             save: sinon.stub(),
             get: sinon.stub()
         };
-
+        rewiremock('../../lib/generateToken').with(generateTokenMock);
+        rewiremock.enable();
         /* eslint-disable global-require */
         Token = require('../../lib/token');
         TokenFactory = require('../../lib/tokenFactory');
@@ -66,12 +61,7 @@ describe('Token Factory', () => {
     });
 
     afterEach(() => {
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.deregisterAll();
-        mockery.disable();
+        rewiremock.disable();
     });
 
     describe('createClass', () => {

--- a/test/lib/trigger.test.js
+++ b/test/lib/trigger.test.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
 const schema = require('screwdriver-data-schema');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -13,13 +12,6 @@ describe('Trigger Model', () => {
     let datastore;
     let createConfig;
     let trigger;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {
@@ -43,12 +35,6 @@ describe('Trigger Model', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('is constructed properly', () => {

--- a/test/lib/triggerFactory.test.js
+++ b/test/lib/triggerFactory.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
+const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -57,13 +57,6 @@ describe('Trigger Factory', () => {
         }
     ];
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
         datastore = {
             save: sinon.stub(),
@@ -112,10 +105,10 @@ describe('Trigger Factory', () => {
             }
         };
 
-        mockery.registerMock('./pipelineFactory', {
+        rewiremock('../../lib/pipelineFactory').with({
             getInstance: sinon.stub().returns(pipelineFactoryMock)
         });
-
+        rewiremock.enable();
         // eslint-disable-next-line global-require
         Trigger = require('../../lib/trigger');
         // eslint-disable-next-line global-require
@@ -126,12 +119,7 @@ describe('Trigger Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
+        rewiremock.disable();
     });
 
     describe('createClass', () => {

--- a/test/lib/userFactory.test.js
+++ b/test/lib/userFactory.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const mockery = require('mockery');
+const rewiremock = require('rewiremock/node');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -15,13 +15,6 @@ describe('User Factory', () => {
     let tokenFactoryMock;
     let factory;
     let User;
-
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
 
     beforeEach(() => {
         datastore = {
@@ -40,11 +33,11 @@ describe('User Factory', () => {
             get: sinon.stub()
         };
 
-        mockery.registerMock('screwdriver-hashr', hashaMock);
-        mockery.registerMock('@hapi/iron', ironMock);
-        mockery.registerMock('./tokenFactory', {
+        rewiremock('@hapi/iron').with(ironMock);
+        rewiremock('../../lib/tokenFactory').with({
             getInstance: sinon.stub().returns(tokenFactoryMock)
         });
+        rewiremock.enable();
 
         // eslint-disable-next-line global-require
         User = require('../../lib/user');
@@ -56,12 +49,7 @@ describe('User Factory', () => {
 
     afterEach(() => {
         datastore = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
+        rewiremock.disable();
     });
 
     describe('createClass', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
mockery massively slows down test running time
<img width="166" alt="Screenshot 2024-02-22 at 11 30 00 AM" src="https://github.com/screwdriver-cd/models/assets/55161078/a74ee1b3-d32d-4fde-a06a-39e5abbad902">
https://cd.screwdriver.cd/pipelines/9/builds/923945
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
replace it with rewiremock
<img width="102" alt="Screenshot 2024-02-22 at 11 30 13 AM" src="https://github.com/screwdriver-cd/models/assets/55161078/22eb865d-fdbf-4403-b71c-528a9d03feda">
https://cd.screwdriver.cd/pipelines/9/builds/925042
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
