### PR TITLE
fix(3055): remove k8s-vm name from test file [skip ci]

### DIFF
--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1597,11 +1597,11 @@ describe('Build Model', () => {
                 state: 'ENABLED',
                 archived: false,
                 pipeline: Promise.resolve(pipelineMockB),
-                permutations: [{ annotations: { 'beta.screwdriver.cd/executor:': 'k8s-vm' }, provider }],
+                permutations: [{ annotations: { 'beta.screwdriver.cd/executor:': 'k8s-test' }, provider }],
                 isPR: () => false,
                 prNum: Promise.resolve(null)
             });
-            expectedExecutorStartConfig.annotations = { 'beta.screwdriver.cd/executor:': 'k8s-vm' };
+            expectedExecutorStartConfig.annotations = { 'beta.screwdriver.cd/executor:': 'k8s-test' };
             expectedExecutorStartConfig.prParentJobId = undefined;
             expectedExecutorStartConfig.freezeWindows = [];
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

[executor-k8s-vm](https://github.com/screwdriver-cd/executor-k8s-vm) has been archived.
We need to remove this package dependence from active repositories.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Remove `executor-k8s-vm` from this repository.
This repository is not dependent on `k8s-vm`, but this repository includes `k8s-vm` name as test text.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3055

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
