### PR TITLE
feat(3322): Add a DELETING state to the pipeline to block updates during the pipeline deletion [2]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -488,6 +488,10 @@ class PipelineModel extends BaseModel {
      * @return  {Promise}
      */
     async addWebhooks(webhookUrl) {
+        if (this.state === 'DELETING') {
+            throw boom.conflict('This pipeline is being deleted.');
+        }
+
         const webhookUrlsWithActionsList = [];
         const webhookUrlWithActions = {
             webhookUrl,
@@ -557,6 +561,10 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     async syncPRs() {
+        if (this.state === 'DELETING') {
+            throw boom.conflict('This pipeline is being deleted.');
+        }
+
         const token = await this.token;
 
         return Promise.all([
@@ -591,6 +599,10 @@ class PipelineModel extends BaseModel {
      * @return  {Promise}
      */
     async syncPR(prNum) {
+        if (this.state === 'DELETING') {
+            throw boom.conflict('This pipeline is being deleted.');
+        }
+
         const token = await this.token;
         const prInfo = await this.scm.getPrInfo({
             scmUri: this.scmUri,
@@ -819,6 +831,12 @@ class PipelineModel extends BaseModel {
         const pipeline = await pipelineFactory.get({ scmUri });
 
         if (pipeline) {
+            if (pipeline.state === 'DELETING') {
+                logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} is been deleted.`);
+
+                return null;
+            }
+
             // Child pipeline belongs to this parent, update it
             if (pipeline.configPipelineId === this.id) {
                 pipeline.admins = newAdmins;
@@ -991,6 +1009,10 @@ class PipelineModel extends BaseModel {
      * @return {Promise}
      */
     async sync(ref, chainPR = false) {
+        if (this.state === 'DELETING') {
+            throw boom.conflict('This pipeline is being deleted.');
+        }
+
         // Lazy load factory dependency to prevent circular dependency issues
         // https://nodejs.org/api/modules.html#modules_cycles
         /* eslint-disable global-require */
@@ -1806,7 +1828,24 @@ class PipelineModel extends BaseModel {
      * collections, and remove the pipeline itself
      * @return {Promise}        Resolves to null if removed successfully
      */
-    remove() {
+    async remove() {
+        const latestBuilds = await this.getBuilds();
+
+        if (latestBuilds.some(b => ['QUEUED', 'RUNNING', 'BLOCKED'].includes(b.status))) {
+            logger.error(`pipelineId:${this.id}: Some builds are still running.`);
+
+            throw boom.conflict('Some builds are still running.');
+        }
+
+        if (this.state === 'DELETING') {
+            logger.error(`pipelineId:${this.id}: This pipeline is being deleted.`);
+
+            throw boom.conflict('This pipeline is being deleted.');
+        }
+
+        this.state = 'DELETING';
+        await this.update();
+
         const pipelineFactory = this._getPipelineFactory();
 
         const removeJobs = archived =>
@@ -1957,22 +1996,24 @@ class PipelineModel extends BaseModel {
             });
         };
 
-        return removeSecrets() // remove secrets
-            .then(() => removeTokens()) // remove tokens
-            .then(() => removeTriggers()) // remove triggers
-            .then(() => removeJobs(true)) // remove archived jobs
-            .then(() => removeJobs(false)) // remove non-archived jobs
-            .then(() => removeEvents('pipeline')) // remove pipeline events
-            .then(() => removeEvents('pr')) // remove pr events
-            .then(() => removeChildPipelines()) // remove pr events
-            .then(() => removeStagesAndStageBuilds()) // remove stages and stageBuilds
-            .then(() => removeFromCollections())
-            .then(() => super.remove()) // remove pipeline
-            .catch(err => {
-                logger.error(`pipelineId:${this.id}: Failed to remove pipeline. :${err}`);
+        try {
+            await removeSecrets(); // remove secrets
+            await removeTokens(); // remove tokens
+            await removeTriggers(); // remove triggers
+            await removeJobs(true); // remove archived jobs
+            await removeJobs(false); // remove non-archived jobs
+            await removeEvents('pipeline'); // remove pipeline events
+            await removeEvents('pr'); // remove pr events
+            await removeChildPipelines(); // remove pr events
+            await removeStagesAndStageBuilds(); // remove stages and stageBuilds
+            await removeFromCollections();
+            await super.remove(); // remove pipeline
+        } catch (err) {
+            logger.error(`pipelineId:${this.id}: Failed to remove pipeline. :${err}`);
+            throw err;
+        }
 
-                throw err;
-            });
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Pipeline related data is remaining after delete pipeline.
Details - https://github.com/screwdriver-cd/screwdriver/issues/3322

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Check no builds are running before delete pipeline
- Change `pipeline.state` to DELETING just before delete the pipeline
- Block update methods if the state is DELETING

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3322
PRs
- [1] https://github.com/screwdriver-cd/data-schema/pull/598
- [3] https://github.com/screwdriver-cd/screwdriver/pull/3327

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
