### PR TITLE
fix: Pull in latest data-schema for workflowGraph in pipeline template versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "screwdriver-config-parser": "^10.0.0",
-    "screwdriver-data-schema": "^23.4.0",
+    "screwdriver-config-parser": "^10.4.2",
+    "screwdriver-data-schema": "^23.5.1",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-workflow-parser": "^4.1.0"
+    "screwdriver-workflow-parser": "^4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "screwdriver-config-parser": "^10.4.2",
+    "screwdriver-config-parser": "^10.4.3",
     "screwdriver-data-schema": "^23.5.1",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-workflow-parser": "^4.3.0"


### PR DESCRIPTION
## Context

Latest data schema allows `workflowGraph` for pipeline template /versions endpoint.

## Objective

This PR pulls in latest packages.

## References
Related to https://github.com/screwdriver-cd/data-schema/pull/571

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
