### PR TITLE
feat(3328): Set event status to CREATED on creation

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -757,7 +757,8 @@ class EventFactory extends BaseFactory {
             creator: config.creator || null,
             meta: config.meta || {},
             pr: {},
-            prNum
+            prNum,
+            status: 'CREATED'
         };
         let prevChainPR = '';
         let decoratedCommit;

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -30,6 +30,7 @@ class Event {
         this.meta = config.meta;
         this.sha = config.sha;
         this.type = config.type;
+        this.status = config.status;
         this.update = updateStub.resolves(this);
     }
 }
@@ -1586,6 +1587,7 @@ describe('Event Factory', () => {
 
                 return eventFactory.create(config).then(model => {
                     assert.instanceOf(model, Event);
+                    assert.equal(model.status, 'CREATED');
                     assert.notCalled(jobFactoryMock.create);
                     assert.notCalled(syncedPipelineMock.syncPR);
                     assert.calledOnce(pipelineMock.sync);
@@ -1639,6 +1641,7 @@ describe('Event Factory', () => {
 
                 return eventFactory.create(config).then(model => {
                     assert.instanceOf(model, Event);
+                    assert.equal(model.status, 'CREATED');
                     assert.notCalled(jobFactoryMock.create);
                     assert.notCalled(syncedPipelineMock.syncPR);
                     assert.calledOnce(pipelineMock.sync);
@@ -1814,6 +1817,7 @@ describe('Event Factory', () => {
 
                 return eventFactory.create(config).then(model => {
                     assert.instanceOf(model, Event);
+                    assert.equal(model.status, 'CREATED');
                     assert.deepEqual(model.configPipelineSha, 'configpipelinesha');
                     assert.calledWith(pipelineMock.sync, 'configpipelinesha');
                     assert.calledWith(
@@ -2008,6 +2012,7 @@ describe('Event Factory', () => {
 
                 return eventFactory.create(config).then(model => {
                     assert.instanceOf(model, Event);
+                    assert.equal(model.status, 'CREATED');
                     assert.notCalled(jobFactoryMock.create);
                     assert.called(jobFactoryMock.list);
                     assert.calledWith(
@@ -2027,6 +2032,7 @@ describe('Event Factory', () => {
         it('should create an Event', () =>
             eventFactory.create(config).then(model => {
                 assert.instanceOf(model, Event);
+                assert.equal(model.status, 'CREATED');
                 assert.calledWith(scm.decorateAuthor, {
                     username: 'stjohn',
                     scmContext,
@@ -2061,6 +2067,7 @@ describe('Event Factory', () => {
 
             return eventFactory.create(config).then(model => {
                 assert.instanceOf(model, Event);
+                assert.equal(model.status, 'CREATED');
                 assert.calledWith(scm.decorateAuthor, {
                     username: 'stjohn',
                     scmContext,
@@ -2126,6 +2133,7 @@ describe('Event Factory', () => {
 
             return eventFactory.create(config).then(model => {
                 assert.instanceOf(model, Event);
+                assert.equal(model.status, 'CREATED');
                 assert.notCalled(scm.decorateAuthor);
                 assert.calledWith(scm.decorateCommit, {
                     scmUri: 'github.com:1234:branch',
@@ -2160,6 +2168,7 @@ describe('Event Factory', () => {
 
             return eventFactory.create(config).then(model => {
                 assert.instanceOf(model, Event);
+                assert.equal(model.status, 'CREATED');
                 assert.notCalled(scm.decorateAuthor);
                 assert.calledWith(scm.decorateCommit, {
                     scmUri: 'github.com:1234:branch',


### PR DESCRIPTION
## Context
A new field `status` has been added for `event` to track the overall execution status for an event.
https://github.com/screwdriver-cd/data-schema/pull/599


## Objective

Set the `status` to `CREATED` when an event is created.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3328

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
