### PR TITLE
feat(3193): Add upstream remote trigger's pipeline name data into workflow graph node as displayName [2]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1136,8 +1136,10 @@ class PipelineModel extends BaseModel {
                             const externalJob = externalWorkflow.nodes.find(n => n.name === externalJobName);
 
                             if (externalJob) {
+                                const { name, branch } = externalPipeline.scmRepo;
+
                                 node.id = externalJob.id;
-                                node.displayName = `${externalPipeline.name}@${externalJob.name}`;
+                                node.displayName = `${name}(${branch}):${externalJob.name}`;
                             } else {
                                 logger.error(
                                     `pipelineId:${externalPipelineId}: workflow has no job:${externalJobName}.`

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1137,6 +1137,7 @@ class PipelineModel extends BaseModel {
 
                             if (externalJob) {
                                 node.id = externalJob.id;
+                                node.displayName = `${externalPipeline.name}@${externalJob.name}`;
                             } else {
                                 logger.error(
                                     `pipelineId:${externalPipelineId}: workflow has no job:${externalJobName}.`

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1139,7 +1139,7 @@ class PipelineModel extends BaseModel {
                                 const { name, branch } = externalPipeline.scmRepo;
 
                                 node.id = externalJob.id;
-                                node.displayName = `${name}(${branch}):${externalJob.name}`;
+                                node.displayName = `${name}#${branch}:${externalJob.name}`;
                             } else {
                                 logger.error(
                                     `pipelineId:${externalPipelineId}: workflow has no job:${externalJobName}.`

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -915,7 +915,10 @@ describe('Pipeline Model', () => {
             jobFactoryMock.create.withArgs(externalMock).resolves(externalModelMock);
             pipelineFactoryMock.get.resolves({
                 id: testId,
-                name: 'foo/bar',
+                scmRepo: {
+                    branch: 'main',
+                    name: 'org/repo'
+                },
                 update: sinon.stub().resolves(null),
                 remove: sinon.stub().resolves(null),
                 workflowGraph: { nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'main', id: 3 }] }
@@ -929,7 +932,7 @@ describe('Pipeline Model', () => {
                         { name: '~commit' },
                         { name: 'main', id: 1 },
                         { name: 'publish', id: 2 },
-                        { name: 'sd@123:main', displayName: 'foo/bar@main', id: 3 }
+                        { name: 'sd@123:main', displayName: 'org/repo(main):main', id: 3 }
                     ],
                     edges: [
                         { src: '~pr', dest: 'main' },

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -916,7 +916,7 @@ describe('Pipeline Model', () => {
             pipelineFactoryMock.get.resolves({
                 id: testId,
                 scmRepo: {
-                    branch: 'main',
+                    branch: 'branch',
                     name: 'org/repo'
                 },
                 update: sinon.stub().resolves(null),
@@ -932,7 +932,7 @@ describe('Pipeline Model', () => {
                         { name: '~commit' },
                         { name: 'main', id: 1 },
                         { name: 'publish', id: 2 },
-                        { name: 'sd@123:main', displayName: 'org/repo(main):main', id: 3 }
+                        { name: 'sd@123:main', displayName: 'org/repo#branch:main', id: 3 }
                     ],
                     edges: [
                         { src: '~pr', dest: 'main' },

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -915,6 +915,7 @@ describe('Pipeline Model', () => {
             jobFactoryMock.create.withArgs(externalMock).resolves(externalModelMock);
             pipelineFactoryMock.get.resolves({
                 id: testId,
+                name: 'foo/bar',
                 update: sinon.stub().resolves(null),
                 remove: sinon.stub().resolves(null),
                 workflowGraph: { nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'main', id: 3 }] }
@@ -928,7 +929,7 @@ describe('Pipeline Model', () => {
                         { name: '~commit' },
                         { name: 'main', id: 1 },
                         { name: 'publish', id: 2 },
-                        { name: 'sd@123:main', id: 3 }
+                        { name: 'sd@123:main', displayName: 'foo/bar@main', id: 3 }
                     ],
                     edges: [
                         { src: '~pr', dest: 'main' },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The upstream remote trigger pipeline name will be shown by the following PR.
https://github.com/screwdriver-cd/ui/pull/1152

This needs to get the pipeline name from workflow graph's node.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Store the upstream remote trigger pipeline name into workflow graph as displayName to show it on UI.
The display name format will be `org/repo#branch:job`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3193

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
