### PR TITLE
feat(3266): make changes to models banner to include scope and scopeId

### DIFF
--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -45,10 +45,7 @@ class BannerFactory extends BaseFactory {
         if (!config.isActive) {
             config.isActive = false;
         }
-        if (!config.scope) {
-            config.scope = 'GLOBAL';
-            config.scopeId = null;
-        }
+        
         if ((config.scope === 'PIPELINE' || config.scope === 'BUILD') && !config.scopeId) {
             throw new Error(`scopeId is required when scope is ${config.scope}`);
         }

--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const BaseFactory = require('./baseFactory');
+const PipelineFactory = require('./pipelineFactory');
+const BuildFactory = require('./buildFactory');
 const Banner = require('./banner');
-const { config } = require('screwdriver-data-schema');
 
 let instance;
 
@@ -27,6 +28,7 @@ class BannerFactory extends BaseFactory {
         return new Banner(config);
     }
 
+    // todo: need to make sure some uniqueness here
     /**
      * Create a Banner model
      * @param {Object}  config
@@ -37,7 +39,7 @@ class BannerFactory extends BaseFactory {
      * @param {String}  [config.scope='GLOBAL']    Scope of the banner (GLOBAL|PIPELINE|BUILD)
      * @memberof BannerFactory
      */
-    create(config) {
+    async create(config) {
         if (!config.type) {
             config.type = 'info';
         }
@@ -48,50 +50,69 @@ class BannerFactory extends BaseFactory {
             config.scope = 'GLOBAL';
             config.scopeId = null;
         }
+        // need to make sure that scope can only be some values
         if ((config.scope === 'PIPELINE' || config.scope === 'BUILD') && !config.scopeId) {
             throw new Error(`scopeId is required when scope is ${config.scope}`);
         }
+        if (config.scope === 'PIPELINE') {
+            const pipeline = await PipelineFactory.getInstance().get(config.scopeId);
 
-        // when scope is PIPELINE - need to make sure that the pipeline ID is valid
-        // when scope is BUILD - need to make sure that the build ID is valid
-        // todo: update needs the same as well
+            if (!pipeline) {
+                throw new Error(`Pipeline ${config.scopeId} does not exist`);
+            }
+        }
+        if (config.scope === 'BUILD') {
+            const build = await BuildFactory.getInstance().get(config.scopeId);
+
+            if (!build) {
+                throw new Error(`Build ${config.scopeId} does not exist`);
+            }
+        }
 
         config.createTime = new Date().toISOString();
 
         return super.create(config);
     }
 
+    /**
+     * Helper function to ensure scope and scopeId are set
+     * @param {Object} banner
+     * @return {Object} banner
+     */
+    _setScopeDefaults(banner) {
+        if (!banner.scope) {
+            banner.scope = 'GLOBAL';
+        }
+        if (!banner.scopeId) {
+            banner.scopeId = null;
+        }
+
+        return banner;
+    }
+
+    /**
+     * Retrieves a banner by its ID and sets default scope values.
+     *
+     * @param {number|string} id - The ID of the banner to retrieve.
+     * @returns {Promise<Object>} A promise that resolves to the banner object with default scope values set.
+     */
     async get(id) {
         const response = await super.get(id);
-        // backward compatibility for banners that do not have scope
-        if (!response.scope) {
-            response.scope = 'GLOBAL';
-        }
-        // backward compatibility for banners that do not have scopeId
-        if (!response.scopeId) {
-            response.scopeId = null;
-        }
-        return response;
+
+        return this._setScopeDefaults(response);
     }
 
-    list(config) {
-        const banners = [];
-        return super.list(config).then (response => {
-            response.forEach(banner => {
-                // backward compatibility for banners that do not have scope
-                if (!banner.scope) {
-                    banner.scope = 'GLOBAL';
-                }
-                // backward compatibility for banners that do not have scopeId
-                if (!banner.scopeId) {
-                    banner.scopeId = null;
-                }
-                banners.push(banner);
-            });
-            return banners;
-        });
-    }
+    /**
+     * Retrieves a list of banners and sets default scope values for each banner.
+     *
+     * @param {Object} config - The configuration object for the list request.
+     * @returns {Promise<Array>} A promise that resolves to an array of banners with default scope values set.
+     */
+    async list(config) {
+        const response = await super.list(config);
 
+        return response.map(banner => this._setScopeDefaults(banner));
+    }
 
     /**
      * Get an instance of BannerFactory

--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -51,7 +51,7 @@ class BannerFactory extends BaseFactory {
             BUILD: BuildFactory
         };
 
-        if (scopeFactories[config.scope]) {
+        if (config.scope !== 'GLOBAL') {
             const factory = scopeFactories[config.scope];
             const scopeInstance = await factory.getInstance().get(config.scopeId);
 

--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -28,7 +28,6 @@ class BannerFactory extends BaseFactory {
         return new Banner(config);
     }
 
-    // todo: need to make sure some uniqueness here
     /**
      * Create a Banner model
      * @param {Object}  config
@@ -50,7 +49,6 @@ class BannerFactory extends BaseFactory {
             config.scope = 'GLOBAL';
             config.scopeId = null;
         }
-        // need to make sure that scope can only be some values
         if ((config.scope === 'PIPELINE' || config.scope === 'BUILD') && !config.scopeId) {
             throw new Error(`scopeId is required when scope is ${config.scope}`);
         }

--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -46,9 +46,7 @@ class BannerFactory extends BaseFactory {
             config.isActive = false;
         }
         
-        if ((config.scope === 'PIPELINE' || config.scope === 'BUILD') && !config.scopeId) {
-            throw new Error(`scopeId is required when scope is ${config.scope}`);
-        }
+        
         if (config.scope === 'PIPELINE') {
             const pipeline = await PipelineFactory.getInstance().get(config.scopeId);
 

--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -2,6 +2,7 @@
 
 const BaseFactory = require('./baseFactory');
 const Banner = require('./banner');
+const { config } = require('screwdriver-data-schema');
 
 let instance;
 
@@ -33,6 +34,7 @@ class BannerFactory extends BaseFactory {
      * @param {String}  config.createdBy           The username of the associated user
      * @param {Boolean} [config.isActive=false]    Whether the banner is active
      * @param {String}  [config.type='info']       Type of banner (info|warn|etc)
+     * @param {String}  [config.scope='GLOBAL']    Scope of the banner (GLOBAL|PIPELINE|BUILD)
      * @memberof BannerFactory
      */
     create(config) {
@@ -42,11 +44,54 @@ class BannerFactory extends BaseFactory {
         if (!config.isActive) {
             config.isActive = false;
         }
+        if (!config.scope) {
+            config.scope = 'GLOBAL';
+            config.scopeId = null;
+        }
+        if ((config.scope === 'PIPELINE' || config.scope === 'BUILD') && !config.scopeId) {
+            throw new Error(`scopeId is required when scope is ${config.scope}`);
+        }
+
+        // when scope is PIPELINE - need to make sure that the pipeline ID is valid
+        // when scope is BUILD - need to make sure that the build ID is valid
+        // todo: update needs the same as well
 
         config.createTime = new Date().toISOString();
 
         return super.create(config);
     }
+
+    async get(id) {
+        const response = await super.get(id);
+        // backward compatibility for banners that do not have scope
+        if (!response.scope) {
+            response.scope = 'GLOBAL';
+        }
+        // backward compatibility for banners that do not have scopeId
+        if (!response.scopeId) {
+            response.scopeId = null;
+        }
+        return response;
+    }
+
+    list(config) {
+        const banners = [];
+        return super.list(config).then (response => {
+            response.forEach(banner => {
+                // backward compatibility for banners that do not have scope
+                if (!banner.scope) {
+                    banner.scope = 'GLOBAL';
+                }
+                // backward compatibility for banners that do not have scopeId
+                if (!banner.scopeId) {
+                    banner.scopeId = null;
+                }
+                banners.push(banner);
+            });
+            return banners;
+        });
+    }
+
 
     /**
      * Get an instance of BannerFactory

--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -68,46 +68,6 @@ class BannerFactory extends BaseFactory {
     }
 
     /**
-     * Helper function to ensure scope and scopeId are set
-     * @param {Object} banner
-     * @return {Object} banner
-     */
-    _setScopeDefaults(banner) {
-        if (!banner.scope) {
-            banner.scope = 'GLOBAL';
-        }
-        if (!banner.scopeId) {
-            banner.scopeId = null;
-        }
-
-        return banner;
-    }
-
-    /**
-     * Retrieves a banner by its ID and sets default scope values.
-     *
-     * @param {number|string} id - The ID of the banner to retrieve.
-     * @returns {Promise<Object>} A promise that resolves to the banner object with default scope values set.
-     */
-    async get(id) {
-        const response = await super.get(id);
-
-        return this._setScopeDefaults(response);
-    }
-
-    /**
-     * Retrieves a list of banners and sets default scope values for each banner.
-     *
-     * @param {Object} config - The configuration object for the list request.
-     * @returns {Promise<Array>} A promise that resolves to an array of banners with default scope values set.
-     */
-    async list(config) {
-        const response = await super.list(config);
-
-        return response.map(banner => this._setScopeDefaults(banner));
-    }
-
-    /**
      * Get an instance of BannerFactory
      * @method getInstance
      * @param {Object} config

--- a/lib/bannerFactory.js
+++ b/lib/bannerFactory.js
@@ -45,20 +45,20 @@ class BannerFactory extends BaseFactory {
         if (!config.isActive) {
             config.isActive = false;
         }
-        
-        
-        if (config.scope === 'PIPELINE') {
-            const pipeline = await PipelineFactory.getInstance().get(config.scopeId);
 
-            if (!pipeline) {
-                throw new Error(`Pipeline ${config.scopeId} does not exist`);
-            }
-        }
-        if (config.scope === 'BUILD') {
-            const build = await BuildFactory.getInstance().get(config.scopeId);
+        const scopeFactories = {
+            PIPELINE: PipelineFactory,
+            BUILD: BuildFactory
+        };
 
-            if (!build) {
-                throw new Error(`Build ${config.scopeId} does not exist`);
+        if (scopeFactories[config.scope]) {
+            const factory = scopeFactories[config.scope];
+            const scopeInstance = await factory.getInstance().get(config.scopeId);
+
+            if (!scopeInstance) {
+                throw new Error(
+                    `${config.scope.charAt(0) + config.scope.slice(1).toLowerCase()} ${config.scopeId} does not exist`
+                );
             }
         }
 

--- a/test/lib/bannerFactory.test.js
+++ b/test/lib/bannerFactory.test.js
@@ -142,32 +142,6 @@ describe('Banner Factory', () => {
                 });
         });
 
-        // todo: fix
-        it('should throw error when creating a Banner with invalid scope', () => {
-            datastore.save.resolves({
-                ...bannerData,
-                scope: 'GLOBAL',
-                scopeId: null
-            });
-
-            return factory
-                .create({
-                    message,
-                    type,
-                    isActive,
-                    scope: 'INVALID'
-                })
-                .then(() => {
-                    // console.log(model);
-                    // do something else here
-                    assert.fail('nope');
-                })
-                .catch(err => {
-                    console.log(err);
-                    // assert.equal('Invalid scope', err.message);
-                });
-        });
-
         it('should throw error when creating a Banner with invalid scopeId', () => {
             return factory
                 .create({

--- a/test/lib/bannerFactory.test.js
+++ b/test/lib/bannerFactory.test.js
@@ -15,9 +15,7 @@ describe('Banner Factory', () => {
         id: bannerId,
         message,
         type,
-        isActive,
-        scope: 'GLOBAL',
-        scopeId: null
+        isActive
     };
 
     let BannerFactory;
@@ -61,13 +59,16 @@ describe('Banner Factory', () => {
 
     describe('create', () => {
         it('should create a Banner with GLOBAL scope', () => {
-            datastore.save.resolves(bannerData);
+            const dataWithGlobalScope = { ...bannerData, scope: 'GLOBAL' };
+
+            datastore.save.resolves(dataWithGlobalScope);
 
             return factory
                 .create({
                     message,
                     type,
-                    isActive
+                    isActive,
+                    scope: 'GLOBAL'
                 })
                 .then(model => {
                     assert.isTrue(datastore.save.calledOnce);
@@ -139,22 +140,6 @@ describe('Banner Factory', () => {
                     Object.keys(bannerData).forEach(key => {
                         assert.strictEqual(model[key], dataWithDefaults[key]);
                     });
-                });
-        });
-
-        it('should throw error when creating a Banner with invalid scopeId', () => {
-            return factory
-                .create({
-                    message,
-                    type,
-                    isActive,
-                    scope: 'PIPELINE'
-                })
-                .then(() => {
-                    assert.fail('nope');
-                })
-                .catch(err => {
-                    assert.equal('scopeId is required when scope is PIPELINE', err.message);
                 });
         });
 

--- a/test/lib/bannerFactory.test.js
+++ b/test/lib/bannerFactory.test.js
@@ -15,7 +15,8 @@ describe('Banner Factory', () => {
         id: bannerId,
         message,
         type,
-        isActive
+        isActive,
+        scope: 'GLOBAL'
     };
 
     let BannerFactory;
@@ -59,9 +60,7 @@ describe('Banner Factory', () => {
 
     describe('create', () => {
         it('should create a Banner with GLOBAL scope', () => {
-            const dataWithGlobalScope = { ...bannerData, scope: 'GLOBAL' };
-
-            datastore.save.resolves(dataWithGlobalScope);
+            datastore.save.resolves(bannerData);
 
             return factory
                 .create({
@@ -89,7 +88,8 @@ describe('Banner Factory', () => {
             return factory
                 .create({
                     message,
-                    isActive
+                    isActive,
+                    scope: 'GLOBAL'
                 })
                 .then(model => {
                     assert.isTrue(datastore.save.calledOnce);
@@ -110,7 +110,8 @@ describe('Banner Factory', () => {
             return factory
                 .create({
                     message,
-                    type
+                    type,
+                    scope: 'GLOBAL'
                 })
                 .then(model => {
                     assert.isTrue(datastore.save.calledOnce);
@@ -131,7 +132,8 @@ describe('Banner Factory', () => {
 
             return factory
                 .create({
-                    message
+                    message,
+                    scope: 'GLOBAL'
                 })
                 .then(model => {
                     assert.isTrue(datastore.save.calledOnce);


### PR DESCRIPTION
## Context

The current banner schema is implemented at a global level, lacking any concept of scope or scopeId.

## Objective

There are instances where a banner is required only at the pipeline or build level. This change incorporates this concept into the banner model.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3266

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
