### PR TITLE
feat(3363): Pin release template version

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,7 +15,7 @@ jobs:
 
     publish:
         requires: main
-        template: screwdriver-cd/semantic-release
+        template: screwdriver-cd/semantic-release@2
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
## Context
Changes made in PR https://github.com/screwdriver-cd/models/pull/651 did not get published  https://cd.screwdriver.cd/pipelines/9/builds/976870/steps/publish

Template v3 has an issue where support for Screwdriver was added but has a issue with branch names causing releases to fail.

## Objective
Pin to v2 of the release job template.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
