### PR TITLE
fix(3228): GH status for virtual job PR build always shows as pending

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -526,55 +526,56 @@ class BuildModel extends BaseModel {
         return this.job.then(job =>
             Promise.all([job.pipeline, job.prNum])
                 .then(([pipeline, prNum]) =>
-                    getBlockedByIds(pipeline, job)
-                        .then(blockedBy => {
-                            const config = {
-                                build: this,
-                                buildId: this.id,
-                                eventId: this.eventId,
-                                jobId: job.id,
-                                jobState: job.state,
-                                jobArchived: job.archived,
-                                jobName: job.name,
-                                annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
-                                blockedBy,
-                                pipelineId: pipeline.id,
-                                pipeline: {
-                                    id: pipeline.id,
-                                    name: pipeline.name,
-                                    scmContext: pipeline.scmContext,
-                                    configPipelineId: pipeline.configPipelineId
-                                },
-                                causeMessage: causeMessage || '',
-                                freezeWindows: hoek.reach(job.permutations[0], 'freezeWindows', { default: [] }),
-                                apiUri: this[apiUri],
-                                container: this.container,
-                                tokenGen: this[tokenGen],
-                                token: getToken(this, job, pipeline),
-                                isPR: job.isPR(),
-                                prParentJobId: job.prParentJobId
-                            };
+                    getBlockedByIds(pipeline, job).then(blockedBy => {
+                        const config = {
+                            build: this,
+                            buildId: this.id,
+                            eventId: this.eventId,
+                            jobId: job.id,
+                            jobState: job.state,
+                            jobArchived: job.archived,
+                            jobName: job.name,
+                            annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
+                            blockedBy,
+                            pipelineId: pipeline.id,
+                            pipeline: {
+                                id: pipeline.id,
+                                name: pipeline.name,
+                                scmContext: pipeline.scmContext,
+                                configPipelineId: pipeline.configPipelineId
+                            },
+                            causeMessage: causeMessage || '',
+                            freezeWindows: hoek.reach(job.permutations[0], 'freezeWindows', { default: [] }),
+                            apiUri: this[apiUri],
+                            container: this.container,
+                            tokenGen: this[tokenGen],
+                            token: getToken(this, job, pipeline),
+                            isPR: job.isPR(),
+                            prParentJobId: job.prParentJobId
+                        };
 
-                            if (template && !hoek.deepEqual(template, {})) {
-                                config.template = template;
-                            }
+                        if (template && !hoek.deepEqual(template, {})) {
+                            config.template = template;
+                        }
 
-                            if (prNum) {
-                                config.prNum = prNum;
-                            }
+                        if (prNum) {
+                            config.prNum = prNum;
+                        }
 
-                            if (this.buildClusterName) {
-                                config.buildClusterName = this.buildClusterName;
-                            }
+                        if (this.buildClusterName) {
+                            config.buildClusterName = this.buildClusterName;
+                        }
 
-                            if (hoek.reach(job.permutations[0], 'provider')) {
-                                config.provider = job.permutations[0].provider;
-                            }
+                        if (hoek.reach(job.permutations[0], 'provider')) {
+                            config.provider = job.permutations[0].provider;
+                        }
 
-                            return this[executor].start(config);
-                        })
-                        .then(() => this.updateCommitStatus(pipeline))
-                ) // update github
+                        return Promise.all([
+                            this[executor].start(config),
+                            this.updateCommitStatus(pipeline) // update github
+                        ]);
+                    })
+                )
                 .then(() => this)
         );
     }


### PR DESCRIPTION
## Context

Github status for a successful PR job build is updated on below occasions

1. Set as "pending" when the build is started
2. Set as "complete" when the build id completed

When the first build of a PR event is for a virtual job, updating the status to "complete" is happening before "pending".
As result, the Github status of the build remains as pending. Thus, failing the PR checks.

## Objective

Ensure the request to update Github status to "pending" is executed before updating the status to "complete".

Requests to Assign the build to executor and updating the Github status are now processed in parallel.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3228

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
