### PR TITLE
fix: branch specific pr-closed trigger does not work when PR base branch is pipeline base branch

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -24,6 +24,7 @@ let instance;
  * @method getJobsFromTrigger
  * @param  {Object}   config
  * @param  {String}   config.branch                         triggered branch name
+ * @param  {String}   [config.baseBranch]                   Pull Request base branch
  * @param  {Array}    config.jobs                           Array of job objects
  * @param  {Object}   config.pipelineConfig
  * @param  {Object}   config.pipelineConfig.workflowGraph   Object with nodes and edges that represent the order of jobs
@@ -33,7 +34,7 @@ let instance;
  * @return {Array}                                          Array of commit jobs to start
  */
 function getJobsFromTrigger(config) {
-    const { jobs, pipelineConfig, startFrom, branch, releaseName, ref } = config;
+    const { jobs, pipelineConfig, startFrom, branch, baseBranch, releaseName, ref } = config;
     const shouldGetJobs = [
         EXTERNAL_TRIGGER.test(startFrom),
         COMMIT_TRIGGER.test(startFrom),
@@ -83,10 +84,10 @@ function getJobsFromTrigger(config) {
         );
     }
 
-    if (startFrom.match(PR_CLOSED_TRIGGER)) {
+    if (startFrom.match(PR_CLOSED_TRIGGER) && baseBranch) {
         nextJobs = nextJobs.concat(
             workflowParser.getNextJobs(pipelineConfig.workflowGraph, {
-                trigger: startFrom
+                trigger: `~pr-closed:${baseBranch}`
             })
         );
     }
@@ -327,6 +328,7 @@ function startBuild(config) {
  * @param  {String}   [config.releaseName]                   SCM webhook releaseName
  * @param  {String}   [config.ref]                           SCM webhook ref
  * @param  {Boolean}  [config.isPR]                          Is it PR?
+ * @param  {String}   [config.baseBranch]                    PR base branch
  * @param  {Object}   [config.decoratedCommit]               Decorated commit object
  * @param  {Object}   [config.pipeline]                      Default pipeline config from database
  * @param  {Object}   [config.pipelineConfig]                Current Pipeline config
@@ -343,6 +345,7 @@ function createBuilds(config) {
         changedFiles,
         webhooks,
         isPR,
+        baseBranch,
         releaseName,
         ref
     } = config;
@@ -374,6 +377,7 @@ function createBuilds(config) {
                 pipelineConfig,
                 startFrom,
                 branch,
+                baseBranch,
                 releaseName,
                 ref
             });
@@ -693,6 +697,7 @@ class EventFactory extends BaseFactory {
      * @param  {String}  config.username            Username of the user that creates this event
      * @param  {String}  config.scmContext          The scm context to which user belongs
      * @param  {String}  [config.prNum]             PR number if it's a PR event
+     * @param  {String}  [config.baseBranch]        PR base branch
      * @param  {String}  [config.prRef]             Ref if it's a PR event
      * @param  {String}  [config.prTitle]           PR title if it's a PR event
      * @param  {String}  [config.startFrom]         Where the event starts from (jobname or ~commit, ~pr, etc)
@@ -735,6 +740,7 @@ class EventFactory extends BaseFactory {
             prTitle,
             prRef,
             prNum,
+            baseBranch,
             skipMessage,
             chainPR,
             groupEventId,
@@ -952,6 +958,7 @@ class EventFactory extends BaseFactory {
                                         pipeline: p,
                                         pipelineConfig: modelConfig,
                                         isPR: !!prInfo,
+                                        baseBranch,
                                         changedFiles,
                                         webhooks,
                                         releaseName,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Branch specific pr-closed trigger does not work when PR base branch is pipeline base branch.

```yaml
jobs:
  foo:
    requires: [ ~pr-closed ]  # Working
  bar:
    requires: [ ~pr-closed:main ] # Not working when the "main" branch is pipeline base
  baz:
    requires: [ ~pr-closed:/main|develop/ ] # Not working when the PR base branch is "main"

```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Trigger the branch specific pr-closed builds properly when the base branch is the pipeline branch

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
