### PR TITLE
fix(3235): delete external meta from completed virtual build

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -9,7 +9,7 @@ const logger = require('screwdriver-logger');
 const { EXTERNAL_TRIGGER } = require('screwdriver-data-schema').config.regex;
 const { SCM_STATE_MAP, SCM_STATUSES } = require('screwdriver-data-schema').plugins.scm;
 const BaseModel = require('./base');
-const { getStageFromSetupJobName } = require('./helper');
+const { getStageFromSetupJobName, isVirtualJob } = require('./helper');
 
 // Symbols for private members
 const executor = Symbol('executor');
@@ -315,12 +315,14 @@ function mergeExternalBuildMeta(mergedMeta, parentJob, parentBuildMeta) {
 
 /**
  * @description Merges metadata from parent builds if available
- * @param {number|number[]} parentBuildId - The ID or list of IDs of parent builds
+ * @param {Build} build - Build model
  * @param {number} pipelineId - The ID of the pipeline
+ * @param {boolean} isVirtual - The build is virtual
  * @param {Object} mergedMeta - The current state of merged metadata
  * @returns {Object} The updated merged metadata
  */
-async function mergeParentBuildsMeta(parentBuildId, pipelineId, mergedMeta) {
+async function mergeParentBuildsMeta(build, pipelineId, isVirtual, mergedMeta) {
+    const { parentBuildId } = build;
     // eslint-disable-next-line global-require
     const BuildFactory = require('./buildFactory');
     const buildFactory = BuildFactory.getInstance();
@@ -349,6 +351,21 @@ async function mergeParentBuildsMeta(parentBuildId, pipelineId, mergedMeta) {
 
             resultMeta = _.merge(mergedMeta, parentBuild.meta);
         }
+    }
+
+    // Delete local version of external meta since this build already has been executed
+    if (isVirtual && build.status === 'SUCCESS') {
+        const sdMeta = resultMeta.sd || {};
+        const newSdMeta = {};
+
+        // Retain the metadata for non-integer values (e.g., tag, release, pr-closed)
+        Object.keys(sdMeta)
+            .filter(key => !/^[1-9]\d*$/.test(key))
+            .forEach(key => {
+                newSdMeta[key] = sdMeta[key];
+            });
+
+        resultMeta.sd = newSdMeta;
     }
 
     return resultMeta;
@@ -1005,7 +1022,7 @@ class BuildModel extends BaseModel {
         const job = await this.job;
 
         if (this.parentBuildId) {
-            mergedMeta = await mergeParentBuildsMeta(this.parentBuildId, job.pipelineId, mergedMeta);
+            mergedMeta = await mergeParentBuildsMeta(this, job.pipelineId, isVirtualJob(job), mergedMeta);
         }
         // Initialize pr comments (Issue #1858)
         if (mergedMeta.meta) {

--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -16,7 +16,7 @@ const logger = require('screwdriver-logger');
 const hoek = require('@hapi/hoek');
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
-const { getStageName, getFullStageJobName } = require('./helper');
+const { getStageName, getFullStageJobName, isVirtualJob } = require('./helper');
 let instance;
 
 /**
@@ -416,12 +416,11 @@ function createBuilds(config) {
 
                     buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;
 
-                    const { annotations, freezeWindows } = j.permutations[0];
-                    const isVirtualJob = annotations ? annotations['screwdriver.cd/virtualJob'] === true : false;
+                    const { freezeWindows } = j.permutations[0];
                     const hasFreezeWindows = freezeWindows ? freezeWindows.length > 0 : false;
 
                     // Bypass execution of the build if the job is virtual
-                    buildConfig.start = !isVirtualJob || hasFreezeWindows;
+                    buildConfig.start = !isVirtualJob(j) || hasFreezeWindows;
 
                     return startBuild({
                         decoratedCommit,

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -462,6 +462,17 @@ function getStageName(workflowGraph, jobName) {
     return null;
 }
 
+/**
+ * Check if the job is virtual
+ * @param {Job} job Job model
+ * @returns {boolean}
+ */
+function isVirtualJob(job) {
+    const { annotations } = job.permutations[0];
+
+    return annotations ? annotations['screwdriver.cd/virtualJob'] === true : false;
+}
+
 module.exports = {
     getAnnotations,
     convertToBool,
@@ -472,5 +483,6 @@ module.exports = {
     getBookendKey,
     getFullStageJobName,
     getStageFromSetupJobName,
-    getStageName
+    getStageName,
+    isVirtualJob
 };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The external metadata are removed in launcher when build start.

However, the virtual build does not run and the launcher does not execute too.
For the result, the virtual build can have external metadata recursive as below.

```json
"meta": {
    "build": { "buildId": ... },
    "commit": { "author": ... },
    "event": { "creator": ... },
    "sd": {
        "41": {
            "main": {
                "build": { "buildId": ... },
                "commit": { "author": ... },
                "event": { "creator": ... },
            }
        },
        "42": {
            "two": {
                "build": { "buildId": ... },
                "commit": { "author": ... },
                "event": { "creator": ... },

                // External metadata contains its upstream metadata recursive
                "sd": {
                    "41": {
                        "main": {
                            "build": { "buildId": ... },
                            "commit": { "author": ... },
                            "event": { "creator": ... },
                        }
                    }
                }
            }
        }
    }
},
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Delete the external metadata if the build is virtual and succeeded same as launcher.
https://github.com/screwdriver-cd/launcher/blob/b9563efd5ea26484d033b2a0390a2e6f1778c983/launch.go#L434-L450

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3235

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
