### PR TITLE
feat(3146): Get repository data from scmRepo without GitHub access [3]

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -307,6 +307,7 @@ class BuildModel extends BaseModel {
                     token,
                     scmUri: pipeline.scmUri,
                     scmContext: pipeline.scmContext,
+                    scmRepo: pipeline.scmRepo,
                     sha: this.sha,
                     buildStatus: SCM_STATE_MAP[this.status],
                     jobName: job.name,
@@ -337,6 +338,7 @@ class BuildModel extends BaseModel {
                         jobName: config.jobName,
                         prNum,
                         scmContext: config.scmContext,
+                        scmRepo: config.scmRepo,
                         scmUri: config.scmUri,
                         token,
                         pipelineId: pipeline.id

--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -65,6 +65,7 @@ function getCommitInfo(config) {
                         .decorateCommit({
                             scmUri: pipeline.scmUri,
                             scmContext: pipeline.scmContext,
+                            scmRepo: pipeline.scmRepo,
                             sha,
                             token
                         })

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -831,7 +831,8 @@ class EventFactory extends BaseFactory {
                                 scmUri: pipeline.scmUri,
                                 scmContext,
                                 sha,
-                                token
+                                token,
+                                scmRepo: pipeline.scmRepo
                             });
                         })
                         .then(commit => {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -821,7 +821,8 @@ class EventFactory extends BaseFactory {
                                             scmUri: pipeline.scmUri,
                                             scmContext,
                                             sha,
-                                            token
+                                            token,
+                                            scmRepo: pipeline.scmRepo
                                         });
                                     });
                             }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -535,6 +535,7 @@ class PipelineModel extends BaseModel {
                 scmUri: webhookUrlsWithActionsList[i].scmUri,
                 scmContext: this.scmContext,
                 token,
+                scmRepo: this.scmRepo,
                 actions: mappedActions,
                 webhookUrl: webhookUrlsWithActionsList[i].webhookUrl
             });
@@ -559,6 +560,7 @@ class PipelineModel extends BaseModel {
             this.scm.getOpenedPRs({
                 scmUri: this.scmUri,
                 scmContext: this.scmContext,
+                scmRepo: this.scmRepo,
                 token
             })
         ])
@@ -1401,6 +1403,7 @@ class PipelineModel extends BaseModel {
             return this.scm.getOpenedPRs({
                 scmUri: this.scmUri,
                 scmContext: this.scmContext,
+                scmRepo: this.scmRepo,
                 token
             });
         });
@@ -1591,6 +1594,7 @@ class PipelineModel extends BaseModel {
                     const openPrs = await this.scm.getOpenedPRs({
                         scmUri: this.scmUri,
                         scmContext: this.scmContext,
+                        scmRepo: this.scmRepo,
                         token: await this.token
                     });
                     const openedPRsMap = openPrs.reduce((map, pr) => {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1746,6 +1746,8 @@ class PipelineModel extends BaseModel {
         const token = await this.token;
 
         return this.scm
+            // Don't pass scmRepo argument since fetch latest scmRepo data from SCM here
+            // If we pass scmRepo, then pipeline uses own scmRepo data forever
             .decorateUrl({
                 scmUri: this.scmUri,
                 scmContext: this.scmContext,

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1745,37 +1745,39 @@ class PipelineModel extends BaseModel {
     async update() {
         const token = await this.token;
 
-        return this.scm
-            // Don't pass scmRepo argument since fetch latest scmRepo data from SCM here
-            // If we pass scmRepo, then pipeline uses own scmRepo data forever
-            .decorateUrl({
-                scmUri: this.scmUri,
-                scmContext: this.scmContext,
-                token
-            })
-            .then(async scmRepo => {
-                this.scmRepo = scmRepo;
-                this.name = scmRepo.name;
+        return (
+            this.scm
+                // Don't pass scmRepo argument since fetch latest scmRepo data from SCM here
+                // If we pass scmRepo, then pipeline uses own scmRepo data forever
+                .decorateUrl({
+                    scmUri: this.scmUri,
+                    scmContext: this.scmContext,
+                    token
+                })
+                .then(async scmRepo => {
+                    this.scmRepo = scmRepo;
+                    this.name = scmRepo.name;
 
-                const annotations = hoek.reach(this, 'annotations', { default: {} });
-                const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+                    const annotations = hoek.reach(this, 'annotations', { default: {} });
+                    const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 
-                const buildClusterName = await getBuildClusterName({
-                    annotations,
-                    pipeline: this,
-                    isPipelineUpdate: true,
-                    multiBuildClusterEnabled: String(this.multiBuildClusterEnabled) === 'true'
-                });
+                    const buildClusterName = await getBuildClusterName({
+                        annotations,
+                        pipeline: this,
+                        isPipelineUpdate: true,
+                        multiBuildClusterEnabled: String(this.multiBuildClusterEnabled) === 'true'
+                    });
 
-                if (buildClusterName) {
-                    if (!this.annotations) {
-                        this.annotations = {};
+                    if (buildClusterName) {
+                        if (!this.annotations) {
+                            this.annotations = {};
+                        }
+                        this.annotations[buildClusterAnnotation] = buildClusterName;
                     }
-                    this.annotations[buildClusterAnnotation] = buildClusterName;
-                }
 
-                return super.update();
-            });
+                    return super.update();
+                })
+        );
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1267,7 +1267,7 @@ class PipelineModel extends BaseModel {
 
             try {
                 // eslint-disable-next-line no-await-in-loop
-                permission = await user.getPermissions(scmUri);
+                permission = await user.getPermissions(scmUri, user.scmContext, this.scmRepo);
             } catch (err) {
                 if (SCM_NO_ACCESS_STATUSES.includes(err.status)) {
                     permission.push = false;

--- a/lib/user.js
+++ b/lib/user.js
@@ -78,15 +78,17 @@ class UserModel extends BaseModel {
      * @method getPermissions
      * @param  {String}     scmUri          The scmUri of the repository
      * @param  {String}     [scmContext]    The scmContext of the repository
+     * @param  {Object}     [scmRepo]       The SCM repo to look up
      * @return {Promise}                    Contains the permissions for [admin, push, pull]
      *                                      Example: {admin: false, push: true, pull: true}
      */
-    getPermissions(scmUri, scmContext) {
+    getPermissions(scmUri, scmContext, scmRepo) {
         return this.unsealToken().then(token =>
             this.scm.getPermissions({
                 token,
                 scmUri,
-                scmContext: scmContext || this.scmContext
+                scmContext: scmContext || this.scmContext,
+                scmRepo
             })
         );
     }

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -38,6 +38,11 @@ describe('Build Model', () => {
     const configPipelineId = 1233;
     const scmUri = 'github.com:12345:master';
     const scmContext = 'github:github.com';
+    const scmRepo = {
+        branch: 'master',
+        url: 'https://github.com/org/name/tree/master',
+        name: 'org/name'
+    };
     const token = 'equivalentToOneQuarter';
     const url = `${uiUri}/pipelines/${pipelineId}/builds/${buildId}`;
     const meta = {
@@ -111,6 +116,7 @@ describe('Build Model', () => {
             id: pipelineId,
             scmUri,
             scmContext,
+            scmRepo,
             admin: Promise.resolve(adminUser),
             token: Promise.resolve('foo'),
             workflowGraph: WORKFLOWGRAPH_WITH_STAGES
@@ -229,6 +235,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'main',
                     buildStatus: SCM_STATE_MAP.QUEUED,
@@ -278,6 +285,7 @@ describe('Build Model', () => {
                     configPipelineId,
                     scmUri,
                     scmContext,
+                    scmRepo,
                     admin: Promise.resolve(adminUser),
                     token: Promise.resolve('foo')
                 }),
@@ -314,6 +322,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -324,6 +333,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     jobName: 'PR-5:main',
                     scmContext,
+                    scmRepo,
                     scmUri,
                     pipelineId,
                     comments: [
@@ -350,6 +360,7 @@ describe('Build Model', () => {
                     configPipelineId,
                     scmUri,
                     scmContext,
+                    scmRepo,
                     admin: Promise.resolve(adminUser),
                     token: Promise.resolve('foo')
                 }),
@@ -397,6 +408,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: 'FAILURE',
@@ -407,6 +419,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: 'SUCCESS',
@@ -419,6 +432,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: 'FAILURE',
@@ -439,6 +453,7 @@ describe('Build Model', () => {
                     configPipelineId,
                     scmUri,
                     scmContext,
+                    scmRepo,
                     admin: Promise.resolve(adminUser),
                     token: Promise.resolve('foo')
                 }),
@@ -484,6 +499,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -494,6 +510,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.SUCCESS,
@@ -506,6 +523,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -549,6 +567,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'main',
                     buildStatus: SCM_STATE_MAP.ABORTED,
@@ -593,6 +612,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'main',
                     buildStatus: SCM_STATE_MAP.ABORTED,
@@ -616,6 +636,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'main',
                     buildStatus: SCM_STATE_MAP.RUNNING,
@@ -638,6 +659,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'main',
                     buildStatus: SCM_STATE_MAP.UNSTABLE,
@@ -688,6 +710,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'main',
                     url,
@@ -717,6 +740,7 @@ describe('Build Model', () => {
                     configPipelineId,
                     scmUri,
                     scmContext,
+                    scmRepo,
                     admin: Promise.resolve(adminUser),
                     token: Promise.resolve('foo')
                 }),
@@ -756,6 +780,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -775,6 +800,7 @@ describe('Build Model', () => {
                     configPipelineId,
                     scmUri,
                     scmContext,
+                    scmRepo,
                     admin: Promise.resolve(adminUser),
                     token: Promise.resolve('foo')
                 }),
@@ -795,6 +821,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -805,6 +832,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -827,6 +855,7 @@ describe('Build Model', () => {
                     configPipelineId,
                     scmUri,
                     scmContext,
+                    scmRepo,
                     admin: Promise.resolve(adminUser),
                     token: Promise.resolve('foo')
                 }),
@@ -847,6 +876,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -857,6 +887,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -879,6 +910,7 @@ describe('Build Model', () => {
                     configPipelineId,
                     scmUri,
                     scmContext,
+                    scmRepo,
                     admin: Promise.resolve(adminUser),
                     token: Promise.resolve('foo')
                 }),
@@ -924,6 +956,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     scmUri,
                     scmContext,
+                    scmRepo,
                     sha,
                     jobName: 'PR-5:main',
                     buildStatus: SCM_STATE_MAP.FAILURE,
@@ -934,6 +967,7 @@ describe('Build Model', () => {
                     token: 'foo',
                     jobName: 'PR-5:main',
                     scmContext,
+                    scmRepo,
                     scmUri,
                     pipelineId,
                     comments: [
@@ -1145,6 +1179,7 @@ describe('Build Model', () => {
             configPipelineId,
             scmUri,
             scmContext,
+            scmRepo,
             admin: Promise.resolve(adminUser),
             token: Promise.resolve('foo')
         };
@@ -1220,6 +1255,7 @@ describe('Build Model', () => {
                 token: 'foo',
                 scmUri,
                 scmContext,
+                scmRepo,
                 sha,
                 jobName: 'main',
                 buildStatus: SCM_STATE_MAP.QUEUED,
@@ -1405,6 +1441,7 @@ describe('Build Model', () => {
             });
             expectedExecutorStartConfig.blockedBy = [jobId, blocking1.id, blocking2.id, prJob.id];
             expectedExecutorStartConfig.isPR = true;
+            expectedExecutorStartConfig.pipeline.configPipelineId = pipelineMockB.configPipelineId;
 
             return build.start().then(() => {
                 assert.calledWith(executorMock.start, expectedExecutorStartConfig);
@@ -1437,6 +1474,7 @@ describe('Build Model', () => {
 
             pipelineMockB = {
                 id: pipelineId,
+                name: expectedExecutorStartConfig.pipeline.name,
                 scmUri,
                 scmContext,
                 configPipelineId,
@@ -1479,6 +1517,7 @@ describe('Build Model', () => {
 
             expectedExecutorStartConfig.blockedBy = [jobId, internalJob.id, externalJob1.id, externalJob2.id];
             expectedExecutorStartConfig.prParentJobId = undefined;
+            expectedExecutorStartConfig.pipeline.configPipelineId = pipelineMockB.configPipelineId;
 
             return build.start().then(() => {
                 assert.calledWith(executorMock.start, expectedExecutorStartConfig);
@@ -1491,6 +1530,7 @@ describe('Build Model', () => {
 
             pipelineMockB = {
                 id: pipelineId,
+                name: expectedExecutorStartConfig.pipeline.name,
                 scmUri,
                 scmContext,
                 configPipelineId,
@@ -1532,6 +1572,7 @@ describe('Build Model', () => {
             });
             expectedExecutorStartConfig.blockedBy = [jobId, internalJob.id, externalJob1.id];
             expectedExecutorStartConfig.prParentJobId = undefined;
+            expectedExecutorStartConfig.pipeline.configPipelineId = pipelineMockB.configPipelineId;
 
             return build.start().then(() => {
                 assert.calledWith(executorMock.start, expectedExecutorStartConfig);
@@ -1541,9 +1582,11 @@ describe('Build Model', () => {
         it('promises to start a build with the executor specified in job annotations', () => {
             pipelineMockB = {
                 id: pipelineId,
+                name: expectedExecutorStartConfig.pipeline.name,
                 configPipelineId,
                 scmUri,
                 scmContext,
+                scmRepo,
                 admin: Promise.resolve(adminUser),
                 token: Promise.resolve('foo')
             };

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -899,7 +899,8 @@ describe('Build Factory', () => {
                         token: 'foo',
                         sha,
                         scmUri,
-                        scmContext
+                        scmContext,
+                        scmRepo
                     });
                     assert.calledWith(bookendMock.getSetupCommands, {
                         pipeline: { scmUri, scmRepo, scmContext },
@@ -948,7 +949,8 @@ describe('Build Factory', () => {
                         token: 'foo',
                         sha,
                         scmUri,
-                        scmContext
+                        scmContext,
+                        scmRepo
                     });
                     assert.calledWith(bookendMock.getSetupCommands, {
                         pipeline: { scmUri, scmRepo, scmContext },

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1853,7 +1853,8 @@ describe('Event Factory', () => {
                     scmUri: 'github.com:1234:branch',
                     scmContext,
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
-                    token: 'foo'
+                    token: 'foo',
+                    scmRepo
                 });
                 assert.strictEqual(syncedPipelineMock.lastEventId, model.id);
                 assert.strictEqual(config.prInfo.url, model.pr.url);
@@ -1886,7 +1887,8 @@ describe('Event Factory', () => {
                     scmUri: 'github.com:1234:branch',
                     scmContext,
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
-                    token: 'foo'
+                    token: 'foo',
+                    scmRepo
                 });
                 assert.strictEqual(syncedPipelineMock.lastEventId, model.id);
                 assert.strictEqual(config.prInfo.url, model.pr.url);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -123,6 +123,11 @@ describe('Event Factory', () => {
         const displayName = 'github';
         // const lastEventId = 'xzy1234';
         const scmContext = 'github:github.com';
+        const scmRepo = {
+            branch: 'master',
+            url: 'https://github.com/org/name/tree/master',
+            name: 'org/name'
+        };
         const creator = {
             avatar: 'https://avatars.githubusercontent.com/u/2042?v=3',
             name: 'St John',
@@ -223,6 +228,7 @@ describe('Event Factory', () => {
                 id: pipelineId,
                 scmUri: 'github.com:1234:branch',
                 scmContext,
+                scmRepo,
                 token: Promise.resolve('foo'),
                 lastEventId: null,
                 workflowGraph: {
@@ -1751,6 +1757,7 @@ describe('Event Factory', () => {
                 assert.calledWith(scm.decorateCommit, {
                     scmUri: 'github.com:1234:branch',
                     scmContext,
+                    scmRepo,
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
                     token: 'foo'
                 });
@@ -1784,6 +1791,7 @@ describe('Event Factory', () => {
                 assert.calledWith(scm.decorateCommit, {
                     scmUri: 'github.com:1234:branch',
                     scmContext,
+                    scmRepo,
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
                     token: 'foo'
                 });
@@ -1813,6 +1821,7 @@ describe('Event Factory', () => {
                 assert.calledWith(scm.decorateCommit, {
                     scmUri: 'github.com:1234:branch',
                     scmContext,
+                    scmRepo,
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
                     token: 'foo'
                 });
@@ -2876,6 +2885,7 @@ describe('Event Factory', () => {
                 assert.notCalled(syncedPipelineMock.syncPRs);
                 assert.calledWith(scm.decorateCommit, {
                     scmContext,
+                    scmRepo,
                     scmUri: 'github.com:1234:branch',
                     sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
                     token: 'foo'

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -88,9 +88,9 @@ describe('Pipeline Model', () => {
     const testId = 123;
     const admins = { batman: true, robin: true };
     const scmRepo = {
-        name: 'foo/bar',
-        branch: 'master',
-        url: 'https://github.com/foo/bar/tree/master'
+        branch: 'branch',
+        url: 'https://host/owner/repo/tree/branch',
+        name: 'owner/repo'
     };
     let jobs;
     let pipelineConfig;
@@ -439,11 +439,7 @@ describe('Pipeline Model', () => {
             id: testId,
             scmUri,
             scmContext,
-            scmRepo: {
-                branch: 'branch',
-                url: 'https://host/owner/repo/tree/branch',
-                name: 'owner/repo'
-            },
+            scmRepo,
             createTime: dateNow,
             admins,
             scm: scmMock,
@@ -513,6 +509,7 @@ describe('Pipeline Model', () => {
                     scmUri,
                     scmContext,
                     token: 'foo',
+                    scmRepo,
                     actions: [],
                     webhookUrl: 'https://api.screwdriver.cd/v4/webhooks'
                 });
@@ -530,6 +527,7 @@ describe('Pipeline Model', () => {
                     scmUri,
                     scmContext: 'gitlab:gitlab.com',
                     token: 'tokenRO',
+                    scmRepo: pipeline.scmRepo,
                     actions: [],
                     webhookUrl: 'https://api.screwdriver.cd/v4/webhooks'
                 });
@@ -2892,7 +2890,7 @@ describe('Pipeline Model', () => {
                 params: {
                     admins: { d2lam: true },
                     id: testId,
-                    name: 'foo/bar',
+                    name: 'owner/repo',
                     scmContext,
                     scmRepo,
                     scmUri
@@ -2935,7 +2933,7 @@ describe('Pipeline Model', () => {
                 params: {
                     admins: { d2lam: true },
                     id: testId,
-                    name: 'foo/bar',
+                    name: 'owner/repo',
                     scmContext,
                     scmRepo,
                     scmUri,
@@ -2988,7 +2986,7 @@ describe('Pipeline Model', () => {
                     params: {
                         admins: { d2lam: true },
                         id: testId,
-                        name: 'foo/bar',
+                        name: 'owner/repo',
                         scmContext,
                         scmRepo,
                         scmUri,
@@ -3041,7 +3039,7 @@ describe('Pipeline Model', () => {
                     params: {
                         admins: { d2lam: true },
                         id: testId,
-                        name: 'foo/bar',
+                        name: 'owner/repo',
                         scmContext,
                         scmRepo,
                         scmUri,
@@ -3102,7 +3100,7 @@ describe('Pipeline Model', () => {
                         scmRepo: {
                             branch: 'master',
                             name: 'screwdriver/ui',
-                            url: 'https://github.com/foo/bar/tree/master'
+                            url: 'https://github.com/owner/repo/tree/master'
                         },
                         scmUri,
                         annotations: { 'screwdriver.cd/buildCluster': 'iOS' }
@@ -3127,7 +3125,7 @@ describe('Pipeline Model', () => {
                 scmMock.decorateUrl.resolves({
                     branch: 'master',
                     name: 'screwdriver/ui',
-                    url: 'https://github.com/foo/bar/tree/master'
+                    url: 'https://github.com/owner/repo/tree/master'
                 });
                 pipeline.scmUri = scmUri;
                 pipeline.scmContext = scmContext;
@@ -3211,7 +3209,7 @@ describe('Pipeline Model', () => {
                 params: {
                     admins: { d2lam: true },
                     id: testId,
-                    name: 'foo/bar',
+                    name: 'owner/repo',
                     scmContext,
                     scmRepo
                 },

--- a/test/lib/user.test.js
+++ b/test/lib/user.test.js
@@ -11,6 +11,11 @@ describe('User Model', () => {
     const password = 'password';
     const token = 'token';
     const scmContext = 'github:github.com';
+    const scmRepo = {
+        branch: 'master',
+        url: 'https://github.com/org/name/tree/master',
+        name: 'org/name'
+    };
     const settings = { displayJobNameLength: 25 };
     let UserModel;
     let datastore;
@@ -156,11 +161,12 @@ describe('User Model', () => {
         });
 
         it('promises to get permissions', () =>
-            user.getPermissions(scmUri).then(data => {
+            user.getPermissions(scmUri, scmContext, scmRepo).then(data => {
                 assert.calledWith(scmMock.getPermissions, {
                     token: '12345',
                     scmUri,
-                    scmContext
+                    scmContext,
+                    scmRepo
                 });
                 assert.deepEqual(data, repo.permissions);
             }));


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We will be able to get repository data from `pipeline.scmRepo` by the following PR.
https://github.com/screwdriver-cd/scm-github/pull/231

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Pass `scmRepo` to skip GitHub access and get repository data from it.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Prior PRs
- https://github.com/screwdriver-cd/data-schema/pull/570
- https://github.com/screwdriver-cd/scm-github/pull/231

Issue
- https://github.com/screwdriver-cd/screwdriver/issues/3146

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
