### PR TITLE
fix: error handling for executor error

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -831,17 +831,23 @@ class BuildModel extends BaseModel {
      * @param pipeline {PipelineModel}
      * @returns {Promise<void>}
      */
-    updateToFailureByExecutorError(pipeline) {
-        return this.getSteps()
-            .then(steps => stepsToAborted(steps))
-            .then(() => {
-                this.status = 'FAILURE';
-                this.statusMessage = 'Failed to start build by executor error';
-                this.statusMessageType = 'ERROR';
+    async updateToFailureByExecutorError() {
+        try {
+            this.status = 'FAILURE';
+            this.statusMessage = 'Failed to start build by executor error';
+            this.statusMessageType = 'ERROR';
 
-                return this.updateCommitStatus(pipeline);
-            })
-            .then(() => super.update());
+            // Through this.update(), stepsToAborted() and stop() are called
+            await this.update();
+        } catch (err) {
+            logger.error(`Failed to stop the ${this.id} build that may have started: ${err}`);
+
+            this.status = 'UNSTABLE';
+            this.statusMessage = 'This build may have failed to started since the executor was unstable';
+            this.statusMessageType = 'ERROR';
+
+            await super.update();
+        }
     }
 
     /**

--- a/test/lib/build.test.js
+++ b/test/lib/build.test.js
@@ -1680,6 +1680,7 @@ describe('Build Model', () => {
                 })
                 .catch(err => {
                     assert.deepEqual(err, expectedError);
+                    assert.calledOnce(executorMock.stop);
                     assert.strictEqual(build.status, 'FAILURE');
                     assert.strictEqual(build.statusMessage, 'Failed to start build by executor error');
                     assert.strictEqual(build.statusMessageType, 'ERROR');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/models/pull/655 .
That PR introduced error handling for `executor.start`, which updates the build status to `FAILURE` when it fails to start.

However, sometimes users cannot start builds because they are `BLOCKED`.
This issue occurs due to failed running builds data remaining in the queue-service.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Add additional error handling to clean up failed running builds data in the queue-service
- If cleanup up fails, the build status will be update to `UNSTABLE` and users can stop the build manually

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

PR - https://github.com/screwdriver-cd/models/pull/655

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
