### PR TITLE
feat(#11530): merge admin annotation override on job update

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -229,11 +229,16 @@ function findBuildCluster(allBuildClusters, buildClusterName, scmContext) {
 async function getManagedBuildClusterName({ annotations, pipeline, isPipelineUpdate, provider }) {
     const allBuildClustersByGroup = await listBuildClustersByGroup();
     const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+    const buildClusterOverride = 'screwdriver.cd/sdAdminBuildClusterOverride';
     const pipelineAnnotations = hoek.reach(pipeline, 'annotations', { default: {} });
     let buildClusterName;
 
     if (annotations) {
         buildClusterName = annotations[buildClusterAnnotation] || '';
+
+        if (annotations[buildClusterOverride]) {
+            buildClusterName = annotations[buildClusterOverride];
+        }
     }
 
     if (!buildClusterName && pipelineAnnotations) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -17,6 +17,7 @@ const MAX_METRIC_GET_COUNT = 1000;
 const MAX_BUILD_DELETE_COUNT = 100;
 const DEFAULT_COUNT = 10;
 const DEPLOY_KEY_SECRET = 'SD_SCM_DEPLOY_KEY';
+const BUILD_CLUSTER_OVERRIDE_ANNOTATION = 'screwdriver.cd/sdAdminBuildClusterOverride';
 
 /**
  * Find metrics and step metrics related to the build
@@ -241,15 +242,14 @@ class Job extends BaseModel {
         const oldPeriodic = getAnnotations(oldJob.permutations[0], 'screwdriver.cd/buildPeriodically');
 
         // check if override exits in datastore
-        const buildClusterOverrideAnnotation = 'screwdriver.cd/sdAdminBuildClusterOverride';
-        const buildClusterOverride = getAnnotations(oldJob.permutations[0], buildClusterOverrideAnnotation);
+        const buildClusterOverride = getAnnotations(oldJob.permutations[0], BUILD_CLUSTER_OVERRIDE_ANNOTATION);
 
         // merge admin annotation
         if (buildClusterOverride) {
             const [permutation] = this.permutations;
 
             permutation.annotations = permutation.annotations || {};
-            permutation.annotations[buildClusterOverrideAnnotation] = buildClusterOverride;
+            permutation.annotations[BUILD_CLUSTER_OVERRIDE_ANNOTATION] = buildClusterOverride;
         }
 
         const newJob = await super.update();
@@ -440,6 +440,28 @@ class Job extends BaseModel {
                 })
             )
         );
+    }
+
+    /**
+     * Update a job's build cluster annotation information
+     * This method should not be used to produce any other side effects
+     * @method update
+     * @return {Promise}
+     */
+    async updateBuildCluster() {
+        /* eslint-disable global-require */
+        const JobFactory = require('./jobFactory');
+        const jobFactory = JobFactory.getInstance();
+        const oldJob = await jobFactory.get(this.id);
+        const oldBuildClusterOverride = getAnnotations(oldJob.permutations[0], BUILD_CLUSTER_OVERRIDE_ANNOTATION);
+        const newBuildClusterOverride = getAnnotations(this.permutations[0], BUILD_CLUSTER_OVERRIDE_ANNOTATION);
+
+        // prevent any side effects if annotation not present or unchanged
+        if (oldBuildClusterOverride === newBuildClusterOverride) {
+            return null;
+        }
+
+        return super.update();
     }
 }
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -240,6 +240,18 @@ class Job extends BaseModel {
         const oldJob = await jobFactory.get(this.id);
         const oldPeriodic = getAnnotations(oldJob.permutations[0], 'screwdriver.cd/buildPeriodically');
 
+        // check if override exits in datastore
+        const buildClusterOverrideAnnotation = 'screwdriver.cd/sdAdminBuildClusterOverride';
+        const buildClusterOverride = getAnnotations(oldJob.permutations[0], buildClusterOverrideAnnotation);
+
+        // merge admin annotation
+        if (buildClusterOverride) {
+            const [permutation] = this.permutations;
+
+            permutation.annotations = permutation.annotations || {};
+            permutation.annotations[buildClusterOverrideAnnotation] = buildClusterOverride;
+        }
+
         const newJob = await super.update();
         const pipeline = await pipelineFactory.get(newJob.pipelineId);
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -445,7 +445,7 @@ class Job extends BaseModel {
     /**
      * Update a job's build cluster annotation information
      * This method should not be used to produce any other side effects
-     * @method update
+     * @method updateBuildCluster
      * @return {Promise}
      */
     async updateBuildCluster() {


### PR DESCRIPTION
## Context

Build Cluster annotation on a job is currently only derived from pipeline or from screwdriver config.
Screwdriver Admin should have a way to override the behavior to move jobs to specific cluster

## Objective

This PR adds logic 
1. to check for admin override annotation from db and merge it to the job annotation if it exits.
2. select build cluster for a job if the override annotation exists
3. add new fn updateBuildCluster to allow updating annotation without any other job side effects

## References

https://github.com/screwdriver-cd/screwdriver/issues/3292

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
