### PR TITLE
fix(3072): PipelineTemplateVersionFactory getWithMetadata() does not return a valid model

### DIFF
--- a/lib/pipelineTemplateVersionFactory.js
+++ b/lib/pipelineTemplateVersionFactory.js
@@ -238,7 +238,16 @@ class PipelineTemplateVersionFactory extends BaseFactory {
 
         const pipelineTemplateVersion = await super.get(config);
 
-        return { ...pipelineTemplateVersion, ...pipelineTemplateMeta };
+        if (!pipelineTemplateVersion) {
+            return null;
+        }
+
+        // merge selected template meta fields into template version
+        ['pipelineId', 'namespace', 'name', 'maintainer', 'latestVersion'].forEach(fieldName => {
+            pipelineTemplateVersion[fieldName] = pipelineTemplateMeta[fieldName];
+        });
+
+        return pipelineTemplateVersion;
     }
 
     /**


### PR DESCRIPTION
## Context

The return value of `getWithMetadata()` of `PipelineTemplateVersionFactory` has below issues

1. Return value is a plain Javascript object instead of an instance of `PipelineTemplateVersion` model
2. it returns non-null object (containing attributes only from PipelineTemplate) when version does not exist
3. `id`, `createTime` of `PipelineTemplateVersion` instance is replaced by  `id`, `createTime` from the `PipelineTemplate` meta

## Objective

Update the logic to selectively merge `PipelineTemplate` meta fields into `PipelineTemplateVersion` instance
1. Return value must be an instance of `PipelineTemplateVersion` model
2. Return `null` when version does not exist
3. Cherry pick the fields (`name`, `namespace`, `latestVersion`, `pipelineId`, `maintainer`) from `PipelineTemplate` meta to be added to `PipelineTemplateVersion` instance

## References

https://github.com/screwdriver-cd/screwdriver/issues/3072

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
