### PR TITLE
fix: Private pipelines are not displayed in the list of pipelines that use job templates

### DIFF
--- a/lib/templateFactory.js
+++ b/lib/templateFactory.js
@@ -383,7 +383,13 @@ class TemplateFactory extends BaseFactory {
         const eventFactory = EventFactory.getInstance();
 
         const pipelineData = await pipelineFactory.list(pipelineConfig);
-        const eventIds = pipelineData.filter(p => p.lastEventId !== null).map(p => p.lastEventId);
+        const publicPipelineData = pipelineData.filter(p => {
+            const privatePipeline = p.scmRepo && p.scmRepo.private;
+            const setToPublic = p.settings && p.settings.public;
+
+            return !privatePipeline || setToPublic;
+        });
+        const eventIds = publicPipelineData.filter(p => p.lastEventId !== null).map(p => p.lastEventId);
         const eventConfig = {
             params: { id: eventIds },
             readOnly: true
@@ -395,7 +401,7 @@ class TemplateFactory extends BaseFactory {
             return map;
         }, {});
 
-        return pipelineData.map(p => {
+        return publicPipelineData.map(p => {
             return {
                 id: p.id,
                 name: p.name,

--- a/test/lib/templateFactory.test.js
+++ b/test/lib/templateFactory.test.js
@@ -1403,7 +1403,7 @@ describe('Template Factory', () => {
                         name: 'nathom/sd-uses-template',
                         url: 'https://github.com/test/repo/tree/main/pipe3',
                         rootDir: 'pipe3',
-                        private: false
+                        private: true
                     },
                     lastRun: '2023-08-31T18:18:37.501Z',
                     admins: { nathom: true }
@@ -1461,11 +1461,29 @@ describe('Template Factory', () => {
                         name: 'nathom/sd-uses-template',
                         url: 'https://github.com/test/repo/tree/main/pipe3',
                         rootDir: 'pipe3',
-                        private: false
+                        private: true
                     },
+                    settings: { public: true },
                     createTime: '2023-08-17T18:18:37.501Z',
                     admins: { nathom: true },
                     lastEventId: 1
+                },
+
+                {
+                    id: 3,
+                    name: 'nathom/sd-uses-template',
+                    scmUri: 'github.com:672032066:main:pipe4',
+                    scmContext: 'github:github.com',
+                    scmRepo: {
+                        branch: 'main',
+                        name: 'nathom/sd-uses-template',
+                        url: 'https://github.com/test/repo/tree/main/pipe4',
+                        rootDir: 'pipe4',
+                        private: true
+                    },
+                    createTime: '2023-08-17T18:18:37.501Z',
+                    admins: { nathom: true },
+                    lastEventId: 3
                 }
             ];
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Private pipelines should not even appear in the pipeline search.
They should not appear in the list of template uses either.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Private pipelines should not appear in the template usage list.

Metrics also include private pipelines. They are excluded from the list page after pressing the pipelines number.
![image](https://github.com/user-attachments/assets/6aa3a0ef-7ce1-4252-86f0-3e204e7e7021)

In the pipeline option, make it visible if visibility is turned on.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
