### PR TITLE
fix(3193): use remoteName instead of displayName to store the upstream remote trigger's pipeline name [1]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1127,7 +1127,8 @@ class PipelineModel extends BaseModel {
             pipelineJobs: updatedJobs
         });
 
-        const { nodes } = this.workflowGraph;
+        const { nodes, edges } = this.workflowGraph;
+        const srcEdgeNames = Object.fromEntries(edges.map(edge => [edge.src, true]));
 
         // Add jobId to workflowGraph.nodes
         await Promise.all(
@@ -1148,7 +1149,10 @@ class PipelineModel extends BaseModel {
                                 const { name, branch } = externalPipeline.scmRepo;
 
                                 node.id = externalJob.id;
-                                node.displayName = `${name}#${branch}:${externalJob.name}`;
+
+                                if (srcEdgeNames[node.name]) {
+                                    node.remoteName = `${name}#${branch}:${externalJob.name}`;
+                                }
                             } else {
                                 logger.error(
                                     `pipelineId:${externalPipelineId}: workflow has no job:${externalJobName}.`

--- a/test/data/parserWithExternalJobs.json
+++ b/test/data/parserWithExternalJobs.json
@@ -3,6 +3,7 @@
         "main": [
             {
                 "image": "node:4",
+                "requires": ["~pr", "~commit", "sd@123:bar"],
                 "commands": [
                     {
                         "name": "init",
@@ -20,6 +21,7 @@
             },
             {
                 "image": "node:5",
+                "requires": ["~pr", "~commit", "sd@123:bar"],
                 "commands": [
                     {
                         "name": "init",
@@ -37,6 +39,7 @@
             },
             {
                 "image": "node:6",
+                "requires": ["~pr", "~commit", "sd@123:bar"],
                 "commands": [
                     {
                         "name": "init",
@@ -78,16 +81,24 @@
         ]
     },
     "workflowGraph": {
-        "nodes": [{ "name": "~pr" }, { "name": "~commit" }, { "name": "main", "id": 3 }],
-        "edges": []
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" },
+            { "name": "sd@123:foo" },
+            { "name": "sd@123:bar" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" },
+            { "src": "publish", "dest": "sd@123:foo" },
+            { "src": "sd@123:bar", "dest": "main" }
+        ]
     },
     "annotations": {
         "beta.screwdriver.cd/executor" : "screwdriver-executor-vm",
         "screwdriver.cd/chainPR" : true
-    },
-    "subscribe": {
-        "scmUrls": [{
-            "git@github.com:baz/foo.git": ["~commit", "~tags", "~release"]
-        }]
     }
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, the name of upstream pipelines are stored in `displayName` to show them on the workflow graph.
However, there are the following issues:

- `displayName` is also used to label normal job, so it makes a little confused on UI side
- Downstream nodes have the name of pipeline unnecessarily

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Use `remoteName` instead of `displayName`
- Store the pipeline name only if the node is upstream trigger

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue: https://github.com/screwdriver-cd/screwdriver/issues/3193
- PR: https://github.com/screwdriver-cd/models/pull/628

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
