### PR TITLE
fix: Add getBuilds method for pipeline model [1]

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -54,9 +54,9 @@ class EventModel extends BaseModel {
         /* eslint-disable global-require */
         const BuildFactory = require('./buildFactory');
         /* eslint-enable global-require */
-        const factory = BuildFactory.getInstance();
+        const buildFactory = BuildFactory.getInstance();
 
-        return factory.list(listConfig);
+        return buildFactory.list(listConfig);
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -20,7 +20,7 @@ const MAX_EVENT_DELETE_COUNT = 100;
 // The default page for fetching not by aggregatedInteval
 // And the start page for fetching by aggregatedInteval
 const DEFAULT_PAGE = 1;
-const DEFAULT_COUNT = 50;
+const DEFAULT_COUNT = 10;
 const SCM_NO_ACCESS_STATUSES = [401, 404];
 
 const { getAllRecords, getBuildClusterName, getFullStageJobName } = require('./helper');
@@ -1663,6 +1663,7 @@ class PipelineModel extends BaseModel {
      * Fetch builds belonging to a pipeline or events
      * @param  {Object}   [config]
      * @param  {Number}   [config.sort]                         Sort rangekey by ascending or descending
+     * @param  {Number}   [config.sortBy]                       Sortby field
      * @param  {Object}   [config.paginate]                     Pagination parameters
      * @param  {Number}   [config.paginate.count]               Number of items per page
      * @param  {Number}   [config.paginate.page]                Specific page of the set to return
@@ -1670,7 +1671,8 @@ class PipelineModel extends BaseModel {
      * @param  {Boolean}  [config.latest]                       If we want to return latest in groupEventId, default false
      * @return {Promise}  Resolves to an array of builds
      */
-    async getBuilds(config) {
+    async getBuilds(config = {}) {
+        const { sort } = config;
         const latest = hoek.reach(config, 'params.latest');
         const groupEventId = hoek.reach(config, 'params.groupEventId');
 
@@ -1717,9 +1719,9 @@ class PipelineModel extends BaseModel {
         const defaultConfig = {
             params: { pipelineId: this.id },
             paginate: {
-                count: DEFAULT_COUNT,
-                page: DEFAULT_PAGE
-            }
+                count: DEFAULT_COUNT
+            },
+            sort: sort ? sort.toLowerCase() : 'descending' // Sort by primary sort key
         };
         const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1715,7 +1715,7 @@ class PipelineModel extends BaseModel {
             delete config.params.latest;
         }
 
-        // Fetch builds for this pipeline with default count and page
+        // Fetch builds for this pipeline with default count and page (implicitly set to 1)
         const defaultConfig = {
             params: { pipelineId: this.id },
             paginate: {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1659,6 +1659,75 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Fetch builds belonging to a pipeline or events
+     * @param  {Object}   [config]
+     * @param  {Number}   [config.sort]                         Sort rangekey by ascending or descending
+     * @param  {Object}   [config.paginate]                     Pagination parameters
+     * @param  {Number}   [config.paginate.count]               Number of items per page
+     * @param  {Number}   [config.paginate.page]                Specific page of the set to return
+     * @param  {Number}   [config.groupEventId]                 Group event ID
+     * @param  {Boolean}  [config.latest]                       If we want to return latest in groupEventId, default false
+     * @return {Promise}  Resolves to an array of builds
+     */
+    async getBuilds(config) {
+        const latest = hoek.reach(config, 'params.latest');
+        const groupEventId = hoek.reach(config, 'params.groupEventId');
+
+        // Fetch all builds for each event with same groupEventId
+        if (groupEventId && !latest) {
+            // Lazy load factory dependency to prevent circular dependency issues
+            // https://nodejs.org/api/modules.html#modules_cycles
+            /* eslint-disable global-require */
+            const EventFactory = require('./eventFactory');
+            /* eslint-enable global-require */
+            const eventFactory = EventFactory.getInstance();
+
+            const events = await eventFactory.list({
+                params: { groupEventId }
+            });
+
+            if (Array.isArray(events) && events.length > 0) {
+                const processed = [];
+
+                events.forEach(e => processed.push(e.getBuilds()));
+
+                return Promise.all(processed).then(builds => {
+                    // flatten array of arrays
+                    return builds.flat(1);
+                });
+            }
+
+            return events;
+        }
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const BuildFactory = require('./buildFactory');
+        /* eslint-enable global-require */
+        const buildFactory = BuildFactory.getInstance();
+
+        // Fetch only latest builds with same groupEventId
+        if (latest && groupEventId) {
+            return buildFactory.getLatestBuilds({
+                groupEventId: config.params.groupEventId
+            });
+        }
+
+        // Latest should not be passed to list config
+        if (latest !== undefined) {
+            delete config.params.latest;
+        }
+
+        // Fetch builds for this pipeline
+        const defaultConfig = {
+            params: { pipelineId: this.id }
+        };
+        const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
+
+        return buildFactory.list(listConfig);
+    }
+
+    /**
      * Update the repository and branch
      * @method update
      * @return {Promise}

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -20,6 +20,7 @@ const MAX_EVENT_DELETE_COUNT = 100;
 // The default page for fetching not by aggregatedInteval
 // And the start page for fetching by aggregatedInteval
 const DEFAULT_PAGE = 1;
+const DEFAULT_COUNT = 50;
 const SCM_NO_ACCESS_STATUSES = [401, 404];
 
 const { getAllRecords, getBuildClusterName, getFullStageJobName } = require('./helper');
@@ -1681,23 +1682,17 @@ class PipelineModel extends BaseModel {
             const EventFactory = require('./eventFactory');
             /* eslint-enable global-require */
             const eventFactory = EventFactory.getInstance();
-
             const events = await eventFactory.list({
                 params: { groupEventId }
             });
+            const processed = [];
 
-            if (Array.isArray(events) && events.length > 0) {
-                const processed = [];
+            events.forEach(e => processed.push(e.getBuilds()));
 
-                events.forEach(e => processed.push(e.getBuilds()));
-
-                return Promise.all(processed).then(builds => {
-                    // flatten array of arrays
-                    return builds.flat(1);
-                });
-            }
-
-            return events;
+            return Promise.all(processed).then(builds => {
+                // flatten array of arrays
+                return builds.flat(1);
+            });
         }
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
@@ -1718,9 +1713,13 @@ class PipelineModel extends BaseModel {
             delete config.params.latest;
         }
 
-        // Fetch builds for this pipeline
+        // Fetch builds for this pipeline with default count and page
         const defaultConfig = {
-            params: { pipelineId: this.id }
+            params: { pipelineId: this.id },
+            paginate: {
+                count: DEFAULT_COUNT,
+                page: DEFAULT_PAGE
+            }
         };
         const listConfig = config ? hoek.applyToDefaults(defaultConfig, config) : defaultConfig;
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2668,7 +2668,8 @@ describe('Pipeline Model', () => {
         it('gets a list of builds with default pagination', () => {
             const expected = {
                 params: { pipelineId: 123 },
-                paginate: { count: 50, page: 1 }
+                paginate: { count: 10 },
+                sort: 'descending'
             };
 
             buildFactoryMock.list.resolves(builds);
@@ -2682,7 +2683,8 @@ describe('Pipeline Model', () => {
         it('gets a list of builds and does not pass through latest when groupEventId not set', () => {
             const expected = {
                 params: { pipelineId: 123 },
-                paginate: { count: 300, page: 2 }
+                paginate: { count: 300, page: 2 },
+                sort: 'descending'
             };
 
             buildFactoryMock.list.resolves(builds);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2665,9 +2665,10 @@ describe('Pipeline Model', () => {
                 });
         });
 
-        it('gets a list of builds', () => {
+        it('gets a list of builds with default pagination', () => {
             const expected = {
-                params: { pipelineId: 123 }
+                params: { pipelineId: 123 },
+                paginate: { count: 50, page: 1 }
             };
 
             buildFactoryMock.list.resolves(builds);
@@ -2680,12 +2681,13 @@ describe('Pipeline Model', () => {
 
         it('gets a list of builds and does not pass through latest when groupEventId not set', () => {
             const expected = {
-                params: { pipelineId: 123 }
+                params: { pipelineId: 123 },
+                paginate: { count: 300, page: 2 }
             };
 
             buildFactoryMock.list.resolves(builds);
 
-            return pipeline.getBuilds({ params: { latest: true } }).then(result => {
+            return pipeline.getBuilds({ params: { latest: true }, paginate: { count: 300, page: 2 } }).then(result => {
                 assert.calledWith(buildFactoryMock.list, expected);
                 assert.deepEqual(result, builds);
             });


### PR DESCRIPTION
## Context

Currently a lot of calls are being made on the PR tab page in the UI to: 
- `GET /pipelines/:id/events?count=1&page=1&prNum=prNum`
- `GET /jobs/:id/builds?count=10&page=1`
- `GET /events/:id/builds`

It would be nice if we could simplify these calls to get only latest builds in a PR and make fewer calls to the API.

## Objective

This PR adds a method for `pipeline.getBuilds()` to get builds for pipeline based on groupEventId.

## References
N/A

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.