### PR TITLE
feat(3211): Upgrade data-schema to v24.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "screwdriver-config-parser": "^11.0.0",
-    "screwdriver-data-schema": "^24.0.0",
+    "screwdriver-data-schema": "^24.1.0",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-workflow-parser": "^5.0.0"
   }


### PR DESCRIPTION
## Context

New field `statusMessageType` has been added to `build` in the PR https://github.com/screwdriver-cd/data-schema/pull/585

## Objective

Upgrading to latest data-schema

## References

https://github.com/screwdriver-cd/screwdriver/issues/3211

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
