### PR TITLE
feat(3363): Get admin for a pipeline from the specified SCM context

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1409,11 +1409,12 @@ class PipelineModel extends BaseModel {
      * @method getFirstAdmin
      * @return {Promise}
      */
-    async getFirstAdmin() {
+    async getFirstAdmin(config = {}) {
         let oldAdmins = this.admins;
         let newAdmins = this.admins;
         let { id, scmContext, scmUri } = this;
         const { enabled } = this.scm.getReadOnlyInfo({ scmContext });
+        const adminUserScmContext = config.scmContext;
 
         // Use parent pipeline info if child pipeline is in read-only SCM
         if (this.configPipelineId && enabled) {
@@ -1434,55 +1435,79 @@ class PipelineModel extends BaseModel {
         /* eslint-disable global-require */
         const UserFactory = require('./userFactory');
         /* eslint-enable global-require */
-        const factory = UserFactory.getInstance();
+        const userFactory = UserFactory.getInstance();
 
-        /* eslint-disable no-restricted-syntax */
-        for (const username of Object.keys(oldAdmins)) {
-            // Lazy load factory dependency to prevent circular dependency issues
-            // https://nodejs.org/api/modules.html#modules_cycles
-            // eslint-disable-next-line no-await-in-loop
-            const user = await factory.get({
-                username,
-                scmContext
-            });
-            let permission = {};
-
-            try {
+        if (adminUserScmContext === undefined || adminUserScmContext === scmContext) {
+            /* eslint-disable no-restricted-syntax */
+            for (const username of Object.keys(oldAdmins)) {
+                // Lazy load userFactory dependency to prevent circular dependency issues
+                // https://nodejs.org/api/modules.html#modules_cycles
                 // eslint-disable-next-line no-await-in-loop
-                permission = await user.getPermissions(scmUri, user.scmContext, this.scmRepo);
-            } catch (err) {
-                if (SCM_NO_ACCESS_STATUSES.includes(err.status)) {
-                    permission.push = false;
+                const user = await userFactory.get({
+                    username,
+                    scmContext
+                });
+                let permission = {};
+
+                try {
+                    // eslint-disable-next-line no-await-in-loop
+                    permission = await user.getPermissions(scmUri, user.scmContext, this.scmRepo);
+                } catch (err) {
+                    if (SCM_NO_ACCESS_STATUSES.includes(err.status)) {
+                        permission.push = false;
+                    } else {
+                        throw err;
+                    }
+                }
+
+                if (!permission.push) {
+                    delete newAdmins[username];
+                    logger.info(`pipelineId:${id}: ${username} has been removed from admins.`);
                 } else {
-                    throw err;
+                    break;
                 }
             }
+            /* eslint-enable no-restricted-syntax */
 
-            if (!permission.push) {
-                delete newAdmins[username];
-                logger.info(`pipelineId:${id}: ${username} has been removed from admins.`);
-            } else {
-                break;
+            if (Object.keys(newAdmins).length === 0) {
+                logger.error(`pipelineId:${id}: Pipeline has no admin.`);
+                throw boom.forbidden('Pipeline has no admin');
             }
+
+            if (!(this.configPipelineId && enabled)) {
+                // This is needed to make admins dirty and update db
+                this.admins = newAdmins;
+            }
+
+            const result = await userFactory.get({
+                username: Object.keys(newAdmins)[0],
+                scmContext
+            });
+
+            return result;
         }
-        /* eslint-enable no-restricted-syntax */
 
-        if (Object.keys(newAdmins).length === 0) {
-            logger.error(`pipelineId:${id}: Pipeline has no admin.`);
-            throw boom.forbidden('Pipeline has no admin');
+        // Get an admin from the specified scmContext which is different from the pipeline scmContext
+        const listConfig = {
+            page: 1,
+            count: 1,
+            params: {
+                scmContext: adminUserScmContext,
+                id: this.adminUserIds
+            }
+        };
+
+        const filteredAdmins = await userFactory.list(listConfig);
+
+        if (filteredAdmins && filteredAdmins.length > 0) {
+            return filteredAdmins[0];
         }
 
-        if (!(this.configPipelineId && enabled)) {
-            // This is needed to make admins dirty and update db
-            this.admins = newAdmins;
-        }
-
-        const result = await factory.get({
-            username: Object.keys(newAdmins)[0],
-            scmContext
-        });
-
-        return result;
+        // There is no admin from the specified scmContext
+        logger.error(
+            `pipelineId:${this.id}: Pipeline has no repository admin from the scmContext:${adminUserScmContext}`
+        );
+        throw new Error(`Pipeline has no admins from the scmContext ${adminUserScmContext}`);
     }
 
     /**


### PR DESCRIPTION
## Context

`getFirstAdmin` on `pipeline` model returns an admin from the same SCM context as that of the pipeline

## Objective

Need to get an admin for a pipeline where the admin user SCM context is different pipeline SCM context.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3363

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
