### PR TITLE
fix: publish the patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "31.0.0",
+  "version": "31.0.2",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-models",
-  "version": "31.0.2",
+  "version": "31.0.1",
   "description": "Screwdriver models",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION

## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
semantic-release did not publish the patch version of #636 merge because the PR title was not used in the commit message during the squash merge.

https://cd.screwdriver.cd/pipelines/9/builds/968460/steps/publish

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Increment patch version manually for creating appropriate commits

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#636

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
