### PR TITLE
fix(3399): Fix metadata merge logic from external pipeline BREAKING CHANGE: external meta is not fetched implicitly

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -278,7 +278,7 @@ function getToken(self, job, pipeline) {
  * @param {Object} mergedMeta - The current state of merged metadata
  * @returns {Object} The updated merged metadata
  */
-async function mergeParentEventMeta(parentEventId, mergedMeta) {
+async function mergeParentEventMeta(parentEventId, pipelineId, mergedMeta) {
     let resultMeta = mergedMeta;
 
     if (parentEventId) {
@@ -287,7 +287,9 @@ async function mergeParentEventMeta(parentEventId, mergedMeta) {
         const eventFactory = EventFactory.getInstance();
         const parentEvent = await eventFactory.get(parentEventId);
 
-        resultMeta = _.merge(mergedMeta, parentEvent.meta);
+        if (pipelineId === parentEvent.pipelineId) {
+            resultMeta = _.merge(mergedMeta, parentEvent.meta);
+        }
     }
 
     return resultMeta;
@@ -347,9 +349,10 @@ async function mergeParentBuildsMeta(build, pipelineId, isVirtual, mergedMeta) {
             if (parentJob.pipelineId !== pipelineId) {
                 resultMeta = mergeExternalBuildMeta(mergedMeta, parentJob, parentBuild.meta);
                 delete parentBuild.meta.parameters;
+            } else {
+                // only fetch parent build meta when parent build is not external
+                resultMeta = _.merge(mergedMeta, parentBuild.meta);
             }
-
-            resultMeta = _.merge(mergedMeta, parentBuild.meta);
         }
     }
 
@@ -1048,14 +1051,13 @@ class BuildModel extends BaseModel {
         let mergedMeta = this.meta ? _.merge({}, this.meta) : {};
 
         const event = await this.event;
+        const job = await this.job;
 
-        mergedMeta = await mergeParentEventMeta(event.parentEventId, mergedMeta);
+        mergedMeta = await mergeParentEventMeta(event.parentEventId, job.pipelineId, mergedMeta);
 
         if (event.meta) {
             mergedMeta = _.merge(mergedMeta, event.meta);
         }
-
-        const job = await this.job;
 
         if (this.parentBuildId) {
             mergedMeta = await mergeParentBuildsMeta(this, job.pipelineId, isVirtualJob(job), mergedMeta);

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -2043,6 +2043,7 @@ describe('Build Model', () => {
 
             // Mock parent event with metadata
             eventFactoryMock.get.withArgs(444).resolves({
+                pipelineId: 1234,
                 meta: {
                     meta1: 'set by parent event', // Overwritten by parent build
                     meta2: 'set by parent event', // Overwritten by parent build
@@ -2053,6 +2054,7 @@ describe('Build Model', () => {
             // Mock own event with metadata
             eventFactoryMock.get.withArgs(555).resolves({
                 parentEventId: 444,
+                pipelineId: 1234,
                 meta: {
                     meta1: 'set by own event', // Overwritten by parent build
                     meta2: 'set by own event', // Overwritten by parent build
@@ -2085,12 +2087,13 @@ describe('Build Model', () => {
                         }
                     },
                     {
+                        // Those should not be merged to meta, but remains under meta.sd.*
                         id: 9000,
                         jobId: 900,
                         endTime: '2025-01-01T10:00:00.000Z',
                         meta: {
-                            meta5: 'set by the external parent build 1', // Overwritten by the newest parent external build
-                            parameters: { param2: 'set by external parent build 1' } // This should be deleted in meta.parameters, but remains under meta.sd.2345.
+                            meta5: 'set by the external parent build 1',
+                            parameters: { param2: 'set by external parent build 1' }
                         }
                     },
                     {
@@ -2098,7 +2101,7 @@ describe('Build Model', () => {
                         jobId: 901,
                         endTime: '2025-01-01T11:00:00.000Z',
                         meta: {
-                            meta5: 'set by the external parent build 2' // Remains
+                            meta5: 'set by the external parent build 2'
                         }
                     },
                     {
@@ -2106,7 +2109,7 @@ describe('Build Model', () => {
                         jobId: 902,
                         endTime: '2025-01-01T10:30:00.000Z',
                         meta: {
-                            meta5: 'set by the external parent build 3' // Overwritten by the newest parent external build
+                            meta5: 'set by the external parent build 3'
                         }
                     }
                 ]);
@@ -2150,7 +2153,6 @@ describe('Build Model', () => {
                     },
                     2346: { externalJob1: { meta5: 'set by the external parent build 3' } }
                 },
-                meta5: 'set by the external parent build 2',
                 build: {
                     pipelineId: '1234',
                     eventId: '555',
@@ -2292,7 +2294,6 @@ describe('Build Model', () => {
                     tag: { name: 'test-tag' },
                     pr: { name: 'test-name', merged: false, number: 222 }
                 },
-                foo: 'set by the parent build 2',
                 build: {
                     pipelineId: '1234',
                     eventId: '555',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
As described in screwdriver-cd/screwdriver#3399, remote triggered build should not fetch metadata implicitly from upstream builds.
Therefore, we are changing the logic for fetching metadata from external builds.
When the parent build/event is an external build, the build does not implicitly fetch metadata.
It is fetched only under `meta.sd.{pipelineId}` and is obtained using the `--external` option of the meta-cli.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- If parent builds/events are external, triggered build does not fetch metadata.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
