### PR TITLE
feat(3181): Skip execution of a virtual job when an event is started from that job

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -526,56 +526,55 @@ class BuildModel extends BaseModel {
         return this.job.then(job =>
             Promise.all([job.pipeline, job.prNum])
                 .then(([pipeline, prNum]) =>
-                    getBlockedByIds(pipeline, job).then(blockedBy => {
-                        const config = {
-                            build: this,
-                            buildId: this.id,
-                            eventId: this.eventId,
-                            jobId: job.id,
-                            jobState: job.state,
-                            jobArchived: job.archived,
-                            jobName: job.name,
-                            annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
-                            blockedBy,
-                            pipelineId: pipeline.id,
-                            pipeline: {
-                                id: pipeline.id,
-                                name: pipeline.name,
-                                scmContext: pipeline.scmContext,
-                                configPipelineId: pipeline.configPipelineId
-                            },
-                            causeMessage: causeMessage || '',
-                            freezeWindows: hoek.reach(job.permutations[0], 'freezeWindows', { default: [] }),
-                            apiUri: this[apiUri],
-                            container: this.container,
-                            tokenGen: this[tokenGen],
-                            token: getToken(this, job, pipeline),
-                            isPR: job.isPR(),
-                            prParentJobId: job.prParentJobId
-                        };
+                    getBlockedByIds(pipeline, job)
+                        .then(blockedBy => {
+                            const config = {
+                                build: this,
+                                buildId: this.id,
+                                eventId: this.eventId,
+                                jobId: job.id,
+                                jobState: job.state,
+                                jobArchived: job.archived,
+                                jobName: job.name,
+                                annotations: hoek.reach(job.permutations[0], 'annotations', { default: {} }),
+                                blockedBy,
+                                pipelineId: pipeline.id,
+                                pipeline: {
+                                    id: pipeline.id,
+                                    name: pipeline.name,
+                                    scmContext: pipeline.scmContext,
+                                    configPipelineId: pipeline.configPipelineId
+                                },
+                                causeMessage: causeMessage || '',
+                                freezeWindows: hoek.reach(job.permutations[0], 'freezeWindows', { default: [] }),
+                                apiUri: this[apiUri],
+                                container: this.container,
+                                tokenGen: this[tokenGen],
+                                token: getToken(this, job, pipeline),
+                                isPR: job.isPR(),
+                                prParentJobId: job.prParentJobId
+                            };
 
-                        if (template && !hoek.deepEqual(template, {})) {
-                            config.template = template;
-                        }
+                            if (template && !hoek.deepEqual(template, {})) {
+                                config.template = template;
+                            }
 
-                        if (prNum) {
-                            config.prNum = prNum;
-                        }
+                            if (prNum) {
+                                config.prNum = prNum;
+                            }
 
-                        if (this.buildClusterName) {
-                            config.buildClusterName = this.buildClusterName;
-                        }
+                            if (this.buildClusterName) {
+                                config.buildClusterName = this.buildClusterName;
+                            }
 
-                        if (hoek.reach(job.permutations[0], 'provider')) {
-                            config.provider = job.permutations[0].provider;
-                        }
+                            if (hoek.reach(job.permutations[0], 'provider')) {
+                                config.provider = job.permutations[0].provider;
+                            }
 
-                        return Promise.all([
-                            this[executor].start(config),
-                            this.updateCommitStatus(pipeline) // update github
-                        ]);
-                    })
-                )
+                            return this[executor].start(config);
+                        })
+                        .then(() => this.updateCommitStatus(pipeline))
+                ) // update github
                 .then(() => this)
         );
     }

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -406,6 +406,13 @@ function createBuilds(config) {
 
                     buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;
 
+                    const { annotations, freezeWindows } = j.permutations[0];
+                    const isVirtualJob = annotations ? annotations['screwdriver.cd/virtualJob'] === true : false;
+                    const hasFreezeWindows = freezeWindows ? freezeWindows.length > 0 : false;
+
+                    // Bypass execution of the build if the job is virtual
+                    buildConfig.start = !isVirtualJob || (isVirtualJob && hasFreezeWindows);
+
                     return startBuild({
                         decoratedCommit,
                         subscribedConfigSha,

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -411,7 +411,7 @@ function createBuilds(config) {
                     const hasFreezeWindows = freezeWindows ? freezeWindows.length > 0 : false;
 
                     // Bypass execution of the build if the job is virtual
-                    buildConfig.start = !isVirtualJob || (isVirtualJob && hasFreezeWindows);
+                    buildConfig.start = !isVirtualJob || hasFreezeWindows;
 
                     return startBuild({
                         decoratedCommit,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "29.0.0",
+  "version": "31.0.0",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE: Virtual job at the beginning of the event is no longer queued for execution. API changes are needed to process such build to mark its status as 'SUCCESS' and trigger its downstream jobs. 

## Context

When an event is started from the virtual job, build for such job is created and queued for execution immediately after creating the event. 

## Objective

For virtual jobs at the beginning in the workflow for an event,
- set the status of the build to `CREATED` instead of `QUEUED` only if it doesn't have freeze windows

## References

https://github.com/screwdriver-cd/screwdriver/issues/3181

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
