### PR TITLE
fix: hold external parameters under meta.sd

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -345,8 +345,8 @@ async function mergeParentBuildsMeta(build, pipelineId, isVirtual, mergedMeta) {
             const parentJob = await jobFactory.get(parentBuild.jobId);
 
             if (parentJob.pipelineId !== pipelineId) {
-                delete parentBuild.meta.parameters;
                 resultMeta = mergeExternalBuildMeta(mergedMeta, parentJob, parentBuild.meta);
+                delete parentBuild.meta.parameters;
             }
 
             resultMeta = _.merge(mergedMeta, parentBuild.meta);

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -2090,7 +2090,7 @@ describe('Build Model', () => {
                         endTime: '2025-01-01T10:00:00.000Z',
                         meta: {
                             meta5: 'set by the external parent build 1', // Overwritten by the newest parent external build
-                            parameters: { param2: 'set by external parent build 1' } // This should be deleted
+                            parameters: { param2: 'set by external parent build 1' } // This should be deleted in meta.parameters, but remains under meta.sd.2345.
                         }
                     },
                     {
@@ -2140,7 +2140,12 @@ describe('Build Model', () => {
                 parameters: { param1: 'set by second newest parent build' },
                 sd: {
                     2345: {
-                        externalJob1: { meta5: 'set by the external parent build 1' },
+                        externalJob1: {
+                            meta5: 'set by the external parent build 1',
+                            parameters: {
+                                param2: 'set by external parent build 1'
+                            }
+                        },
                         externalJob2: { meta5: 'set by the external parent build 2' }
                     },
                     2346: { externalJob1: { meta5: 'set by the external parent build 3' } }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Users cannot get the build parameter from external parent builds using `meta get --external --skip-fetch`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

External build parameters should remains under `meta.sd` to get by `meta get --external`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
