### PR TITLE
feat(3235): migrate meta settings from launcher to API [2]

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1002,10 +1002,10 @@ class BuildModel extends BaseModel {
             mergedMeta = _.merge(mergedMeta, event.meta);
         }
 
-        const pipeline = await this.pipeline;
+        const job = await this.job;
 
         if (this.parentBuildId) {
-            mergedMeta = await mergeParentBuildsMeta(this.parentBuildId, pipeline.id, mergedMeta);
+            mergedMeta = await mergeParentBuildsMeta(this.parentBuildId, job.pipelineId, mergedMeta);
         }
         // Initialize pr comments (Issue #1858)
         if (mergedMeta.meta) {
@@ -1016,9 +1016,7 @@ class BuildModel extends BaseModel {
             mergedMeta.parameters = this.meta.parameters;
         }
 
-        const job = await this.job;
-
-        mergedMeta.build = constructBuildMeta(this, pipeline.id, job, mergedMeta);
+        mergedMeta.build = constructBuildMeta(this, job.pipelineId, job, mergedMeta);
         mergedMeta.event = constructEventMeta(event.creator.username, mergedMeta);
 
         this.meta = mergedMeta;

--- a/lib/build.js
+++ b/lib/build.js
@@ -4,6 +4,7 @@ const boom = require('@hapi/boom');
 const dayjs = require('dayjs');
 const hoek = require('@hapi/hoek');
 const deepcopy = require('deepcopy');
+const _ = require('lodash');
 const logger = require('screwdriver-logger');
 const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const { SCM_STATE_MAP, SCM_STATUSES } = require('screwdriver-data-schema').plugins.scm;
@@ -271,6 +272,122 @@ function getToken(self, job, pipeline) {
     return token;
 }
 
+/**
+ * @description Merges metadata from the parent event if available
+ * @param {number} parentEventId - The ID of the parent event
+ * @param {Object} mergedMeta - The current state of merged metadata
+ * @returns {Object} The updated merged metadata
+ */
+async function mergeParentEventMeta(parentEventId, mergedMeta) {
+    let resultMeta = mergedMeta;
+
+    if (parentEventId) {
+        // eslint-disable-next-line global-require
+        const EventFactory = require('./eventFactory');
+        const eventFactory = EventFactory.getInstance();
+        const parentEvent = await eventFactory.get(parentEventId);
+
+        resultMeta = _.merge(mergedMeta, parentEvent.meta);
+    }
+
+    return resultMeta;
+}
+
+/**
+ * @description Merges metadata from an external build
+ * @param {Object} mergedMeta - The current state of merged metadata
+ * @param {Object} parentJob - The job object associated with the parent build
+ * @param {Object} parentBuildMeta - The metadata from the parent build
+ * @returns {Object} The updated merged metadata
+ */
+function mergeExternalBuildMeta(mergedMeta, parentJob, parentBuildMeta) {
+    const jobName = parentJob.name;
+
+    mergedMeta.sd = mergedMeta.sd || {};
+    mergedMeta.sd[parentJob.pipelineId] = mergedMeta.sd[parentJob.pipelineId] || {};
+    mergedMeta.sd[parentJob.pipelineId][jobName] = _.merge(
+        mergedMeta.sd[parentJob.pipelineId][jobName] || {},
+        parentBuildMeta
+    );
+
+    return mergedMeta;
+}
+
+/**
+ * @description Merges metadata from parent builds if available
+ * @param {number|number[]} parentBuildId - The ID or list of IDs of parent builds
+ * @param {number} pipelineId - The ID of the pipeline
+ * @param {Object} mergedMeta - The current state of merged metadata
+ * @returns {Object} The updated merged metadata
+ */
+async function mergeParentBuildsMeta(parentBuildId, pipelineId, mergedMeta) {
+    // eslint-disable-next-line global-require
+    const BuildFactory = require('./buildFactory');
+    const buildFactory = BuildFactory.getInstance();
+    const parentBuildIds = Array.isArray(parentBuildId) ? parentBuildId : [Number(parentBuildId)];
+
+    const parentBuilds = await Promise.all(parentBuildIds.map(id => buildFactory.get(id)));
+
+    parentBuilds.sort((a, b) => a.endTime - b.endTime);
+
+    // eslint-disable-next-line global-require
+    const JobFactory = require('./jobFactory');
+    const jobFactory = JobFactory.getInstance();
+
+    let resultMeta = mergedMeta;
+
+    for (const parentBuild of parentBuilds) {
+        if (parentBuild.meta) {
+            const parentJob = await jobFactory.get(parentBuild.jobId);
+
+            if (parentJob.pipelineId !== pipelineId) {
+                delete parentBuild.meta.parameters;
+                resultMeta = mergeExternalBuildMeta(mergedMeta, parentJob, parentBuild.meta);
+            }
+
+            resultMeta = _.merge(mergedMeta, parentBuild.meta);
+        }
+    }
+
+    return resultMeta;
+}
+
+/**
+ * @description Constructs the build metadata
+ * @param {Object} self - The build model instance
+ * @param {number} pipelineId - The ID of the pipeline
+ * @param {Object} job - The job object
+ * @param {Object} mergedMeta - The current state of merged metadata
+ * @returns {Object} The constructed build metadata
+ */
+function constructBuildMeta(self, pipelineId, job, mergedMeta) {
+    const buildMeta = {
+        pipelineId: String(pipelineId),
+        eventId: String(self.eventId),
+        jobId: String(job.id),
+        buildId: String(self.id),
+        jobName: job.name,
+        sha: self.sha
+    };
+    const mergedBuildMeta = mergedMeta.build ? _.merge(mergedMeta.build, buildMeta) : buildMeta;
+
+    delete mergedBuildMeta.warning;
+
+    return mergedBuildMeta;
+}
+
+/**
+ * @description Constructs the event metadata
+ * @param {string} creatorName - The username of the event creator
+ * @param {Object} mergedMeta - The current state of merged metadata
+ * @returns {Object} The constructed event metadata
+ */
+function constructEventMeta(creatorName, mergedMeta) {
+    const eventMeta = { creator: creatorName };
+
+    return mergedMeta.event ? _.merge(mergedMeta.event, eventMeta) : eventMeta;
+}
+
 class BuildModel extends BaseModel {
     /**
      * Construct a BuildModel object
@@ -483,6 +600,28 @@ class BuildModel extends BaseModel {
         return secrets;
     }
 
+    get event() {
+        // Lazy load factory dependency to prevent circular dependency issues
+        // https://nodejs.org/api/modules.html#modules_cycles
+        /* eslint-disable global-require */
+        const EventFactory = require('./eventFactory');
+        /* eslint-enable global-require */
+
+        delete this.event;
+        const factory = EventFactory.getInstance();
+        const event = factory.get(this.eventId);
+
+        // ES6 has weird getters and setters in classes,
+        // so we redefine the pipeline property here to resolve to the
+        // resulting promise and not try to recreate the factory, etc.
+        Object.defineProperty(this, 'event', {
+            enumerable: true,
+            value: event
+        });
+
+        return event;
+    }
+
     /**
      * Start this build and update commit status as pending
      * @method start
@@ -521,6 +660,8 @@ class BuildModel extends BaseModel {
                 template.version = version;
             }
         }
+
+        await this.initMeta();
 
         // Make sure that a pipeline and job is associated with the build
         return this.job.then(job =>
@@ -842,6 +983,45 @@ class BuildModel extends BaseModel {
 
                 return Object.assign(deepcopy(this.toJson()), { steps });
             });
+    }
+
+    /**
+     * @description Initializes the metadata for the build
+     * @returns {Promise} A promise that resolves when the metadata is initialized and updated
+     */
+    async initMeta() {
+        let mergedMeta = this.meta ? _.merge({}, this.meta) : {};
+
+        const event = await this.event;
+
+        mergedMeta = await mergeParentEventMeta(event.parentEventId, mergedMeta);
+
+        if (event.meta) {
+            mergedMeta = _.merge(mergedMeta, event.meta);
+        }
+
+        const pipeline = await this.pipeline;
+
+        if (this.parentBuildId) {
+            mergedMeta = await mergeParentBuildsMeta(this.parentBuildId, pipeline.id, mergedMeta);
+        }
+        // Initialize pr comments (Issue #1858)
+        if (mergedMeta.meta) {
+            delete mergedMeta.meta.summary;
+        }
+        // Set build parameter explicitly (Issue #2501)
+        if (this.meta.parameters) {
+            mergedMeta.parameters = this.meta.parameters;
+        }
+
+        const job = await this.job;
+
+        mergedMeta.build = constructBuildMeta(this, pipeline.id, job, mergedMeta);
+        mergedMeta.event = constructEventMeta(event.creator.username, mergedMeta);
+
+        this.meta = mergedMeta;
+
+        return this.update();
     }
 }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -326,9 +326,11 @@ async function mergeParentBuildsMeta(parentBuildId, pipelineId, mergedMeta) {
     const buildFactory = BuildFactory.getInstance();
     const parentBuildIds = Array.isArray(parentBuildId) ? parentBuildId : [Number(parentBuildId)];
 
-    const parentBuilds = await Promise.all(parentBuildIds.map(id => buildFactory.get(id)));
+    const parentBuilds = await buildFactory.list({
+        params: { id: parentBuildIds }
+    });
 
-    parentBuilds.sort((a, b) => a.endTime - b.endTime);
+    parentBuilds.sort((a, b) => new Date(a.endTime) - new Date(b.endTime));
 
     // eslint-disable-next-line global-require
     const JobFactory = require('./jobFactory');

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1983,7 +1983,7 @@ describe('Build Model', () => {
             jobFactoryMock.get.withArgs(777).resolves({
                 id: 777,
                 name: 'thisJob',
-                pipeline: Promise.resolve(pipelineMock)
+                pipelineId: 1234
             });
         });
 

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -117,7 +117,8 @@ describe('Build Model', () => {
             get: sinon.stub()
         };
         buildFactoryMock = {
-            get: sinon.stub()
+            get: sinon.stub(),
+            list: sinon.stub().resolves([])
         };
 
         pipelineMock = {
@@ -2034,45 +2035,55 @@ describe('Build Model', () => {
                 creator: { username: 'St John' }
             });
             // Mock parent builds with metadata
-            buildFactoryMock.get.withArgs(8000).resolves({
-                jobId: 800,
-                endTime: new Date('2025-01-01T08:00:00.000Z'),
-                meta: {
-                    meta1: 'set by second newest parent build', // Overwritten by the newest parent build
-                    meta2: 'set by second newest parent build', // Remains
-                    parameters: { param1: 'set by second newest parent build' } // Remains
-                }
-            });
-            buildFactoryMock.get.withArgs(8001).resolves({
-                jobId: 801,
-                endTime: new Date('2025-01-01T09:00:00.000Z'),
-                meta: {
-                    meta1: 'set by the newest parent build' // Remains
-                }
-            });
-            // Mock parent external builds with metadata
-            buildFactoryMock.get.withArgs(9000).resolves({
-                jobId: 900,
-                endTime: new Date('2025-01-01T10:00:00.000Z'),
-                meta: {
-                    meta5: 'set by the external parent build 1', // Overwritten by the newest parent external build
-                    parameters: { param2: 'set by external parent build 1' } // This should be deleted
-                }
-            });
-            buildFactoryMock.get.withArgs(9001).resolves({
-                jobId: 901,
-                endTime: new Date('2025-01-01T11:00:00.000Z'),
-                meta: {
-                    meta5: 'set by the external parent build 2' // Remains
-                }
-            });
-            buildFactoryMock.get.withArgs(9002).resolves({
-                jobId: 902,
-                endTime: new Date('2025-01-01T10:30:00.000Z'),
-                meta: {
-                    meta5: 'set by the external parent build 3' // Overwritten by the newest parent external build
-                }
-            });
+            buildFactoryMock.list
+                .withArgs({
+                    params: { id: build.parentBuildId }
+                })
+                .resolves([
+                    {
+                        id: 8000,
+                        jobId: 800,
+                        endTime: '2025-01-01T08:00:00.000Z',
+                        meta: {
+                            meta1: 'set by second newest parent build', // Overwritten by the newest parent build
+                            meta2: 'set by second newest parent build', // Remains
+                            parameters: { param1: 'set by second newest parent build' } // Remains
+                        }
+                    },
+                    {
+                        id: 8001,
+                        jobId: 801,
+                        endTime: '2025-01-01T09:00:00.000Z',
+                        meta: {
+                            meta1: 'set by the newest parent build' // Remains
+                        }
+                    },
+                    {
+                        id: 9000,
+                        jobId: 900,
+                        endTime: '2025-01-01T10:00:00.000Z',
+                        meta: {
+                            meta5: 'set by the external parent build 1', // Overwritten by the newest parent external build
+                            parameters: { param2: 'set by external parent build 1' } // This should be deleted
+                        }
+                    },
+                    {
+                        id: 9001,
+                        jobId: 901,
+                        endTime: '2025-01-01T11:00:00.000Z',
+                        meta: {
+                            meta5: 'set by the external parent build 2' // Remains
+                        }
+                    },
+                    {
+                        id: 9002,
+                        jobId: 902,
+                        endTime: '2025-01-01T10:30:00.000Z',
+                        meta: {
+                            meta5: 'set by the external parent build 3' // Overwritten by the newest parent external build
+                        }
+                    }
+                ]);
             // Mock job of the parent build
             jobFactoryMock.get.withArgs(800).resolves({
                 pipelineId: 1234
@@ -2144,13 +2155,20 @@ describe('Build Model', () => {
                 creator: { username: 'St John' }
             });
             // Mock parent builds with parameter
-            buildFactoryMock.get.withArgs(8000).resolves({
-                jobId: 800,
-                endTime: new Date('2025-01-01T08:00:00.000Z'),
-                meta: {
-                    parameters: { param1: 'set by source event' } // Overwritten by own build
-                }
-            });
+            buildFactoryMock.list
+                .withArgs({
+                    params: { id: build.parentBuildId }
+                })
+                .resolves([
+                    {
+                        id: 8000,
+                        jobId: 800,
+                        endTime: '2025-01-01T08:00:00.000Z',
+                        meta: {
+                            parameters: { param1: 'set by source event' } // Overwritten by own build
+                        }
+                    }
+                ]);
             // Mock job of the parent build executed by source event
             jobFactoryMock.get.withArgs(800).resolves({
                 pipelineId: 1234

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -72,6 +72,8 @@ describe('Build Model', () => {
     let pipelineMock;
     let jobMock;
     let templateMock;
+    let eventFactoryMock;
+    let buildFactoryMock;
 
     beforeEach(() => {
         datastore = {
@@ -109,6 +111,12 @@ describe('Build Model', () => {
             removeSteps: sinon.stub().resolves([])
         };
         templateFactoryMock = {
+            get: sinon.stub()
+        };
+        eventFactoryMock = {
+            get: sinon.stub()
+        };
+        buildFactoryMock = {
             get: sinon.stub()
         };
 
@@ -161,6 +169,12 @@ describe('Build Model', () => {
         const tF = {
             getInstance: sinon.stub().returns(templateFactoryMock)
         };
+        const eF = {
+            getInstance: sinon.stub().returns(eventFactoryMock)
+        };
+        const bF = {
+            getInstance: sinon.stub().returns(buildFactoryMock)
+        };
 
         rewiremock('../../lib/pipelineFactory').with(pF);
         rewiremock('../../lib/userFactory').with(uF);
@@ -169,6 +183,8 @@ describe('Build Model', () => {
         rewiremock('../../lib/stageFactory').with(stageF);
         rewiremock('../../lib/stageBuildFactory').with(stageBuildF);
         rewiremock('../../lib/templateFactory').with(tF);
+        rewiremock('../../lib/eventFactory').with(eF);
+        rewiremock('../../lib/buildFactory').with(bF);
         rewiremock.enable();
 
         // eslint-disable-next-line global-require
@@ -1262,6 +1278,7 @@ describe('Build Model', () => {
                 url,
                 pipelineId
             };
+            build.initMeta = sinon.stub().resolves();
         });
 
         afterEach(() => {
@@ -1288,6 +1305,7 @@ describe('Build Model', () => {
                 );
 
                 assert.calledWith(scmMock.updateCommitStatus, expectedUpdateCommitStatusConfig);
+                assert.calledOnce(build.initMeta);
             }));
 
         it('passes template info to executor if it exists', () => {
@@ -1944,5 +1962,217 @@ describe('Build Model', () => {
                     token
                 });
             }));
+    });
+
+    describe('initMeta', () => {
+        beforeEach(() => {
+            build.meta = {
+                meta: {
+                    remainMeta: 'This meta should not be deleted',
+                    // This should be deleted
+                    summary: {
+                        coverage: 'Coverage increased by 15%',
+                        markdown: 'This markdown comment is **bold** and *italic*'
+                    }
+                }
+            };
+            // Stub build.update to ensure it's only executed in initMeta()
+            build.update = sinon.stub().resolves();
+            // Mock the job associated with the build
+            jobFactoryMock.get.withArgs(777).resolves({
+                id: 777,
+                name: 'thisJob',
+                pipeline: Promise.resolve(pipelineMock)
+            });
+        });
+
+        it('sets default metadata when starting the pipeline without any specific metadata', () => {
+            // Mock event without metadata
+            eventFactoryMock.get.withArgs(555).resolves({
+                creator: { username: 'St John' }
+            });
+
+            const expected = {
+                meta: { remainMeta: 'This meta should not be deleted' },
+                build: {
+                    pipelineId: '1234',
+                    eventId: '555',
+                    jobId: '777',
+                    buildId: '9876',
+                    jobName: 'thisJob',
+                    sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'
+                },
+                event: { creator: 'St John' }
+            };
+
+            return build.initMeta().then(() => {
+                assert.calledOnce(build.update);
+                assert.deepEqual(build.meta, expected);
+            });
+        });
+
+        it('merges metadata giving precedence to the latest parent builds, event, and parent event', () => {
+            build.parentBuildId = [8000, 8001, 9000, 9001, 9002];
+
+            // Mock parent event with metadata
+            eventFactoryMock.get.withArgs(444).resolves({
+                meta: {
+                    meta1: 'set by parent event', // Overwritten by parent build
+                    meta2: 'set by parent event', // Overwritten by parent build
+                    meta3: 'set by parent event', // Overwritten by own event
+                    meta4: 'set by parent event' // Remains
+                }
+            });
+            // Mock own event with metadata
+            eventFactoryMock.get.withArgs(555).resolves({
+                parentEventId: 444,
+                meta: {
+                    meta1: 'set by own event', // Overwritten by parent build
+                    meta2: 'set by own event', // Overwritten by parent build
+                    meta3: 'set by own event' // Remains
+                },
+                creator: { username: 'St John' }
+            });
+            // Mock parent builds with metadata
+            buildFactoryMock.get.withArgs(8000).resolves({
+                jobId: 800,
+                endTime: new Date('2025-01-01T08:00:00.000Z'),
+                meta: {
+                    meta1: 'set by second newest parent build', // Overwritten by the newest parent build
+                    meta2: 'set by second newest parent build', // Remains
+                    parameters: { param1: 'set by second newest parent build' } // Remains
+                }
+            });
+            buildFactoryMock.get.withArgs(8001).resolves({
+                jobId: 801,
+                endTime: new Date('2025-01-01T09:00:00.000Z'),
+                meta: {
+                    meta1: 'set by the newest parent build' // Remains
+                }
+            });
+            // Mock parent external builds with metadata
+            buildFactoryMock.get.withArgs(9000).resolves({
+                jobId: 900,
+                endTime: new Date('2025-01-01T10:00:00.000Z'),
+                meta: {
+                    meta5: 'set by the external parent build 1', // Overwritten by the newest parent external build
+                    parameters: { param2: 'set by external parent build 1' } // This should be deleted
+                }
+            });
+            buildFactoryMock.get.withArgs(9001).resolves({
+                jobId: 901,
+                endTime: new Date('2025-01-01T11:00:00.000Z'),
+                meta: {
+                    meta5: 'set by the external parent build 2' // Remains
+                }
+            });
+            buildFactoryMock.get.withArgs(9002).resolves({
+                jobId: 902,
+                endTime: new Date('2025-01-01T10:30:00.000Z'),
+                meta: {
+                    meta5: 'set by the external parent build 3' // Overwritten by the newest parent external build
+                }
+            });
+            // Mock job of the parent build
+            jobFactoryMock.get.withArgs(800).resolves({
+                pipelineId: 1234
+            });
+            jobFactoryMock.get.withArgs(801).resolves({
+                pipelineId: 1234
+            });
+            // Mock job of the parent external build
+            jobFactoryMock.get.withArgs(900).resolves({
+                pipelineId: 2345,
+                name: 'externalJob1'
+            });
+            jobFactoryMock.get.withArgs(901).resolves({
+                pipelineId: 2345,
+                name: 'externalJob2'
+            });
+            jobFactoryMock.get.withArgs(902).resolves({
+                pipelineId: 2346,
+                name: 'externalJob1'
+            });
+
+            const expected = {
+                meta: { remainMeta: 'This meta should not be deleted' },
+                meta1: 'set by the newest parent build',
+                meta2: 'set by second newest parent build',
+                meta3: 'set by own event',
+                meta4: 'set by parent event',
+                parameters: { param1: 'set by second newest parent build' },
+                sd: {
+                    2345: {
+                        externalJob1: { meta5: 'set by the external parent build 1' },
+                        externalJob2: { meta5: 'set by the external parent build 2' }
+                    },
+                    2346: { externalJob1: { meta5: 'set by the external parent build 3' } }
+                },
+                meta5: 'set by the external parent build 2',
+                build: {
+                    pipelineId: '1234',
+                    eventId: '555',
+                    jobId: '777',
+                    buildId: '9876',
+                    jobName: 'thisJob',
+                    sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'
+                },
+                event: { creator: 'St John' }
+            };
+
+            return build.initMeta().then(() => {
+                assert.deepEqual(build.meta, expected);
+            });
+        });
+
+        it('restarts build with parameters changed from the previous event', () => {
+            build.parentBuildId = [8000];
+            build.meta.parameters = { param1: 'set by restart event' }; // Remains
+
+            // Mock parent event with parameter
+            eventFactoryMock.get.withArgs(444).resolves({
+                meta: {
+                    parameters: { param1: 'set by source event' } // Overwritten by own build
+                }
+            });
+            // Mock own event with parameter
+            eventFactoryMock.get.withArgs(555).resolves({
+                parentEventId: 444,
+                meta: {
+                    parameters: { param1: 'set by restart event' } // Overwritten by own build
+                },
+                creator: { username: 'St John' }
+            });
+            // Mock parent builds with parameter
+            buildFactoryMock.get.withArgs(8000).resolves({
+                jobId: 800,
+                endTime: new Date('2025-01-01T08:00:00.000Z'),
+                meta: {
+                    parameters: { param1: 'set by source event' } // Overwritten by own build
+                }
+            });
+            // Mock job of the parent build executed by source event
+            jobFactoryMock.get.withArgs(800).resolves({
+                pipelineId: 1234
+            });
+
+            const expected = {
+                meta: { remainMeta: 'This meta should not be deleted' },
+                parameters: { param1: 'set by restart event' },
+                build: {
+                    pipelineId: '1234',
+                    eventId: '555',
+                    jobId: '777',
+                    buildId: '9876',
+                    jobName: 'thisJob',
+                    sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'
+                },
+                event: { creator: 'St John' }
+            };
+
+            return build.initMeta().then(() => {
+                assert.deepEqual(build.meta, expected);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The process of setting the metadata needs to be moved from the launcher to the API.
Merge after the changes in https://github.com/screwdriver-cd/launcher/pull/491 have been reflected.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Implement the metadata settings executed on the launcher side on the API side.
In `build.start()`, the build is updated with the metadata set and the launcher uses it.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3235

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
