### PR TITLE
fix: Cannot fetch builds based on pipelineId [1.5]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1715,9 +1715,15 @@ class PipelineModel extends BaseModel {
             delete config.params.latest;
         }
 
+        // Fetch jobs for this pipeline
+        const jobs = await this.getJobs({
+            params: { pipelineId: this.id }
+        });
+        const jobIds = jobs.map(j => j.id);
+
         // Fetch builds for this pipeline with default count and page (implicitly set to 1)
         const defaultConfig = {
-            params: { pipelineId: this.id },
+            params: { jobId: jobIds },
             paginate: {
                 count: DEFAULT_COUNT
             },

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1717,7 +1717,10 @@ class PipelineModel extends BaseModel {
 
         // Fetch jobs for this pipeline
         const jobs = await this.getJobs({
-            params: { pipelineId: this.id }
+            params: {
+                pipelineId: this.id,
+                archived: false
+            }
         });
         const jobIds = jobs.map(j => j.id);
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2618,6 +2618,13 @@ describe('Pipeline Model', () => {
         ];
         const groupEventId = 999;
 
+        beforeEach(() => {
+            getUserPermissionMocks({ username: 'janedoe', push: true });
+            getUserPermissionMocks({ username: 'johnsmith', push: true });
+            pipeline.admins = { janedoe: true, johnsmith: true };
+            scmMock.getOpenedPRs.resolves([pr3Info, pr10Info]);
+        });
+
         it('gets a list of builds by groupEventId', () => {
             const expected = {
                 params: { groupEventId }
@@ -2667,11 +2674,12 @@ describe('Pipeline Model', () => {
 
         it('gets a list of builds with default pagination', () => {
             const expected = {
-                params: { pipelineId: 123 },
+                params: { jobId: [99999, 99998, 99996, 99997] },
                 paginate: { count: 10 },
                 sort: 'descending'
             };
 
+            jobFactoryMock.list.resolves([publishJob, mainJob, pr10, pr3]);
             buildFactoryMock.list.resolves(builds);
 
             return pipeline.getBuilds({}).then(result => {
@@ -2682,11 +2690,12 @@ describe('Pipeline Model', () => {
 
         it('gets a list of builds and does not pass through latest when groupEventId not set', () => {
             const expected = {
-                params: { pipelineId: 123 },
+                params: { jobId: [99999, 99998, 99996, 99997] },
                 paginate: { count: 300, page: 2 },
                 sort: 'descending'
             };
 
+            jobFactoryMock.list.resolves([publishJob, mainJob, pr10, pr3]);
             buildFactoryMock.list.resolves(builds);
 
             return pipeline.getBuilds({ params: { latest: true }, paginate: { count: 300, page: 2 } }).then(result => {
@@ -2696,6 +2705,7 @@ describe('Pipeline Model', () => {
         });
 
         it('rejects with errors', () => {
+            jobFactoryMock.list.resolves([publishJob, mainJob, pr10, pr3]);
             buildFactoryMock.list.rejects(new Error('cannotgetit'));
 
             return pipeline


### PR DESCRIPTION
## Context

Currently a lot of calls are being made on the PR tab page in the UI to: 
- `GET /pipelines/:id/events?count=1&page=1&prNum=prNum`
- `GET /jobs/:id/builds?count=10&page=1`
- `GET /events/:id/builds`

It would be nice if we could simplify these calls to get only latest builds in a PR and make fewer calls to the API.

## Objective

This PR modifies `pipeline.getBuilds()` to get jobs for a pipeline and get builds for that pipeline based on jobIds.

## References
Related to https://github.com/screwdriver-cd/models/pull/619

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.