### PR TITLE
feat: support glob patterns in sourcePaths for startBuild

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -14,6 +14,7 @@ const {
 const workflowParser = require('screwdriver-workflow-parser');
 const logger = require('screwdriver-logger');
 const hoek = require('@hapi/hoek');
+const { minimatch } = require('minimatch');
 const BaseFactory = require('./baseFactory');
 const Event = require('./event');
 const { getStageName, getFullStageJobName, isVirtualJob } = require('./helper');
@@ -185,6 +186,17 @@ function getJobsFromPR(config) {
 }
 
 /**
+ * Normalize a source path pattern:
+ * - If it ends with "/", treat it as a directory and append "**".
+ * - Otherwise, return unchanged.
+ * @param {string} pattern The glob pattern or path
+ * @returns {string} Normalized glob pattern
+ */
+function normalizePattern(pattern) {
+    return pattern.endsWith('/') ? `${pattern}**` : pattern;
+}
+
+/**
  * Starts the build if the changed file is part of the sourcePaths, or if there is no sourcePaths
  * @method startBuild
  * @param  {Object}   config                    configuration object
@@ -244,15 +256,9 @@ function startBuild(config) {
                     return false;
                 }
 
-                let isMatch = false;
+                const normalizedSource = normalizePattern(source);
 
-                // source path is a file
-                if (source.slice(-1) !== '/') {
-                    isMatch = file === source;
-                    // source path is a directory
-                } else {
-                    isMatch = file.startsWith(source);
-                }
+                const isMatch = minimatch(file, normalizedSource);
 
                 // Set env var
                 if (isMatch) {
@@ -267,15 +273,10 @@ function startBuild(config) {
                     return false;
                 }
 
-                let isMatchExclude = false;
+                const normalizedSource = normalizePattern(source);
 
-                // source path is a file
-                if (source.slice(-1) !== '/') {
-                    isMatchExclude = '!'.concat(file) === source;
-                    // source path is a directory
-                } else {
-                    isMatchExclude = '!'.concat(file).startsWith(source);
-                }
+                // NOTE: strip "!" before passing to minimatch
+                const isMatchExclude = minimatch(file, normalizedSource.slice(1));
 
                 return isMatchExclude;
             });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "docker-parse-image": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
+    "minimatch": "^10.0.3",
     "screwdriver-config-parser": "^12.0.0",
     "screwdriver-data-schema": "^25.5.0",
     "screwdriver-logger": "^3.0.0",


### PR DESCRIPTION
## Context

Currently, `startBuild` in `screwdriver-cd/models` only supports exact file paths or directory prefixes in `sourcePaths`. There is no support for glob patterns, which makes it difficult to trigger builds based on patterns like `*.md` or `src/**/*.js`. This limits flexibility for pipelines that want to trigger builds on multiple files matching a pattern.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

This PR adds support for glob patterns in `sourcePaths` for `startBuild`:

- Directories ending with `/` are automatically normalized to `/**` to match all files under them.
- Uses `minimatch` to perform glob matching for changed files against `sourcePaths`.
- Sets the `SD_SOURCE_PATH` environment variable to the first matching pattern that triggered the build.
- Unit tests updated to cover glob matching, including includes (`*.md`) pattern.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

- Related issue: https://github.com/screwdriver-cd/screwdriver/issues/2101
- `minimatch` library for glob support: https://github.com/isaacs/minimatch

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
