### PR TITLE
feat(3336): Run a build correctly based on the previous job data  [2]

### DIFF
--- a/lib/buildFactory.js
+++ b/lib/buildFactory.js
@@ -178,10 +178,11 @@ class BuildFactory extends BaseFactory {
      */
     create(config) {
         const number = Date.now();
-        const { jobId, configPipelineSha, start, meta, username, causeMessage } = config;
+        const { jobId, configPipelineSha, start, meta, username, causeMessage, sha } = config;
         const modelConfig = config;
         const displayLabel = this.scm.getDisplayName(config);
         const displayName = displayLabel ? `${displayLabel}:${username}` : username;
+        const oldJobSha = configPipelineSha || sha;
 
         modelConfig.cause = `Started by user ${displayName}`;
         modelConfig.number = number;
@@ -208,10 +209,28 @@ class BuildFactory extends BaseFactory {
 
             return Promise.all([job.pipeline, getCommitInfo({ job, scm: this.scm, modelConfig })]).then(
                 async ([pipeline, data]) => {
+                    let jobConfig = job;
+
+                    // If job data was updated, fetch the job belonging to the build sha
+                    if (job.sha && job.sha !== oldJobSha) {
+                        const { jobs } = await pipeline.getConfiguration({ ref: oldJobSha });
+                        const permutations = jobs[job.name];
+                        const templateId = permutations[0].templateId || null;
+
+                        jobConfig = {
+                            pipelineId: pipeline.id,
+                            name: job.name,
+                            permutations,
+                            templateId,
+                            sha: oldJobSha,
+                            archived: false
+                        };
+                    }
+
                     // TODO: support matrix jobs
                     const index = number.toString().split('.')[1] || 0;
-                    const permutation = job.permutations[index];
-                    const annotations = hoek.reach(job.permutations[0], 'annotations', { default: {} });
+                    const permutation = jobConfig.permutations[index];
+                    const annotations = hoek.reach(jobConfig.permutations[0], 'annotations', { default: {} });
                     let provider;
 
                     if (hoek.reach(permutation, 'provider')) {
@@ -226,7 +245,7 @@ class BuildFactory extends BaseFactory {
                     });
 
                     // Create stage build if current job is stage setup
-                    const nextStageName = getStageFromSetupJobName(job.name);
+                    const nextStageName = getStageFromSetupJobName(jobConfig.name);
 
                     if (nextStageName) {
                         const stage = await stageFactory.get({
@@ -266,7 +285,7 @@ class BuildFactory extends BaseFactory {
                         ...permutation.environment
                     };
 
-                    const bookendConfig = { pipeline, job, build: modelConfig };
+                    const bookendConfig = { pipeline, job: jobConfig, build: modelConfig };
 
                     if (pipeline.configPipelineId) {
                         bookendConfig.configPipeline = await pipeline.configPipeline;
@@ -294,7 +313,7 @@ class BuildFactory extends BaseFactory {
                         ...teardown
                     ];
 
-                    modelConfig.templateId = job.templateId;
+                    modelConfig.templateId = jobConfig.templateId;
 
                     modelConfig.stats = {};
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -294,6 +294,33 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Get sha from SCM
+     * @method _getCurrentSha
+     * @return {Promise}        Resolves to latest commit sha
+     */
+    _getCurrentSha() {
+        return this.admin
+            .then(user => user.unsealToken())
+            .then(token => {
+                const config = {
+                    scmUri: this.scmUri,
+                    scmContext: this.scmContext,
+                    scmRepo: this.scmRepo,
+                    token
+                };
+
+                return this.scm.getCommitSha(config);
+            })
+            .catch(err => {
+                const message = `pipelineId:${this.id}: Failed to get latest commit sha.`;
+
+                logger.error(message, err);
+
+                return null;
+            });
+    }
+
+    /**
      * Insert provider yaml to screwdriver config
      * @method _getYamlWithProvider
      * @param  {String} config  The Screwdriver yaml configuration (yaml format)
@@ -469,6 +496,7 @@ class PipelineModel extends BaseModel {
                 const parsedJob = parsedConfig.jobs[jobName];
                 const jobConfig = parsedJob[0] || {};
 
+                j.sha = parsedConfig.sha;
                 j.permutations = parsedJob;
                 j.templateId = jobConfig.templateId || null;
                 j.description = jobConfig.description || null;
@@ -1004,11 +1032,11 @@ class PipelineModel extends BaseModel {
      * Create, update, or disable jobs if necessary.
      * Store/update the pipeline workflowGraph
      * @method sync
-     * @param {String}  [ref]     A reference to fetch the screwdriver.yaml, can be branch/tag/commit
+     * @param {String}  [sha]     A sha to fetch the screwdriver.yaml
      * @param {Boolean} [chainPR] Chain PR flag
      * @return {Promise}
      */
-    async sync(ref, chainPR = false) {
+    async sync(sha, chainPR = false) {
         if (this.state === 'DELETING') {
             throw boom.conflict('This pipeline is being deleted.');
         }
@@ -1028,7 +1056,8 @@ class PipelineModel extends BaseModel {
         const stageFactory = StageFactory.getInstance();
 
         // get the pipeline configuration
-        const parsedConfig = await this.getConfiguration({ ref });
+        const parsedConfig = await this.getConfiguration({ ref: sha });
+        const jobSha = sha || (await this._getCurrentSha());
 
         const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
         const parsedConfigAnnotations = hoek.reach(parsedConfig, 'annotations', { default: {} });
@@ -1093,6 +1122,7 @@ class PipelineModel extends BaseModel {
                         const permutations = parsedConfig.jobs[jobName];
 
                         requiresList = permutations[0].requires || [];
+                        job.sha = jobSha;
                         job.permutations = permutations;
                         job.templateId = templateId;
                         job.archived = false;
@@ -1123,7 +1153,8 @@ class PipelineModel extends BaseModel {
                     const jobConfig = {
                         pipelineId,
                         name: jobName,
-                        permutations
+                        permutations,
+                        sha: jobSha
                     };
                     const requiresList = permutations[0].requires || [];
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -45,6 +45,7 @@ const MAX_METRIC_GET_COUNT = 1000;
 const FAKE_MAX_METRIC_GET_COUNT = 5;
 const SCM_CONTEXT_GITHUB = 'github:github.com';
 const SCM_CONTEXT_GITLAB = 'gitlab:gitlab.com';
+const DEFAULT_COMMIT_SHA = 'aebcdcbdb267ad4395a40aa8b8908f44babd4a18';
 
 /**
  * Load sample data from disk
@@ -326,7 +327,8 @@ describe('Pipeline Model', () => {
             getOpenedPRs: sinon.stub(),
             getPrInfo: sinon.stub(),
             getScmContext: sinon.stub(),
-            getReadOnlyInfo: sinon.stub().returns({})
+            getReadOnlyInfo: sinon.stub().returns({}),
+            getCommitSha: sinon.stub()
         };
         parserMock = sinon.stub();
 
@@ -609,6 +611,7 @@ describe('Pipeline Model', () => {
             scmMock.getReadOnlyInfo
                 .withArgs({ scmContext: SCM_CONTEXT_GITLAB })
                 .returns({ enabled: true, username: 'sd-buildbot', accessToken: 'tokenRO' });
+            scmMock.getCommitSha.resolves(DEFAULT_COMMIT_SHA);
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
@@ -682,77 +685,88 @@ describe('Pipeline Model', () => {
                 update: sinon.stub(),
                 id: 1,
                 name: 'main',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             publishModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 2,
                 name: 'publish',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             setupModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 5,
                 name: 'stage@canary:setup',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             teardownModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 6,
                 name: 'stage@canary:teardown',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             aModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 3,
                 name: 'A',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             bModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 4,
                 name: 'B',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             setupModelMock2 = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 7,
                 name: 'stage@deploy:setup',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             teardownModelMock2 = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 8,
                 name: 'stage@deploy:teardown',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             externalModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 3,
                 name: 'main',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             downstreamModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 3,
                 name: 'foo',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             upstreamModelMock = {
                 isPR: sinon.stub().returns(false),
                 update: sinon.stub(),
                 id: 4,
                 name: 'bar',
-                state: 'ENABLED'
+                state: 'ENABLED',
+                sha: DEFAULT_COMMIT_SHA
             };
             publishMock = {
                 pipelineId: testId,
@@ -767,7 +781,8 @@ describe('Pipeline Model', () => {
                         environment: { NODE_ENV: 'test', NODE_TAG: 'latest' },
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             mainMock = {
                 pipelineId: testId,
@@ -797,7 +812,8 @@ describe('Pipeline Model', () => {
                         environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
                         image: 'node:6'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             aMock = {
                 pipelineId: testId,
@@ -808,7 +824,8 @@ describe('Pipeline Model', () => {
                         environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             bMock = {
                 pipelineId: testId,
@@ -819,7 +836,8 @@ describe('Pipeline Model', () => {
                         environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             externalMock = {
                 pipelineId: testId,
@@ -834,7 +852,8 @@ describe('Pipeline Model', () => {
                         environment: { NODE_ENV: 'test', NODE_TAG: 'latest' },
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             downstreamMock = {
                 pipelineId: testId,
@@ -849,7 +868,8 @@ describe('Pipeline Model', () => {
                         environment: { NODE_ENV: 'test', NODE_TAG: 'latest' },
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             upstreamMock = {
                 pipelineId: testId,
@@ -864,7 +884,8 @@ describe('Pipeline Model', () => {
                         environment: { NODE_ENV: 'test', NODE_TAG: 'latest' },
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             stageSetupMock = {
                 pipelineId: testId,
@@ -874,7 +895,8 @@ describe('Pipeline Model', () => {
                         commands: [{ name: 'announce', command: 'post banner' }],
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             stageTeardownMock = {
                 pipelineId: testId,
@@ -884,7 +906,8 @@ describe('Pipeline Model', () => {
                         commands: [{ name: 'publish', command: 'publish blog' }],
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             stageSetupMock2 = {
                 pipelineId: testId,
@@ -894,7 +917,8 @@ describe('Pipeline Model', () => {
                         commands: [{ name: 'announce', command: 'post banner' }],
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
             stageTeardownMock2 = {
                 pipelineId: testId,
@@ -904,7 +928,8 @@ describe('Pipeline Model', () => {
                         commands: [{ name: 'publish', command: 'publish blog' }],
                         image: 'node:4'
                     }
-                ]
+                ],
+                sha: DEFAULT_COMMIT_SHA
             };
         });
 
@@ -1223,8 +1248,8 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('gets job config from the given ref/sha if passed in', () => {
-            const ref = 'shafromoldevent';
+        it('gets job config from the given sha if passed in', () => {
+            const sha = 'shafromoldevent';
             // deep clone PARSED_YAML
             const YAML_FROM_SHA = JSON.parse(JSON.stringify(PARSED_YAML));
 
@@ -1234,17 +1259,21 @@ describe('Pipeline Model', () => {
                     command: 'echo old step from a specific sha'
                 }
             ];
-            scmMock.getFile.withArgs(sinon.match({ ref })).resolves('yamlcontentfromsha');
+            scmMock.getFile.withArgs(sinon.match({ ref: sha })).resolves('yamlcontentfromsha');
             parserConfig.yaml = 'yamlcontentfromsha';
             parserMock.withArgs(parserConfig).resolves(YAML_FROM_SHA);
             publishMock.permutations[0].commands = YAML_FROM_SHA.jobs.publish[0].commands;
             jobs = [];
+            mainMock.sha = sha;
+            mainModelMock.sha = sha;
+            publishMock.sha = sha;
+            publishModelMock.sha = sha;
             jobFactoryMock.list.resolves(jobs);
             jobFactoryMock.create.withArgs(mainMock).resolves(mainModelMock);
             jobFactoryMock.create.withArgs(publishMock).resolves(publishModelMock);
 
-            return pipeline.sync(ref).then(() => {
-                assert.calledWith(scmMock.getFile, sinon.match({ ref }));
+            return pipeline.sync(sha).then(() => {
+                assert.calledWith(scmMock.getFile, sinon.match({ ref: sha }));
                 assert.calledTwice(jobFactoryMock.create);
                 assert.calledWith(jobFactoryMock.create, publishMock);
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Fix https://github.com/screwdriver-cd/screwdriver/issues/3336 .

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Set `job.sha` to indicate which commit the job is based on.
- Fetch the previous job definition if the job data has already been updated.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- PR - https://github.com/screwdriver-cd/data-schema/pull/601
- Issue - https://github.com/screwdriver-cd/data-schema/pull/601

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
