### PR TITLE
feat(3112): Add support to start an event from a stage

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { TRIGGER, EXTERNAL_TRIGGER, COMMIT_TRIGGER, PR_TRIGGER, RELEASE_TRIGGER, TAG_TRIGGER } =
+const { TRIGGER, EXTERNAL_TRIGGER, COMMIT_TRIGGER, PR_TRIGGER, RELEASE_TRIGGER, TAG_TRIGGER, QUALIFIED_STAGE_NAME } =
     require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const logger = require('screwdriver-logger');
@@ -327,11 +327,16 @@ function createBuilds(config) {
         releaseName,
         ref
     } = config;
-    const { startFrom } = eventConfig;
+    let { startFrom } = eventConfig;
     let rootDir = '';
 
     if (!startFrom) {
         return null;
+    }
+
+    // If startFrom is a stage, point it to stage setup job
+    if (QUALIFIED_STAGE_NAME.test(startFrom)) {
+        startFrom = `${startFrom}:setup`;
     }
 
     return Promise.all([pipeline.branch, pipeline.getJobs(), pipeline.rootDir])

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "screwdriver-config-parser": "^10.0.0",
-    "screwdriver-data-schema": "^23.0.4",
+    "screwdriver-data-schema": "^23.4.0",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-workflow-parser": "^4.1.0"
   }


### PR DESCRIPTION
## Context
An event can be started from one of the below entry points in the workflow
- SCM events. Ex: `~commit`, `~tag`
- internal job names. Ex: `component`, `stage@integration:setup`
- external job triggers. Ex: `~sd@123:release`

Entry point is specified in `startFrom` field in the event creation request.

Related PR
https://github.com/screwdriver-cd/data-schema/pull/569

## Objective

Allow event creation from a stage. Ex: `stage@integration`.
When an event is created from a stage, the build must be created for the stage `setup` job (Ex: `stage@integration:setup`)

## References

https://github.com/screwdriver-cd/screwdriver/issues/3112

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
