### PR TITLE
feat: add pr-closed check in event create

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -8,7 +8,8 @@ const {
     RELEASE_TRIGGER,
     TAG_TRIGGER,
     QUALIFIED_STAGE_NAME,
-    STAGE_SETUP_TEARDOWN_JOB_NAME
+    STAGE_SETUP_TEARDOWN_JOB_NAME,
+    PR_CLOSED_TRIGGER
 } = require('screwdriver-data-schema').config.regex;
 const workflowParser = require('screwdriver-workflow-parser');
 const logger = require('screwdriver-logger');
@@ -38,6 +39,7 @@ function getJobsFromTrigger(config) {
         COMMIT_TRIGGER.test(startFrom),
         RELEASE_TRIGGER.test(startFrom),
         TAG_TRIGGER.test(startFrom),
+        PR_CLOSED_TRIGGER.test(startFrom),
         startFrom === '~subscribe'
     ];
 
@@ -77,6 +79,14 @@ function getJobsFromTrigger(config) {
         nextJobs = nextJobs.concat(
             workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
                 trigger: '~subscribe'
+            })
+        );
+    }
+
+    if (startFrom.match(PR_CLOSED_TRIGGER)) {
+        nextJobs = nextJobs.concat(
+            workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
+                trigger: startFrom
             })
         );
     }
@@ -179,7 +189,7 @@ function getJobsFromPR(config) {
  * @param  {Object}   config.buildConfig        Build Config to create the build with
  * @param  {String}   config.startFrom          Startfrom (e.g. ~commit, ~pr, etc)
  * @param  {Array}    config.changedFiles       List of files that were changed
- * @param  {Array}    config.sourcePaths        List of soure paths
+ * @param  {Array}    config.sourcePaths        List of source paths
  * @param  {Boolean}  [config.webhooks]         If the create came from a webhook (pr or push) or not
  * @param  {Boolean}  [config.isPR]             Is it PR?
  * @param  {Object}   [config.decoratedCommit]  Decorated commit object
@@ -318,7 +328,7 @@ function startBuild(config) {
  * @param  {String}   [config.ref]                           SCM webhook ref
  * @param  {Boolean}  [config.isPR]                          Is it PR?
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
- * @param  {Object}   [config.pipeline]                      Default pipeline config from databse
+ * @param  {Object}   [config.pipeline]                      Default pipeline config from database
  * @param  {Object}   [config.pipelineConfig]                Current Pipeline config
  */
 function createBuilds(config) {
@@ -786,6 +796,10 @@ class EventFactory extends BaseFactory {
 
                             return p.sync(commitSha, chainPR);
                         });
+                    }
+
+                    if (startFrom && startFrom.match(PR_CLOSED_TRIGGER)) {
+                        return p.sync(config.sha, chainPR);
                     }
 
                     return p.sync(null, chainPR);

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "screwdriver-config-parser": "^12.0.0",
-    "screwdriver-data-schema": "^25.0.0",
+    "screwdriver-data-schema": "^25.5.0",
     "screwdriver-logger": "^3.0.0",
     "screwdriver-workflow-parser": "^6.0.0"
   }


### PR DESCRIPTION
## Context

Screwdriver should support triggering jobs when pull_request closed webhook event is received

## Objective

This PR adds support for pr closed event creation

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
