### PR TITLE
fix(3272): Error while creating an event with a skip message

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -925,7 +925,7 @@ class EventFactory extends BaseFactory {
                                 .then(p => {
                                     // Skip creating & starting builds
                                     if (skipMessage) {
-                                        return event;
+                                        return null;
                                     }
 
                                     // Start builds

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -943,6 +943,7 @@ describe('Event Factory', () => {
 
                 return eventFactory.create(config).then(model => {
                     assert.instanceOf(model, Event);
+                    assert.equal(model.builds, null);
                     assert.notCalled(jobFactoryMock.create);
                     assert.notCalled(buildFactoryMock.create);
                     assert.calledOnce(pipelineMock.sync);


### PR DESCRIPTION
## Context

After an event is created via SCM webhook with a skip message "[skip ci]", no builds are created.
In such scenario, the event itself is set as the `builds` on the event which is incorrect.

https://github.com/screwdriver-cd/screwdriver/pull/3261 added a logic which iterates the builds that are created after the event to process the workflow for virtual builds. This new logic expects the `builds` set on the event to be either null or an array.

Due to the above mentioned incorrect the mapping, the new logic is failing with the below error
```
Error: Failed to start some events caused by \"event.builds.filter is not a function
```

## Objective

After the event creation, when the builds are meant to be skipped, set `null` as the `builds` on the event.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3272

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
