### PR TITLE
fix: Update stop all steps and build when executor error

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -811,7 +811,7 @@ class BuildModel extends BaseModel {
                     }
 
                     return this[executor].startTimer(config).catch(err => {
-                        logger.error(`Failed to start ${this.id} build: ${err}`);
+                        logger.error(`Failed to update ${this.id} build: ${err}`);
 
                         return this.updateToFailureByExecutorError(pipeline).then(() => {
                             throw err;

--- a/lib/build.js
+++ b/lib/build.js
@@ -756,12 +756,13 @@ class BuildModel extends BaseModel {
                                 config.provider = job.permutations[0].provider;
                             }
 
-                            return this[executor].start(config).catch(err =>
-                                this.updateToFailureByExecutorError(pipeline).then(() => {
-                                    logger.error(`Failed to start ${this.id} build: ${err}`);
+                            return this[executor].start(config).catch(err => {
+                                logger.error(`Failed to start ${this.id} build: ${err}`);
+
+                                return this.updateToFailureByExecutorError(pipeline).then(() => {
                                     throw err;
-                                })
-                            );
+                                });
+                            });
                         })
                         .then(() => this.updateCommitStatus(pipeline))
                 ) // update github
@@ -809,11 +810,13 @@ class BuildModel extends BaseModel {
                         config.provider = job.permutations[0].provider;
                     }
 
-                    return this[executor].startTimer(config).catch(err =>
-                        this.updateToFailureByExecutorError(pipeline).then(() => {
+                    return this[executor].startTimer(config).catch(err => {
+                        logger.error(`Failed to start ${this.id} build: ${err}`);
+
+                        return this.updateToFailureByExecutorError(pipeline).then(() => {
                             throw err;
-                        })
-                    );
+                        });
+                    });
                 }
 
                 return Promise.resolve();

--- a/lib/build.js
+++ b/lib/build.js
@@ -410,7 +410,7 @@ function constructEventMeta(creatorName, mergedMeta) {
 /**
  * Abort running steps. If no steps ever ran, abort the first step
  *
- * @param steps
+ * @param steps {StepModel[]}
  * @returns {Promise}
  */
 function stepsToAborted(steps) {
@@ -824,7 +824,7 @@ class BuildModel extends BaseModel {
     /**
      * Stop all steps and build failure by executor error
      *
-     * @param pipeline {Pipeline}
+     * @param pipeline {PipelineModel}
      * @returns {Promise<void>}
      */
     updateToFailureByExecutorError(pipeline) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -407,6 +407,31 @@ function constructEventMeta(creatorName, mergedMeta) {
     return mergedMeta.event ? _.merge(mergedMeta.event, eventMeta) : eventMeta;
 }
 
+/**
+ * Abort running steps. If no steps ever ran, abort the first step
+ *
+ * @param steps
+ * @returns {Promise}
+ */
+function stepsToAborted(steps) {
+    const now = new Date().toISOString();
+
+    if (steps.length === 0) {
+        return Promise.resolve();
+    }
+
+    return Promise.all(
+        steps.map(step => {
+            if (step.startTime && !step.endTime) {
+                step.endTime = now;
+                step.code = ABORT_CODE;
+            }
+
+            return step.update();
+        })
+    );
+}
+
 class BuildModel extends BaseModel {
     /**
      * Construct a BuildModel object
@@ -731,7 +756,11 @@ class BuildModel extends BaseModel {
                                 config.provider = job.permutations[0].provider;
                             }
 
-                            return this[executor].start(config);
+                            return this[executor].start(config).catch(err =>
+                                this.updateToFailureByExecutorError(pipeline).then(() => {
+                                    throw err;
+                                })
+                            );
                         })
                         .then(() => this.updateCommitStatus(pipeline))
                 ) // update github
@@ -747,31 +776,11 @@ class BuildModel extends BaseModel {
     update() {
         let prom = Promise.resolve();
 
-        // Abort running steps. If no steps ever ran, abort the first step
-        const abortSteps = () => {
-            const now = new Date().toISOString();
-
-            return this.getSteps().then(steps => {
-                if (steps.length === 0) {
-                    return Promise.resolve();
-                }
-
-                return Promise.all(
-                    steps.map(step => {
-                        if (step.startTime && !step.endTime) {
-                            step.endTime = now;
-                            step.code = ABORT_CODE;
-                        }
-
-                        return step.update();
-                    })
-                );
-            });
-        };
-
         // stop the build if we're done
         if (this.isDone()) {
-            prom = abortSteps().then(() => this.stop());
+            prom = this.getSteps()
+                .then(steps => stepsToAborted(steps))
+                .then(() => this.stop());
         }
 
         // check if the status is changing
@@ -799,13 +808,36 @@ class BuildModel extends BaseModel {
                         config.provider = job.permutations[0].provider;
                     }
 
-                    return this[executor].startTimer(config);
+                    return this[executor].startTimer(config).catch(err =>
+                        this.updateToFailureByExecutorError(pipeline).then(() => {
+                            throw err;
+                        })
+                    );
                 }
 
                 return Promise.resolve();
             })
             .then(() => super.update())
             .then(() => this);
+    }
+
+    /**
+     * Stop all steps and build failure by executor error
+     *
+     * @param pipeline {Pipeline}
+     * @returns {Promise<void>}
+     */
+    updateToFailureByExecutorError(pipeline) {
+        return this.getSteps()
+            .then(steps => stepsToAborted(steps))
+            .then(() => {
+                this.status = 'FAILURE';
+                this.statusMessage = 'Failed to start build by executor error';
+                this.statusMessageType = 'ERROR';
+
+                return this.updateCommitStatus(pipeline);
+            })
+            .then(() => super.update());
     }
 
     /**

--- a/lib/build.js
+++ b/lib/build.js
@@ -758,6 +758,7 @@ class BuildModel extends BaseModel {
 
                             return this[executor].start(config).catch(err =>
                                 this.updateToFailureByExecutorError(pipeline).then(() => {
+                                    logger.error(`Failed to start ${this.id} build: ${err}`);
                                     throw err;
                                 })
                             );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

There is no error handling for the executor calling when starting or updating a build.
Consequently, if the executor has not started or cannot be called successfully due to a network error, the build status will remain queue.

<img width="524" height="220" alt="スクリーンショット 2025-09-12 15 23 06" src="https://github.com/user-attachments/assets/619efaff-152e-4f90-9da1-17b1ae2d7b25" />

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Added error handling to ensure the build fails correctly if the Executor call fails.
And that error will also be notified to the user.

<img width="592" height="300" alt="スクリーンショット 2025-09-12 15 22 45" src="https://github.com/user-attachments/assets/0903cd74-3d4a-4ec3-9a86-be1aacd5a759" />


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
