### PR TITLE
fix(3322): remove pipeline when its repo has already been removed

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -2007,8 +2007,11 @@ class PipelineModel extends BaseModel {
             throw boom.conflict('This pipeline is being deleted.');
         }
 
+        // If the repository has been removed, calling this.update() will throw an exception, preventing this.state from being updated.
+        // Update this.state without calling this.update(), as this.update() requires access to the SCM.
+        // When removing a pipeline, calling this.update() is unnecessary; we can directly call super.update().
         this.state = 'DELETING';
-        await this.update();
+        await super.update();
 
         const pipelineFactory = this._getPipelineFactory();
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -3765,7 +3765,6 @@ describe('Pipeline Model', () => {
         };
 
         beforeEach(() => {
-            pipeline.update = sinon.stub();
             datastore.update.resolves();
             buildFactoryMock.list.resolves([]);
             eventFactoryMock.list.resolves([]);

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -3766,6 +3766,7 @@ describe('Pipeline Model', () => {
 
         beforeEach(() => {
             pipeline.update = sinon.stub();
+            datastore.update.resolves();
             buildFactoryMock.list.resolves([]);
             eventFactoryMock.list.resolves([]);
             jobFactoryMock.list.resolves([]);
@@ -3806,6 +3807,7 @@ describe('Pipeline Model', () => {
                 assert.calledOnce(trigger.remove);
                 assert.calledOnce(datastore.remove); // delete self
                 assert.strictEqual(pipeline.state, 'DELETING');
+                assert.calledOnce(datastore.update);
             }));
 
         it('does not remove stage or stageBuilds if stages does not exist', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/models/pull/644#discussion_r2154992449 .

Now, `pipeline.update()` is called in `pipeline.remove()` method.
This requires access to the SCM.
Thus SD admins cannot remove that pipeline when the repository has already removed.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Use `super.update()` instead of `this.update()` to skip access the SCM.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/3322

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
