### PR TITLE
fix: Show error details and change status code in case of webhook error [1]

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -267,10 +267,13 @@ async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpd
     const buildCluster = findBuildCluster(allBuildClusters, buildClusterName, pipeline.scmContext);
 
     if (!buildCluster) {
-        throw new Error(
+        const error = new Error(
             `Cluster specified in screwdriver.cd/buildCluster ${buildClusterName} ` +
                 `for scmContext ${pipeline.scmContext} and group ${groupName} does not exist.`
         );
+
+        error.statusCode = 400;
+        throw error;
     }
 
     if (buildCluster.scmContext !== pipeline.scmContext || !hasClusterAccess(pipeline.name, buildCluster)) {

--- a/test/lib/buildFactory.test.js
+++ b/test/lib/buildFactory.test.js
@@ -689,6 +689,7 @@ describe('Build Factory', () => {
                         'Cluster specified in screwdriver.cd/buildCluster iOS ' +
                             `for scmContext ${scmContext} and group default does not exist.`
                     );
+                    assert.strictEqual(err.statusCode, 400);
                 });
         });
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -3213,6 +3213,7 @@ describe('Pipeline Model', () => {
                     'Cluster specified in screwdriver.cd/buildCluster iOS ' +
                         `for scmContext ${pipeline.scmContext} and group default does not exist.`
                 );
+                assert.strictEqual(err.statusCode, 400);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If a user specifies a non-existent buildcluster for a job, models will return an error, but the API will return 500 because no status code is specified.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The user is misconfigured so that it returns 400

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Related: https://github.com/screwdriver-cd/screwdriver/pull/3257

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
