### PR TITLE
fix(3397): Use non-PR job paramters in pr-closed events

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -594,7 +594,7 @@ async function getJobParameters(config) {
 
         if (!jobParameters) return;
 
-        if (eventConfig.prNum) {
+        if (eventConfig.type === 'pr') {
             // For PR events, include only the parameters of the PR job for that PR
             if (parseInt(eventConfig.prNum, 10) === job.prNum) {
                 const baseJobName = job.parsePRJobName('job');

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -3193,6 +3193,7 @@ describe('Event Factory', () => {
                 config.prRef = 'branch';
                 config.prNum = 3;
                 config.prTitle = 'Update screwdriver.yaml';
+                config.type = 'pr';
 
                 afterSyncedPRPipelineMock.getJobs.resolves(jobsMock);
 
@@ -3215,6 +3216,58 @@ describe('Event Factory', () => {
                                 value: 'hiking',
                                 default: 'hiking'
                             }
+                        }
+                    });
+                });
+            });
+
+            it('should use job parameters for PR closed builds', () => {
+                config.startFrom = '~pr-closed';
+                config.prNum = 3;
+                config.prTitle = 'Update screwdriver.yaml';
+                config.type = 'pipeline';
+
+                return eventFactory.create(config).then(model => {
+                    assert.deepEqual(model.meta.parameters, {
+                        component: {
+                            car: {
+                                value: 'Audi',
+                                default: 'Audi'
+                            },
+                            color: {
+                                value: 'white',
+                                default: 'white'
+                            },
+                            cuisine: {
+                                value: 'Italian',
+                                default: 'Italian'
+                            },
+                            music: {
+                                value: 'jazz',
+                                default: 'jazz'
+                            }
+                        },
+                        publish: {
+                            car: {
+                                value: 'Ferrari',
+                                default: 'Ferrari'
+                            },
+                            color: {
+                                value: 'red',
+                                default: 'red'
+                            },
+                            cuisine: {
+                                value: 'Japanese',
+                                default: 'Japanese'
+                            },
+                            sports: {
+                                value: 'cricket',
+                                default: 'cricket'
+                            }
+                        },
+                        user: {
+                            value: 'ironman',
+                            default: 'ironman'
                         }
                     });
                 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Since pr-closed events should be treated as normal events rather than PR events, the job parameter must also be configured to reference non-PR job parameters instead of PR job parameters.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Changed the determination of whether an event is a PR from checking if prNum is included to checking type instead.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#3397

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
