### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/lib/pipelineTemplateVersionFactory.js
+++ b/lib/pipelineTemplateVersionFactory.js
@@ -109,6 +109,7 @@ class PipelineTemplateVersionFactory extends BaseFactory {
             templateId: pipelineTemplateMeta.id,
             description: config.description,
             config: config.config,
+            workflowGraph: config.workflowGraph,
             createTime,
             version: newVersion
         });

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "screwdriver-config-parser": "^10.4.3",
-    "screwdriver-data-schema": "^23.5.1",
+    "screwdriver-config-parser": "^11.0.0",
+    "screwdriver-data-schema": "^24.0.0",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-workflow-parser": "^4.3.0"
+    "screwdriver-workflow-parser": "^5.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

Changes were made in https://github.com/screwdriver-cd/data-schema/pull/571 (and related PRs) to store `workflowGraph` of pipeline template as part of the `config

## Objective

Move `workflowGraph` out of `config` and keep it at the same level as `config`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
