### PR TITLE
feat(3143): When a event is started from a job in the middle of a stage, execute setup hook before executing that job.

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -1,12 +1,21 @@
 'use strict';
 
-const { TRIGGER, EXTERNAL_TRIGGER, COMMIT_TRIGGER, PR_TRIGGER, RELEASE_TRIGGER, TAG_TRIGGER, QUALIFIED_STAGE_NAME } =
-    require('screwdriver-data-schema').config.regex;
+const {
+    TRIGGER,
+    EXTERNAL_TRIGGER,
+    COMMIT_TRIGGER,
+    PR_TRIGGER,
+    RELEASE_TRIGGER,
+    TAG_TRIGGER,
+    QUALIFIED_STAGE_NAME,
+    STAGE_SETUP_TEARDOWN_JOB_NAME
+} = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const logger = require('screwdriver-logger');
 const hoek = require('@hapi/hoek');
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
+const { getStageName, getFullStageJobName } = require('./helper');
 let instance;
 
 /**
@@ -337,6 +346,13 @@ function createBuilds(config) {
     // If startFrom is a stage, point it to stage setup job
     if (QUALIFIED_STAGE_NAME.test(startFrom)) {
         startFrom = `${startFrom}:setup`;
+    }
+
+    const stageName = getStageName(pipelineConfig.workflowGraph, startFrom);
+
+    // if the startFrom is a stage job, replace it to the setup of the same stage
+    if (stageName && !STAGE_SETUP_TEARDOWN_JOB_NAME.test(startFrom)) {
+        startFrom = getFullStageJobName({ stageName, jobName: 'setup' });
     }
 
     return Promise.all([pipeline.branch, pipeline.getJobs(), pipeline.rootDir])

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -421,6 +421,18 @@ function getStageFromSetupJobName(jobName) {
     return stageSetupJobName ? stageSetupJobName[1] : null;
 }
 
+/**
+ * get the stage name of a job
+ * @param  {String} jobName                 Job name
+ * @param  {Object} workflowGraph           Workflow Graph
+ * @return {String}                         Stage name
+ */
+function getStageName(workflowGraph, jobName) {
+    const jobNode = workflowGraph.nodes.find(n => n.name === jobName);
+
+    return jobNode ? jobNode.stageName : null;
+}
+
 module.exports = {
     getAnnotations,
     convertToBool,
@@ -430,5 +442,6 @@ module.exports = {
     getToken,
     getBookendKey,
     getFullStageJobName,
-    getStageFromSetupJobName
+    getStageFromSetupJobName,
+    getStageName
 };

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -180,11 +180,11 @@ describe('Event Factory', () => {
                         { name: '~commit' },
                         { name: 'main' },
                         { name: 'disabledJob' },
-                        { name: 'stage@integration:setup' },
-                        { name: 'int-deploy' },
-                        { name: 'int-test' },
-                        { name: 'int-certify' },
-                        { name: 'stage@integration:teardown' },
+                        { name: 'stage@integration:setup', stageName: 'integration' },
+                        { name: 'int-deploy', stageName: 'integration' },
+                        { name: 'int-test', stageName: 'integration' },
+                        { name: 'int-certify', stageName: 'integration' },
+                        { name: 'stage@integration:teardown', stageName: 'integration' },
                         { name: 'publish' },
                         { name: '~sd@123:main' },
                         { name: '~commit:branch' },
@@ -237,11 +237,11 @@ describe('Event Factory', () => {
                         { name: '~commit' },
                         { name: 'main' },
                         { name: 'disabledJob' },
-                        { name: 'stage@integration:setup' },
-                        { name: 'int-deploy' },
-                        { name: 'int-test' },
-                        { name: 'int-certify' },
-                        { name: 'stage@integration:teardown' },
+                        { name: 'stage@integration:setup', stageName: 'integration' },
+                        { name: 'int-deploy', stageName: 'integration' },
+                        { name: 'int-test', stageName: 'integration' },
+                        { name: 'int-certify', stageName: 'integration' },
+                        { name: 'stage@integration:teardown', stageName: 'integration' },
                         { name: 'publish' },
                         { name: '~sd@123:main' },
                         { name: '~commit:branch' },
@@ -1251,6 +1251,26 @@ describe('Event Factory', () => {
 
             it('should create build for stage setup job, if startFrom is a stage name', () => {
                 config.startFrom = 'stage@integration';
+
+                return eventFactory.create(config).then(model => {
+                    assert.instanceOf(model, Event);
+                    assert.notCalled(jobFactoryMock.create);
+                    assert.notCalled(syncedPipelineMock.syncPR);
+                    assert.calledOnce(pipelineMock.sync);
+                    assert.calledOnce(buildFactoryMock.create);
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 11
+                        })
+                    );
+                });
+            });
+
+            it('should create build for stage setup job, if startFrom is a stage name', () => {
+                config.startFrom = 'int-test';
 
                 return eventFactory.create(config).then(model => {
                     assert.instanceOf(model, Event);

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1269,7 +1269,7 @@ describe('Event Factory', () => {
                 });
             });
 
-            it('should create build for stage setup job, if startFrom is a stage name', () => {
+            it('should create build for stage setup job, if startFrom is a job in the middle of a stage', () => {
                 config.startFrom = 'int-test';
 
                 return eventFactory.create(config).then(model => {


### PR DESCRIPTION

## Context

Currently if the event is started from a job in the middle of the stage, the build for stage setup is not created

## Objective

If the event is started from a job in the middle of the stage, the startFrom gets replaced to the setup job of the same stage

## References

https://github.com/screwdriver-cd/screwdriver/issues/3143

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
