### PR TITLE
feat(3460): Migrate child pipelines when parent pipeline is migrated to another SCM

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -235,6 +235,70 @@ function syncExternalTriggers(config) {
     });
 }
 
+/**
+ *
+ * @param scmUrl
+ * @param scm
+ * @returns {*}
+ */
+function getScmContextFromScmUrl(scmUrl, scm) {
+    // Get hostname using scmUrl
+    const regex = Schema.config.regex.CHECKOUT_URL;
+    const matched = regex.exec(scmUrl);
+    const hostname = matched[MATCH_COMPONENT_HOSTNAME];
+
+    // Set scmContext
+    return scm.getScmContext({ hostname });
+}
+
+/**
+ *
+ * @param pipelines
+ * @returns {*}
+ */
+function groupPipelinesByScmContext(pipelines) {
+    return pipelines.reduce((accumulator, pipeline) => {
+        const key = pipeline.scmContext;
+
+        if (!accumulator[key]) {
+            accumulator[key] = [];
+        }
+
+        accumulator[key].push(pipeline);
+
+        return accumulator;
+    }, {});
+}
+
+/**
+ *
+ * @param pipelines
+ * @param scmRepo
+ * @returns {null}
+ */
+function findAndRemovePipelineByScmRepo(pipelines, scmRepo) {
+    let matchedPipeline = null;
+
+    // find a pipeline matching the repo name, branch and root directory
+    const index = pipelines.findIndex(pipeline => {
+        const pipelineScmRepo = pipeline.scmRepo;
+
+        return (
+            pipelineScmRepo.name.split('/')[1] === scmRepo.name.split('/')[1] &&
+            pipelineScmRepo.branch === scmRepo.branch &&
+            pipelineScmRepo.rootDir === scmRepo.rootDir
+        );
+    });
+
+    if (index !== -1) {
+        matchedPipeline = pipelines[index];
+
+        pipelines.splice(index, 1);
+    }
+
+    return matchedPipeline;
+}
+
 class PipelineModel extends BaseModel {
     /**
      * Construct a PipelineModel object
@@ -849,109 +913,167 @@ class PipelineModel extends BaseModel {
      * @param {Object} config
      * @param {String} config.scmUrl        Checkout url for a repository
      * @param {String} [config.scmContext]  Scm context
+     * @param {String} [config.token]       User token
      * @return {Promise}
      */
-    async _getScmUri({ scmUrl, scmContext }) {
+    async _getScmUri({ scmUrl, scmContext, token }) {
         const pipelineFactory = this._getPipelineFactory();
-        const token = await this.token;
         const scmUri = await pipelineFactory.scm.parseUrl({
             scmContext: scmContext || this.scmContext,
             checkoutUrl: scmUrl,
-            token
+            token: token || (await this.token)
         });
 
         return scmUri;
     }
 
     /**
-     * Update or create a pipeline given a scmUrl
-     * @method _createOrUpdatePipeline
-     * @param {String} scmUrl  checkout url for a repository
-     * @param {String} newState  new state for the pipeline associated with the specified scmUrl
-     * @return {Promise}
+     *
+     * @param childPipeline
+     * @param newConfig
+     * @param scmUrl
+     * @returns {Promise<*>}
+     * @private
      */
-    async _createOrUpdatePipeline(scmUrl, newState) {
-        const { admins } = this;
-        const newAdmins = admins;
-        let scmToken;
+    async _updateChildPipeline(childPipeline, newConfig, scmUrl) {
+        Object.assign(childPipeline, newConfig);
 
-        // Get hostname using scmUrl
-        const regex = Schema.config.regex.CHECKOUT_URL;
-        const matched = regex.exec(scmUrl);
-        const hostname = matched[MATCH_COMPONENT_HOSTNAME];
+        logger.info(
+            `pipelineId:${this.id}: Updating child pipeline ${scmUrl || childPipeline.scmUri} with pipelineId:${childPipeline.id}.`
+        );
 
-        // Set scmContext
-        const scmContext = this.scm.getScmContext({ hostname });
-        const scmUri = await this._getScmUri({ scmUrl, scmContext });
-        let hasAdminPermission = false;
+        return childPipeline.state === 'ACTIVE' ? childPipeline.sync() : childPipeline.update();
+    }
 
-        if (this.scmContext !== scmContext) {
-            // If read-only scm, add as admin to admin config
-            const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
+    async _createOrUpdateOrMigrateChildPipelines(
+        scmContext,
+        scmUrls,
+        childPipelines,
+        childPipelinesEligibleForMigration,
+        scmContextToTokenMap,
+        pipelineConfigOverrides
+    ) {
+        let createOrUpdatePromises = [];
+        const scmUriToChildPipelineMap = childPipelines.reduce((map, p) => {
+            map[p.scmUri] = p;
 
-            if (!readOnlyInfo.enabled) {
-                logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+            return map;
+        }, {});
 
-                return null;
+        for (const scmUrl of scmUrls) {
+            const scmUri = await this._getScmUri({
+                scmUrl,
+                scmContext,
+                token: scmContextToTokenMap[scmContext]
+            });
+
+            if (scmContext === this.scmContext) {
+                // Check permissions
+                const hasAdminPermission = await this._hasAdminPermission(scmUri);
+
+                if (!hasAdminPermission) {
+                    // TODO: figure out how to bubble up this err to user
+                    logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+                    break;
+                }
             }
 
-            scmToken = readOnlyInfo.accessToken;
-            hasAdminPermission = true;
-        } else {
-            // Check permissions
-            hasAdminPermission = await this._hasAdminPermission(scmUri);
+            const scmRepo = await this.scm.decorateUrl({
+                scmUri,
+                scmContext: this.scmContext,
+                token: scmContextToTokenMap[scmContext]
+            });
+
+            // find existing pipeline from same scm context
+            let pipeline = scmUriToChildPipelineMap[scmUri];
+
+            delete scmUriToChildPipelineMap[scmUri];
+
+            // migrate pipeline from another scm context
+            if (!pipeline) {
+                pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo);
+            }
+
+            if (pipeline) {
+                if (pipeline.state === 'DELETING') {
+                    logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} is been deleted.`);
+                    break;
+                }
+
+                createOrUpdatePromises.push(
+                    this._updateChildPipeline(
+                        pipeline,
+                        {
+                            ...pipelineConfigOverrides,
+                            scmContext,
+                            scmUri,
+                            scmRepo,
+                            name: scmRepo.name,
+                            state: 'ACTIVE'
+                        },
+                        scmUrl
+                    )
+                );
+            } else {
+                const pipelineConfig = {
+                    ...pipelineConfigOverrides,
+                    scmContext,
+                    scmUri
+                };
+
+                const pipelineFactory = this._getPipelineFactory();
+
+                createOrUpdatePromises.push(
+                    pipelineFactory.create(pipelineConfig).then(async p => {
+                        logger.info(
+                            `pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`
+                        );
+                        // sync pipeline to create jobs
+                        await p.sync();
+                        if (SD_API_URI) {
+                            await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
+                        }
+                    })
+                );
+            }
         }
 
-        if (!hasAdminPermission) {
-            // TODO: figure out how to bubble up this err to user
-            logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+        // deactivate remaining child pipelines
+        const childPipelinesToBeDeactivated = [
+            ...Object.values(scmUriToChildPipelineMap),
+            ...childPipelinesEligibleForMigration
+        ];
 
-            return null;
-        }
+        createOrUpdatePromises = createOrUpdatePromises.concat(
+            this._deactivateChildPipelines(childPipelinesToBeDeactivated, pipelineConfigOverrides)
+        );
 
-        const pipelineFactory = this._getPipelineFactory();
-        const pipeline = await pipelineFactory.get({ scmUri });
+        return createOrUpdatePromises;
+    }
 
-        if (pipeline) {
+    /**
+     *
+     * @param pipelines
+     * @param pipelineConfigOverrides
+     * @returns {Promise<*[]>}
+     * @private
+     */
+    async _deactivateChildPipelines(pipelines, pipelineConfigOverrides) {
+        const updatePromises = [];
+
+        for (const pipeline of pipelines) {
             if (pipeline.state === 'DELETING') {
-                logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} is been deleted.`);
-
-                return null;
+                logger.error(
+                    `pipelineId:${pipeline.configPipelineId}: Child pipeline with id ${pipeline.id} is been deleted.`
+                );
+            } else if (pipeline.state !== 'INACTIVE') {
+                updatePromises.push(
+                    this._updateChildPipeline(pipeline, { ...pipelineConfigOverrides, state: 'INACTIVE' })
+                );
             }
-
-            // Child pipeline belongs to this parent, update it
-            if (pipeline.configPipelineId === this.id) {
-                pipeline.admins = newAdmins;
-                pipeline.state = newState;
-                logger.info(`pipelineId:${this.id}: Updating child pipeline ${scmUrl} with pipelineId:${pipeline.id}.`);
-
-                return newState === 'ACTIVE' ? pipeline.sync() : pipeline.update();
-            }
-            // Child pipeline does not belong to this parent, return
-            logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
-
-            return null;
         }
 
-        const pipelineConfig = {
-            admins: newAdmins,
-            scmContext,
-            scmUri,
-            configPipelineId: this.id
-        };
-
-        if (scmToken) {
-            pipelineConfig.scmToken = scmToken;
-        }
-
-        return pipelineFactory.create(pipelineConfig).then(async p => {
-            logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
-            // sync pipeline to create jobs
-            await p.sync();
-            if (SD_API_URI) {
-                await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
-            }
-        });
+        return updatePromises;
     }
 
     /**
@@ -960,21 +1082,95 @@ class PipelineModel extends BaseModel {
      * @param {Array} scmUrls  An array of scmUrls for child pipelines
      * @return {Promise}
      */
-    async _syncChildPipelines(scmUrls) {
-        const toCreateOrUpdate = [];
-        const toDeactivate = [];
-        const oldScmUrls = hoek.reach(this.childPipelines, 'scmUrls') || [];
-        const newScmUrls = scmUrls || [];
-        // scmUrls in the old list but not the new list should be removed
-        const scmUrlsToDeactivate = oldScmUrls.filter(scmUrl => !newScmUrls.includes(scmUrl));
+    async _syncChildPipelines(newScmUrls = []) {
+        let toCreateOrUpdatePromises = [];
+        const scmContextToNewScmUrlsMap = {
+            [this.scmContext]: []
+        };
+        const scmContextToTokenMap = {
+            [this.scmContext]: await this.token
+        };
+        const scmContextToReadOnlyScmFlagMap = {
+            [this.scmContext]: false
+        };
 
-        // create or update active child pipelines
-        newScmUrls.forEach(scmUrl => toCreateOrUpdate.push(this._createOrUpdatePipeline(scmUrl, 'ACTIVE')));
+        const invalidNewScmUrls = [];
 
-        // deactivate obsolete child pipelines
-        scmUrlsToDeactivate.forEach(scmUrl => toDeactivate.push(this._createOrUpdatePipeline(scmUrl, 'INACTIVE')));
+        newScmUrls.forEach(newScmUrl => {
+            const scmContext = getScmContextFromScmUrl(newScmUrl, this.scm);
 
-        return Promise.allSettled([...toCreateOrUpdate, ...toDeactivate]);
+            if (scmContext === this.scmContext) {
+                scmContextToNewScmUrlsMap[scmContext].push(newScmUrl);
+            } else {
+                let isReadOnlyScm = scmContextToReadOnlyScmFlagMap[scmContext];
+
+                if (isReadOnlyScm === undefined) {
+                    // If read-only scm, consider the scmUrl and use the token from the config
+                    const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
+
+                    isReadOnlyScm = !!readOnlyInfo.enabled;
+                    scmContextToReadOnlyScmFlagMap[scmContext] = isReadOnlyScm;
+
+                    if (isReadOnlyScm) {
+                        scmContextToTokenMap[scmContext] = readOnlyInfo.accessToken;
+                    }
+                }
+
+                if (isReadOnlyScm) {
+                    const scmUrls = scmContextToNewScmUrlsMap[scmContext] || [];
+
+                    scmUrls.push(newScmUrl);
+                    scmContextToNewScmUrlsMap[scmContext] = scmUrls;
+                } else {
+                    invalidNewScmUrls.push(newScmUrl);
+                }
+            }
+        });
+
+        if (invalidNewScmUrls.length) {
+            logger.error(
+                `pipelineId:${this.id}: Following child pipeline scmUrls are not supported for this pipeline ${invalidNewScmUrls.join(', ')}.`
+            );
+        }
+
+        // get child pipelines
+        const pipelineFactory = this._getPipelineFactory();
+        const config = {
+            params: { configPipelineId: this.id }
+        };
+        const childPipelines = await pipelineFactory.list(config);
+
+        // categorize child pipelines
+        const scmContextToChildPipelinesMap = groupPipelinesByScmContext(childPipelines);
+        let childPipelinesEligibleForMigration = [];
+
+        Object.entries(scmContextToChildPipelinesMap).forEach(([scmContext, pipelines]) => {
+            if (!scmContextToNewScmUrlsMap[scmContext]) {
+                childPipelinesEligibleForMigration = childPipelinesEligibleForMigration.concat(pipelines);
+            }
+        });
+
+        // process child pipelines
+        const pipelineConfigOverrides = {
+            admins: this.admins,
+            adminUserIds: this.adminUserIds,
+            configPipelineId: this.id
+        };
+
+        Object.entries(scmContextToNewScmUrlsMap).forEach(([scmContext, scmUrls]) => {
+            toCreateOrUpdatePromises = toCreateOrUpdatePromises.concat(
+                this._createOrUpdateOrMigrateChildPipelines(
+                    scmContext,
+                    scmUrls,
+                    scmContextToChildPipelinesMap[scmContext] || [],
+                    scmContext === this.scmContext ? childPipelinesEligibleForMigration : [],
+                    scmContextToTokenMap,
+                    pipelineConfigOverrides
+                )
+            );
+        });
+
+        return Promise.allSettled(toCreateOrUpdatePromises);
     }
 
     /**

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -236,10 +236,12 @@ function syncExternalTriggers(config) {
 }
 
 /**
- *
- * @param scmUrl
- * @param scm
- * @returns {*}
+ * Extract SCM context from an SCM URL
+ * Parses the hostname from the provided SCM URL and retrieves the corresponding
+ * SCM context using the SCM service instance
+ * @param   {String}  scmUrl  The SCM checkout URL to parse (e.g., 'github.com:owner/repo.git#branch')
+ * @param   {Object}  scm     The SCM service instance
+ * @return  {String}          The SCM context identifier for the hostname
  */
 function getScmContextFromScmUrl(scmUrl, scm) {
     // Get hostname using scmUrl
@@ -247,14 +249,17 @@ function getScmContextFromScmUrl(scmUrl, scm) {
     const matched = regex.exec(scmUrl);
     const hostname = matched[MATCH_COMPONENT_HOSTNAME];
 
-    // Set scmContext
+    // Get scmContext
     return scm.getScmContext({ hostname });
 }
 
 /**
- *
- * @param pipelines
- * @returns {*}
+ * Group pipelines by their SCM context
+ * Organizes an array of pipeline objects into groups based on their scmContext property.
+ * Each group is represented as an array of pipelines sharing the same scmContext.
+ * @param   {Array}   pipelines  Array of pipeline objects to group
+ * @return  {Object}             Object with scmContext as keys and arrays of pipelines as values
+ *                                Example: { 'github:github.com': [pipeline1, pipeline2], 'bitbucket:bitbucket.org': [pipeline3] }
  */
 function groupPipelinesByScmContext(pipelines) {
     return pipelines.reduce((accumulator, pipeline) => {
@@ -271,20 +276,29 @@ function groupPipelinesByScmContext(pipelines) {
 }
 
 /**
- *
- * @param pipelines
- * @param scmRepo
- * @returns {null}
+ * Find and remove a pipeline from an array by SCM repository properties
+ * Searches for a pipeline matching the given SCM repository's name, branch, and root directory.
+ * If found, removes it from the pipelines array and returns it.
+ * Note: This function mutates the input pipelines array by removing the matched pipeline.
+ * @param   {Array}    pipelines         Array of pipeline objects to search through
+ * @param   {Object}   scmRepo           SCM repository object with properties: name, branch, rootDir
+ * @param   {Boolean}  shouldMatchOwner  If true, also matches the owner part of the repository name (default: false)
+ * @return  {Object|null}                The matched pipeline object if found, null otherwise
  */
-function findAndRemovePipelineByScmRepo(pipelines, scmRepo) {
+function findAndRemovePipelineByScmRepo(pipelines, scmRepo, shouldMatchOwner = false) {
     let matchedPipeline = null;
+
+    const [scmRepoOwner, scmRepoName] = scmRepo.name.split('/');
 
     // find a pipeline matching the repo name, branch and root directory
     const index = pipelines.findIndex(pipeline => {
         const pipelineScmRepo = pipeline.scmRepo;
 
+        const [pipelineScmRepoOwner, pipelineScmRepoName] = pipelineScmRepo.name.split('/');
+
         return (
-            pipelineScmRepo.name.split('/')[1] === scmRepo.name.split('/')[1] &&
+            (!shouldMatchOwner || pipelineScmRepoOwner === scmRepoOwner) &&
+            pipelineScmRepoName === scmRepoName &&
             pipelineScmRepo.branch === scmRepo.branch &&
             pipelineScmRepo.rootDir === scmRepo.rootDir
         );
@@ -928,11 +942,13 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     *
-     * @param childPipeline
-     * @param newConfig
-     * @param scmUrl
-     * @returns {Promise<*>}
+     * Update a child pipeline with new configuration
+     * Merges the new configuration into the child pipeline object and persists the changes.
+     * For ACTIVE pipelines, triggers a full sync; otherwise performs a simple update.
+     * @param   {Object}  childPipeline  The child pipeline object to update
+     * @param   {Object}  newConfig      Configuration object containing properties to merge into the child pipeline
+     * @param   {String}  scmUrl         Optional SCM URL for logging purposes (falls back to childPipeline.scmUri)
+     * @return  {Promise<Object>}        Promise that resolves to the updated child pipeline object
      * @private
      */
     async _updateChildPipeline(childPipeline, newConfig, scmUrl) {
@@ -945,6 +961,52 @@ class PipelineModel extends BaseModel {
         return childPipeline.state === 'ACTIVE' ? childPipeline.sync() : childPipeline.update();
     }
 
+    /**
+     * Deactivate child pipelines by setting their state to INACTIVE
+     * Iterates through child pipelines and creates update promises to deactivate them.
+     * Pipelines in 'DELETING' state are logged as errors and skipped.
+     * Pipelines already 'INACTIVE' are skipped. Returns an array of update promises.
+     * @param   {Array}   pipelines                 Array of child pipeline objects to deactivate
+     * @param   {Object}  pipelineConfigOverrides  Configuration overrides to apply along with state change
+     * @return  {Array<Promise>}                   Array of promises for pipeline updates
+     * @private
+     */
+    async _deactivateChildPipelines(pipelines, pipelineConfigOverrides) {
+        const updatePromises = [];
+
+        for (const pipeline of pipelines) {
+            if (pipeline.state === 'DELETING') {
+                logger.error(
+                    `pipelineId:${pipeline.configPipelineId}: Child pipeline with id ${pipeline.id} is been deleted.`
+                );
+            } else if (pipeline.state !== 'INACTIVE') {
+                updatePromises.push(
+                    this._updateChildPipeline(pipeline, { ...pipelineConfigOverrides, state: 'INACTIVE' })
+                );
+            }
+        }
+
+        return updatePromises;
+    }
+
+    /**
+     * Create, update, or migrate child pipelines based on SCM URLs
+     * Processes a list of SCM URLs and manages child pipeline lifecycle:
+     * - Finds existing pipelines in the same SCM context
+     * - Migrates pipelines from other SCM contexts (with and without owner matching)
+     * - Creates new pipelines for URLs without existing pipelines
+     * - Updates existing pipelines with new configuration and state
+     * - Deactivates pipelines no longer in the SCM URL list
+     * - Validates admin permissions for same-context operations
+     * @param   {String}  scmContext                           The SCM context identifier (e.g., 'github:github.com')
+     * @param   {Array}   scmUrls                              Array of SCM URLs to process for child pipelines
+     * @param   {Array}   childPipelines                       Existing child pipelines in the same SCM context
+     * @param   {Array}   childPipelinesEligibleForMigration   Child pipelines from other SCM contexts that can be migrated
+     * @param   {Object}  scmContextToTokenMap                 Map of SCM contexts to authentication tokens
+     * @param   {Object}  pipelineConfigOverrides              Configuration overrides to apply to all child pipelines
+     * @return  {Array<Promise>}                               Array of promises for pipeline create/update/deactivate operations
+     * @private
+     */
     async _createOrUpdateOrMigrateChildPipelines(
         scmContext,
         scmUrls,
@@ -991,7 +1053,12 @@ class PipelineModel extends BaseModel {
 
             // migrate pipeline from another scm context
             if (!pipeline) {
-                pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo);
+                pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, true);
+            }
+
+            // migrate pipeline from another scm context without matching the repo owner
+            if (!pipeline) {
+                pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, false);
             }
 
             if (pipeline) {
@@ -1052,34 +1119,9 @@ class PipelineModel extends BaseModel {
     }
 
     /**
-     *
-     * @param pipelines
-     * @param pipelineConfigOverrides
-     * @returns {Promise<*[]>}
-     * @private
-     */
-    async _deactivateChildPipelines(pipelines, pipelineConfigOverrides) {
-        const updatePromises = [];
-
-        for (const pipeline of pipelines) {
-            if (pipeline.state === 'DELETING') {
-                logger.error(
-                    `pipelineId:${pipeline.configPipelineId}: Child pipeline with id ${pipeline.id} is been deleted.`
-                );
-            } else if (pipeline.state !== 'INACTIVE') {
-                updatePromises.push(
-                    this._updateChildPipeline(pipeline, { ...pipelineConfigOverrides, state: 'INACTIVE' })
-                );
-            }
-        }
-
-        return updatePromises;
-    }
-
-    /**
      * Sync child pipelines given scmUrls
      * @method syncChildPipelines
-     * @param {Array} scmUrls  An array of scmUrls for child pipelines
+     * @param {Array} newScmUrls  An array of scmUrls for child pipelines
      * @return {Promise}
      */
     async _syncChildPipelines(newScmUrls = []) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1042,7 +1042,7 @@ class PipelineModel extends BaseModel {
 
             const scmRepo = await this.scm.decorateUrl({
                 scmUri,
-                scmContext: this.scmContext,
+                scmContext,
                 token: scmContextToTokenMap[scmContext]
             });
 

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "dayjs": "^1.11.13",
     "deepcopy": "^2.1.0",
     "docker-parse-image": "^3.0.1",
-    "js-yaml": "^4.1.0",
-    "lodash": "^4.17.21",
+    "js-yaml": "^4.1.1",
+    "lodash": "^4.17.23",
     "screwdriver-config-parser": "^12.0.0",
-    "screwdriver-data-schema": "^25.5.0",
+    "screwdriver-data-schema": "^25.12.0",
     "screwdriver-logger": "^3.0.0",
     "screwdriver-workflow-parser": "^6.0.0"
   }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -206,18 +206,15 @@ describe('Pipeline Model', () => {
     };
 
     const getChildPipelineMock = config => {
-        const childPipeline = {
+        return {
             ...config,
-            state: 'ACTIVE',
+            state: config.state || 'ACTIVE',
             id: Date.now(),
             configPipelineId: testId,
             remove: sinon.stub().resolves(null),
-            sync: sinon.stub().resolves(null)
+            sync: sinon.stub().resolves(null),
+            update: sinon.stub().resolves(null)
         };
-
-        childPipeline.update = sinon.stub().resolves(pipeline);
-
-        return childPipeline;
     };
 
     beforeEach(() => {
@@ -286,17 +283,6 @@ describe('Pipeline Model', () => {
                 rootDir: ''
             }
         };
-
-        console.log(
-            [
-                childPipelineGitLabFooConfig,
-                childPipelineGitLabBarConfig,
-                childPipelineGitLabBazConfig,
-                childPipelineGitHubFooConfig,
-                childPipelineGitHubBarConfig,
-                childPipelineGitHubBazConfig
-            ].length
-        );
 
         publishJob = getJobMocks({
             id: 99999,
@@ -423,6 +409,7 @@ describe('Pipeline Model', () => {
         tokenFactoryMock = {
             list: sinon.stub()
         };
+
         scmMock = {
             addWebhook: sinon.stub(),
             getWebhookEventsMapping: sinon.stub().returns({ pr: 'pull_request' }),
@@ -435,6 +422,24 @@ describe('Pipeline Model', () => {
             getReadOnlyInfo: sinon.stub().returns({}),
             getCommitSha: sinon.stub()
         };
+
+        [
+            childPipelineGitHubFooConfig,
+            childPipelineGitHubBarConfig,
+            childPipelineGitHubBazConfig,
+            childPipelineGitLabFooConfig,
+            childPipelineGitLabBarConfig,
+            childPipelineGitLabBazConfig
+        ].forEach(cp => {
+            scmMock.decorateUrl
+                .withArgs(
+                    sinon.match({
+                        scmUri: cp.scmUri
+                    })
+                )
+                .resolves(cp.scmRepo);
+        });
+
         parserMock = sinon.stub();
 
         stageMocks = getStageMocks([
@@ -1640,7 +1645,7 @@ describe('Pipeline Model', () => {
                         scmUri: 'gitLab.com:ownerfoo:main'
                     })
                 );
-                assert.calledOnce(childPipelineFooMock.update);
+                assert.notCalled(childPipelineFooMock.update);
                 assert.equal(childPipelineFooMock.state, 'INACTIVE');
                 assert.calledOnce(childPipelineBazMock.update);
                 assert.equal(childPipelineBazMock.state, 'INACTIVE');
@@ -1673,7 +1678,7 @@ describe('Pipeline Model', () => {
                 assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB_FOO, SCM_URL_GITLAB_BAR]);
                 assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
                 assert.notCalled(pipelineFactoryMock.create);
-                assert.calledOnce(childPipelineFooMock.update);
+                assert.notCalled(childPipelineFooMock.update);
                 assert.equal(childPipelineFooMock.state, 'INACTIVE');
                 assert.calledOnce(childPipelineBazMock.update);
                 assert.equal(childPipelineBazMock.state, 'INACTIVE');
@@ -1877,6 +1882,95 @@ describe('Pipeline Model', () => {
                     assert.isOk(err);
                     assert.equal(err.message, 'This pipeline is being deleted.');
                 });
+        });
+
+        it('migrates child pipelines from another SCM to parent pipeline SCM', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitLabFooConfig, state: 'ACTIVE' });
+            const childPipelineBarMock = getChildPipelineMock({ ...childPipelineGitLabBarConfig, state: 'ACTIVE' });
+            const childPipelineBazMock = getChildPipelineMock({ ...childPipelineGitLabBazConfig, state: 'INACTIVE' });
+
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO, SCM_URL_GITHUB_BAR, SCM_URL_GITHUB_BAZ]
+            };
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns({ enabled: false });
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock, childPipelineBarMock, childPipelineBazMock]);
+            pipeline.childPipelines = {
+                scmUrls: [SCM_URL_GITLAB_FOO, SCM_URL_GITLAB_BAR]
+            };
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.deepEqual(p.childPipelines.scmUrls, [
+                    SCM_URL_GITHUB_FOO,
+                    SCM_URL_GITHUB_BAR,
+                    SCM_URL_GITHUB_BAZ
+                ]);
+                assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
+                assert.notCalled(pipelineFactoryMock.create);
+                assert.calledOnce(childPipelineFooMock.sync);
+                assert.equal(childPipelineFooMock.state, 'ACTIVE');
+                assert.calledOnce(childPipelineBarMock.sync);
+                assert.equal(childPipelineBarMock.state, 'ACTIVE');
+                assert.calledOnce(childPipelineBazMock.sync);
+                assert.equal(childPipelineBazMock.state, 'ACTIVE');
+            });
+        });
+
+        it('should create a new child pipeline when a child pipeline from another SCM is unavailable to migrate to parent pipeline SCM', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const childPipelineBarMock = getChildPipelineMock({ ...childPipelineGitLabBarConfig, state: 'ACTIVE' });
+            const childPipelineBazMock = getChildPipelineMock({ ...childPipelineGitLabBazConfig, state: 'INACTIVE' });
+
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO, SCM_URL_GITHUB_BAR, SCM_URL_GITHUB_BAZ]
+            };
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns({ enabled: false });
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineBarMock, childPipelineBazMock]);
+            pipeline.childPipelines = {
+                scmUrls: [SCM_URL_GITLAB_BAR]
+            };
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.deepEqual(p.childPipelines.scmUrls, [
+                    SCM_URL_GITHUB_FOO,
+                    SCM_URL_GITHUB_BAR,
+                    SCM_URL_GITHUB_BAZ
+                ]);
+                assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
+                assert.calledOnce(pipelineFactoryMock.create);
+                assert.calledWith(
+                    pipelineFactoryMock.create,
+                    sinon.match({
+                        admins: pipeline.admins,
+                        adminUserIds: pipeline.adminUserIds,
+                        configPipelineId: pipeline.id,
+                        scmContext: SCM_CONTEXT_GITHUB,
+                        scmUri: childPipelineGitHubFooConfig.scmUri
+                    })
+                );
+                assert.calledOnce(childPipelineBarMock.sync);
+                assert.equal(childPipelineBarMock.state, 'ACTIVE');
+                assert.calledOnce(childPipelineBazMock.sync);
+                assert.equal(childPipelineBazMock.state, 'ACTIVE');
+            });
         });
     });
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -24,13 +24,13 @@ const PARSED_YAML_WITH_REQUIRES = require('../data/parserWithRequires.json');
 const PARSED_YAML_PR = require('../data/parserWithWorkflowGraphPR.json');
 const PARSED_YAML_WITH_ERRORS = require('../data/parserWithErrors.json');
 const PARSED_YAML_WITH_SUBSCRIBE = require('../data/parserWithSubscribedScms.json');
-const SCM_URL_FOO = 'git@github.com:baz/foo.git';
-const SCM_URL_BAR = 'git@github.com:baz/bar.git';
-const SCM_URL_BAZ = 'git@github.com:baz/baz.git';
-const SCM_URL_GITLAB = 'git@gitlab.com:baz/foo.git';
-const SCM_URL_GITLAB2 = 'git@gitlab.com:baz/bar.git';
-const SCM_URL_GITLAB3 = 'git@gitlab.com:baz/baz.git';
-const SCM_URLS = [SCM_URL_FOO];
+const SCM_URL_GITHUB_FOO = 'git@github.com:baz/foo.git';
+const SCM_URL_GITHUB_BAR = 'git@github.com:baz/bar.git';
+const SCM_URL_GITHUB_BAZ = 'git@github.com:baz/baz.git';
+const SCM_URL_GITLAB_FOO = 'git@gitlab.com:baz/foo.git';
+const SCM_URL_GITLAB_BAR = 'git@gitlab.com:baz/bar.git';
+const SCM_URL_GITLAB_BAZ = 'git@gitlab.com:baz/baz.git';
+const SCM_URLS = [SCM_URL_GITHUB_FOO];
 const EXTERNAL_PARSED_YAML = hoek.applyToDefaults(PARSED_YAML, {
     annotations: { 'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s' },
     childPipelines: {
@@ -86,9 +86,10 @@ describe('Pipeline Model', () => {
 
     const dateNow = 1111111111;
     const scmUri = 'github.com:12345:master';
-    const scmContext = 'github:github.com';
+    const scmContext = SCM_CONTEXT_GITHUB;
     const testId = 123;
     const admins = { batman: true, robin: true };
+    const adminUserIds = [44, 55];
     const scmRepo = {
         branch: 'branch',
         url: 'https://host/owner/repo/tree/branch',
@@ -96,6 +97,12 @@ describe('Pipeline Model', () => {
     };
     let jobs;
     let pipelineConfig;
+    let childPipelineGitHubFooConfig;
+    let childPipelineGitHubBarConfig;
+    let childPipelineGitHubBazConfig;
+    let childPipelineGitLabFooConfig;
+    let childPipelineGitLabBarConfig;
+    let childPipelineGitLabBazConfig;
     let publishJob;
     let mainJob;
     let blahJob;
@@ -187,7 +194,110 @@ describe('Pipeline Model', () => {
         return decorateStageBuildMock(sb);
     };
 
+    const getUserPermissionMocks = (a, context = scmContext) => {
+        userFactoryMock.get.withArgs({ username: a.username, scmContext: context }).resolves({
+            unsealToken: sinon.stub().resolves('foo'),
+            getPermissions: sinon.stub().resolves({
+                push: a.push,
+                admin: a.admin
+            }),
+            username: a.username
+        });
+    };
+
+    const getChildPipelineMock = config => {
+        const childPipeline = {
+            ...config,
+            state: 'ACTIVE',
+            id: Date.now(),
+            configPipelineId: testId,
+            remove: sinon.stub().resolves(null),
+            sync: sinon.stub().resolves(null)
+        };
+
+        childPipeline.update = sinon.stub().resolves(pipeline);
+
+        return childPipeline;
+    };
+
     beforeEach(() => {
+        childPipelineGitHubFooConfig = {
+            scmContext: SCM_CONTEXT_GITHUB,
+            scmUri: 'github.com:ownerfoo:main',
+            scmRepo: {
+                branch: 'main',
+                name: 'owner/foo',
+                url: 'https://github.com/owner/foo/tree/main',
+                rootDir: ''
+            }
+        };
+
+        childPipelineGitHubBarConfig = {
+            scmContext: SCM_CONTEXT_GITHUB,
+            scmUri: 'github.com:ownerbar:main',
+            scmRepo: {
+                branch: 'main',
+                name: 'owner/bar',
+                url: 'https://github.com/owner/bar/tree/main',
+                rootDir: ''
+            }
+        };
+
+        childPipelineGitHubBazConfig = {
+            scmContext: SCM_CONTEXT_GITHUB,
+            scmUri: 'github.com:ownerbaz:main',
+            scmRepo: {
+                branch: 'main',
+                name: 'owner/baz',
+                url: 'https://github.com/owner/baz/tree/main',
+                rootDir: ''
+            }
+        };
+
+        childPipelineGitLabFooConfig = {
+            scmContext: SCM_CONTEXT_GITLAB,
+            scmUri: 'gitLab.com:ownerfoo:main',
+            scmRepo: {
+                branch: 'main',
+                name: 'owner/foo',
+                url: 'https://gitLab.com/owner/foo/tree/main',
+                rootDir: ''
+            }
+        };
+
+        childPipelineGitLabBarConfig = {
+            scmContext: SCM_CONTEXT_GITLAB,
+            scmUri: 'gitLab.com:ownerbar:main',
+            scmRepo: {
+                branch: 'main',
+                name: 'owner/bar',
+                url: 'https://gitLab.com/owner/bar/tree/main',
+                rootDir: ''
+            }
+        };
+
+        childPipelineGitLabBazConfig = {
+            scmContext: SCM_CONTEXT_GITLAB,
+            scmUri: 'gitLab.com:ownerbaz:main',
+            scmRepo: {
+                branch: 'main',
+                name: 'owner/baz',
+                url: 'https://gitLab.com/owner/baz/tree/main',
+                rootDir: ''
+            }
+        };
+
+        console.log(
+            [
+                childPipelineGitLabFooConfig,
+                childPipelineGitLabBarConfig,
+                childPipelineGitLabBazConfig,
+                childPipelineGitHubFooConfig,
+                childPipelineGitHubBarConfig,
+                childPipelineGitHubBazConfig
+            ].length
+        );
+
         publishJob = getJobMocks({
             id: 99999,
             name: 'publish',
@@ -295,13 +405,7 @@ describe('Pipeline Model', () => {
             update: sinon.stub().resolves(null),
             remove: sinon.stub().resolves(null)
         };
-        childPipelineMock = {
-            id: 2,
-            configPipelineId: testId,
-            update: sinon.stub().resolves(null),
-            remove: sinon.stub().resolves(null),
-            sync: sinon.stub().resolves(null)
-        };
+        childPipelineMock = { ...getChildPipelineMock(childPipelineGitHubFooConfig), id: 2 };
         pipelineFactoryMock = {
             getExternalJoinFlag: sinon.stub(),
             getNotificationsValidationErrFlag: sinon.stub(),
@@ -446,6 +550,7 @@ describe('Pipeline Model', () => {
             scmRepo,
             createTime: dateNow,
             admins,
+            adminUserIds,
             scm: scmMock,
             multiBuildClusterEnabled: true
         };
@@ -472,27 +577,6 @@ describe('Pipeline Model', () => {
             assert.strictEqual(pipeline[key], pipelineConfig[key]);
         });
     });
-
-    const getUserPermissionMocks = (a, context = scmContext) => {
-        userFactoryMock.get.withArgs({ username: a.username, scmContext: context }).resolves({
-            unsealToken: sinon.stub().resolves('foo'),
-            getPermissions: sinon.stub().resolves({
-                push: a.push,
-                admin: a.admin
-            }),
-            username: a.username
-        });
-    };
-
-    const getChildPipelineMock = () => {
-        return {
-            id: Date.now(),
-            configPipelineId: testId,
-            update: sinon.stub().resolves(null),
-            remove: sinon.stub().resolves(null),
-            sync: sinon.stub().resolves(null)
-        };
-    };
 
     describe('addWebhooks', () => {
         beforeEach(() => {
@@ -616,45 +700,45 @@ describe('Pipeline Model', () => {
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
-                        checkoutUrl: SCM_URL_FOO
+                        checkoutUrl: SCM_URL_GITHUB_FOO
                     })
                 )
-                .resolves('foo');
+                .resolves(childPipelineGitHubFooConfig.scmUri);
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
-                        checkoutUrl: SCM_URL_BAR
+                        checkoutUrl: SCM_URL_GITHUB_BAR
                     })
                 )
-                .resolves('bar');
+                .resolves(childPipelineGitHubBarConfig.scmUri);
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
-                        checkoutUrl: SCM_URL_BAZ
+                        checkoutUrl: SCM_URL_GITHUB_BAZ
                     })
                 )
-                .resolves('baz');
+                .resolves(childPipelineGitHubBazConfig.scmUri);
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
-                        checkoutUrl: SCM_URL_GITLAB
+                        checkoutUrl: SCM_URL_GITLAB_FOO
                     })
                 )
-                .resolves('foo');
+                .resolves(childPipelineGitLabFooConfig.scmUri);
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
-                        checkoutUrl: SCM_URL_GITLAB2
+                        checkoutUrl: SCM_URL_GITLAB_BAR
                     })
                 )
-                .resolves('bar');
+                .resolves(childPipelineGitLabBarConfig.scmUri);
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(
                     sinon.match({
-                        checkoutUrl: SCM_URL_GITLAB3
+                        checkoutUrl: SCM_URL_GITLAB_BAZ
                     })
                 )
-                .resolves('baz');
+                .resolves(childPipelineGitLabBazConfig.scmUri);
             parserConfig = {
                 yaml: SCM_CONTEXT_GITHUB,
                 templateFactory: templateFactoryMock,
@@ -1214,7 +1298,7 @@ describe('Pipeline Model', () => {
 
             return pipeline.sync().then(() => {
                 assert.deepEqual(pipeline.subscribedScmUrlsWithActions, [
-                    { actions: ['commit', 'tags', 'release'], scmUri: 'foo' }
+                    { actions: ['commit', 'tags', 'release'], scmUri: childPipelineGitHubFooConfig.scmUri }
                 ]);
             });
         });
@@ -1232,6 +1316,7 @@ describe('Pipeline Model', () => {
                 },
                 createTime: dateNow,
                 admins,
+                adminUserIds,
                 scm: scmMock,
                 multiBuildClusterEnabled: true,
                 subscribedScmUrlsWithActions: [{ actions: ['commit', 'tags', 'release'], scmUri: 'foo' }]
@@ -1478,11 +1563,11 @@ describe('Pipeline Model', () => {
 
         it('syncs child pipeline if there are changes in scmUrls', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
-            const childPipelineFooMock = getChildPipelineMock();
-            const childPipelineBazMock = getChildPipelineMock();
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitHubFooConfig, state: 'INACTIVE' });
+            const childPipelineBazMock = getChildPipelineMock({ ...childPipelineGitHubBazConfig, state: 'ACTIVE' });
 
             parsedYaml.childPipelines = {
-                scmUrls: [SCM_URL_FOO, SCM_URL_BAR]
+                scmUrls: [SCM_URL_GITHUB_FOO, SCM_URL_GITHUB_BAR]
             };
 
             jobs = [mainJob, publishJob];
@@ -1490,73 +1575,85 @@ describe('Pipeline Model', () => {
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
             scmMock.getFile.resolves('yamlcontentwithscmurls');
             parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'foo' }).resolves(childPipelineFooMock);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'baz' }).resolves(childPipelineBazMock);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'bar' }).resolves(null);
+
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock, childPipelineBazMock]);
+
             pipeline.childPipelines = {
-                scmUrls: [SCM_URL_BAZ]
+                scmUrls: [SCM_URL_GITHUB_BAZ]
             };
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
-                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_FOO, SCM_URL_BAR]);
+                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITHUB_FOO, SCM_URL_GITHUB_BAR]);
                 assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
                 assert.calledOnce(pipelineFactoryMock.create);
                 assert.calledWith(
                     pipelineFactoryMock.create,
                     sinon.match({
-                        configPipelineId: testId,
-                        scmUri: 'bar'
+                        admins: pipeline.admins,
+                        adminUserIds: pipeline.adminUserIds,
+                        configPipelineId: pipeline.id,
+                        scmContext: SCM_CONTEXT_GITHUB,
+                        scmUri: childPipelineGitHubBarConfig.scmUri
                     })
                 );
                 assert.calledOnce(childPipelineFooMock.sync);
+                assert.equal(childPipelineFooMock.state, 'ACTIVE');
                 assert.calledOnce(childPipelineBazMock.update);
+                assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
 
         it('syncs child pipeline if from read-only SCM', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
-            const childPipelineFooMock = getChildPipelineMock();
-            const childPipelineBazMock = getChildPipelineMock();
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitHubFooConfig, state: 'INACTIVE' });
+            const childPipelineBazMock = getChildPipelineMock({ ...childPipelineGitHubBazConfig, state: 'ACTIVE' });
 
             parsedYaml.childPipelines = {
-                scmUrls: [SCM_URL_GITLAB, SCM_URL_GITLAB2]
+                scmUrls: [SCM_URL_GITLAB_FOO, SCM_URL_GITLAB_BAR]
             };
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
             scmMock.getFile.resolves('yamlcontentwithscmurls');
             parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'foo' }).resolves(childPipelineFooMock);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'baz' }).resolves(childPipelineBazMock);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'bar' }).resolves(null);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock, childPipelineBazMock]);
             pipeline.childPipelines = {
-                scmUrls: [SCM_URL_BAZ]
+                scmUrls: [SCM_URL_GITHUB_BAZ]
             };
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
-                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB, SCM_URL_GITLAB2]);
+                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB_FOO, SCM_URL_GITLAB_BAR]);
                 assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
                 assert.calledWith(
                     pipelineFactoryMock.create,
                     sinon.match({
-                        configPipelineId: testId,
-                        scmUri: 'bar'
+                        admins: pipeline.admins,
+                        adminUserIds: pipeline.adminUserIds,
+                        configPipelineId: pipeline.id,
+                        scmContext: SCM_CONTEXT_GITLAB,
+                        scmUri: 'gitLab.com:ownerfoo:main'
                     })
                 );
-                assert.calledOnce(childPipelineFooMock.sync);
+                assert.calledOnce(childPipelineFooMock.update);
+                assert.equal(childPipelineFooMock.state, 'INACTIVE');
                 assert.calledOnce(childPipelineBazMock.update);
+                assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
 
         it('does not sync if child pipeline not from read-only SCM', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
-            const childPipelineFooMock = getChildPipelineMock();
-            const childPipelineBazMock = getChildPipelineMock();
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitHubFooConfig, state: 'INACTIVE' });
+            const childPipelineBazMock = getChildPipelineMock({ ...childPipelineGitHubBazConfig, state: 'ACTIVE' });
 
             parsedYaml.childPipelines = {
-                scmUrls: [SCM_URL_GITLAB, SCM_URL_GITLAB2]
+                scmUrls: [SCM_URL_GITLAB_FOO, SCM_URL_GITLAB_BAR]
             };
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
@@ -1564,20 +1661,22 @@ describe('Pipeline Model', () => {
             scmMock.getFile.resolves('yamlcontentwithscmurls');
             parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
             scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns({ enabled: false });
-            pipelineFactoryMock.get.withArgs({ scmUri: 'foo' }).resolves(childPipelineFooMock);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'baz' }).resolves(childPipelineBazMock);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'bar' }).resolves(null);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock, childPipelineBazMock]);
             pipeline.childPipelines = {
-                scmUrls: [SCM_URL_BAZ]
+                scmUrls: [SCM_URL_GITHUB_BAZ]
             };
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
-                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB, SCM_URL_GITLAB2]);
+                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB_FOO, SCM_URL_GITLAB_BAR]);
                 assert.calledWith(parserMock, { ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } });
                 assert.notCalled(pipelineFactoryMock.create);
-                assert.notCalled(childPipelineFooMock.sync);
+                assert.calledOnce(childPipelineFooMock.update);
+                assert.equal(childPipelineFooMock.state, 'INACTIVE');
                 assert.calledOnce(childPipelineBazMock.update);
+                assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
 
@@ -1627,24 +1726,6 @@ describe('Pipeline Model', () => {
             });
         });
 
-        it('does not deactivate child pipelines if does not belong to this parent', () => {
-            jobs = [mainJob, publishJob];
-            jobFactoryMock.list.resolves(jobs);
-            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
-            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GITLAB }).returns({ enabled: false });
-            childPipelineMock.configPipelineId = 789;
-            pipelineFactoryMock.get.resolves(childPipelineMock);
-            pipeline.childPipelines = {
-                scmUrls: [SCM_URL_BAR, SCM_URL_GITLAB3]
-            };
-            buildClusterFactoryMock.list.resolves(sdBuildClusters);
-
-            return pipeline.sync().then(p => {
-                assert.equal(p.id, testId);
-                assert.notCalled(childPipelineMock.update);
-            });
-        });
-
         it('does not deactivate child pipelines if no admin permissions', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
@@ -1654,7 +1735,7 @@ describe('Pipeline Model', () => {
             childPipelineMock.configPipelineId = 789;
             pipelineFactoryMock.get.resolves(childPipelineMock);
             pipeline.childPipelines = {
-                scmUrls: [SCM_URL_BAR, SCM_URL_GITLAB3]
+                scmUrls: [SCM_URL_GITHUB_BAR, SCM_URL_GITLAB_BAZ]
             };
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
@@ -1669,17 +1750,21 @@ describe('Pipeline Model', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
-            childPipelineMock.configPipelineId = testId;
-            pipelineFactoryMock.get.resolves(childPipelineMock);
+            const childPipelineBarMock = getChildPipelineMock({ ...childPipelineGitHubBarConfig, state: 'ACTIVE' });
+
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineBarMock]);
             pipeline.childPipelines = {
-                scmUrls: [SCM_URL_BAR]
+                scmUrls: [SCM_URL_GITHUB_BAR]
             };
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
                 assert.equal(p.childPipelines, null);
-                assert.calledOnce(childPipelineMock.update);
+                assert.calledOnce(childPipelineBarMock.update);
+                assert.equal(childPipelineBarMock.state, 'INACTIVE');
             });
         });
 
@@ -1687,63 +1772,76 @@ describe('Pipeline Model', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
-            childPipelineMock.configPipelineId = testId;
-            pipelineFactoryMock.get.resolves(childPipelineMock);
+
+            const childPipelineBazMock = getChildPipelineMock({ ...childPipelineGitLabBazConfig, state: 'ACTIVE' });
+
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineBazMock]);
+
             pipeline.childPipelines = {
-                scmUrls: [SCM_URL_GITLAB3]
+                scmUrls: [SCM_URL_GITLAB_BAZ]
             };
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
                 assert.equal(p.childPipelines, null);
-                assert.calledOnce(childPipelineMock.update);
+                assert.calledOnce(childPipelineBazMock.update);
+                assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
 
         it('reactivates child pipeline if scmUrls is added back (previously removed) in the new yaml', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
-            const inActiveChildPipelineMock = getChildPipelineMock({ state: 'INACTIVE' });
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitHubFooConfig, state: 'INACTIVE' });
 
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
             parsedYaml.childPipelines = {
-                scmUrls: [SCM_URL_FOO]
+                scmUrls: [SCM_URL_GITHUB_FOO]
             };
             scmMock.getFile.resolves('yamlcontentwithscmurls');
             parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'foo' }).resolves(inActiveChildPipelineMock);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock]);
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
-                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_FOO]);
-                assert.equal(inActiveChildPipelineMock.state, 'ACTIVE');
-                assert.calledOnce(inActiveChildPipelineMock.sync);
+                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITHUB_FOO]);
+                assert.calledOnce(childPipelineFooMock.sync);
+                assert.equal(childPipelineFooMock.state, 'ACTIVE');
             });
         });
 
         it('reactivates child pipeline if scmUrls is read-only SCM and added back (previously removed) in the new yaml', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
-            const inActiveChildPipelineMock = getChildPipelineMock({ state: 'INACTIVE' });
+            const childPipelineGitLabFooMock = getChildPipelineMock({
+                ...childPipelineGitLabFooConfig,
+                state: 'INACTIVE'
+            });
 
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
             getUserPermissionMocks({ username: 'batman', push: true, admin: true });
             parsedYaml.childPipelines = {
-                scmUrls: [SCM_URL_GITLAB]
+                scmUrls: [SCM_URL_GITLAB_FOO]
             };
             scmMock.getFile.resolves('yamlcontentwithscmurls');
             parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
-            pipelineFactoryMock.get.withArgs({ scmUri: 'foo' }).resolves(inActiveChildPipelineMock);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineGitLabFooMock]);
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
-                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB]);
-                assert.equal(inActiveChildPipelineMock.state, 'ACTIVE');
-                assert.calledOnce(inActiveChildPipelineMock.sync);
+                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB_FOO]);
+                assert.equal(childPipelineGitLabFooMock.state, 'ACTIVE');
+                assert.calledOnce(childPipelineGitLabFooMock.sync);
             });
         });
 


### PR DESCRIPTION
## Context

When a Screwdriver pipeline having child pipelines configured is migrated from one SCM (Ex: `GitHub`) to another SCM (Ex: `BitBucket`), only the parent pipeline gets migrated.
New child pipelines are created for the new SCM child pipeline `scmUrls`.
Child pipelines for the previous SCM child pipeline `scmUrls` continue to exist in `ACTIVE` state.

This defeats the goal of reusing the pipeline ID for child pipelines.

**Sample - Pipeline configuration in source SCM (GitHub)**
https://github.com/sagar1312/screwdriver-migration-external-config-test-pipeline

**Sample - Pipeline configuration in source SCM (BitBucket)**
https://bitbucket.org/sagar-1312/screwdriver-migration-external-config-test-pipeline/src/main/screwdriver.yaml

**Child pipelines before migration**
<img width="3456" height="910" alt="Image" src="https://github.com/user-attachments/assets/3e1da6f6-d011-4163-868b-0b4c2ad1762e" />

**Child pipelines after migration**
<img width="3444" height="1206" alt="Image" src="https://github.com/user-attachments/assets/51e79c52-46a1-48de-aa6a-3fd0aa068257" />

## Objective

When a parent pipeline is migrated to another SCM, event the child pipelines must be migrated.

**Note:**
Child pipelines should be migrated only if repo name, branch and root directory match. Otherwise the child pipelines associated with previous SCM would be marked as `INACTIVE`.

<img width="3436" height="912" alt="Image" src="https://github.com/user-attachments/assets/1bc96f6b-d9d6-40aa-8b73-1d3df49fc5b7" />

## References

https://github.com/screwdriver-cd/screwdriver/issues/3460

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
