### PR TITLE
feat(3460): Skip creation of child pipeline if a pipeline already exists

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1022,6 +1022,8 @@ class PipelineModel extends BaseModel {
             return map;
         }, {});
 
+        const pipelineFactory = this._getPipelineFactory();
+
         for (const scmUrl of scmUrls) {
             const scmUri = await this._getScmUri({
                 scmUrl,
@@ -1051,8 +1053,16 @@ class PipelineModel extends BaseModel {
 
             delete scmUriToChildPipelineMap[scmUri];
 
-            // migrate pipeline from another scm context
             if (!pipeline) {
+                // Check if pipeline already exists that is not associated with the parent pipeline
+                pipeline = await pipelineFactory.get({ scmUri });
+                if (pipeline && pipeline.configPipelineId !== this.id) {
+                    // Child pipeline does not belong to this parent, return
+                    logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
+                    break;
+                }
+
+                // migrate pipeline from another scm context
                 pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, true);
             }
 
@@ -1087,8 +1097,6 @@ class PipelineModel extends BaseModel {
                     scmContext,
                     scmUri
                 };
-
-                const pipelineFactory = this._getPipelineFactory();
 
                 createOrUpdatePromises.push(
                     pipelineFactory.create(pipelineConfig).then(async p => {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1057,16 +1057,15 @@ class PipelineModel extends BaseModel {
                 // Check if pipeline already exists that is not associated with the parent pipeline
                 pipeline = await pipelineFactory.get({ scmUri });
                 if (pipeline && pipeline.configPipelineId !== this.id) {
-                    // Child pipeline does not belong to this parent, return
                     logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
                     break;
                 }
 
-                // migrate pipeline from another scm context
+                // find and migrate pipeline from another scm context
                 pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, true);
             }
 
-            // migrate pipeline from another scm context without matching the repo owner
+            // find and migrate pipeline from another scm context without matching the repo owner
             if (!pipeline) {
                 pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, false);
             }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -210,7 +210,7 @@ describe('Pipeline Model', () => {
             ...config,
             state: config.state || 'ACTIVE',
             id: Date.now(),
-            configPipelineId: testId,
+            configPipelineId: config.configPipelineId || testId,
             remove: sinon.stub().resolves(null),
             sync: sinon.stub().resolves(null),
             update: sinon.stub().resolves(null)
@@ -1732,6 +1732,44 @@ describe('Pipeline Model', () => {
                 assert.equal(p.id, testId);
                 assert.notCalled(pipelineFactoryMock.update);
                 assert.notCalled(childPipelineMock.sync);
+            });
+        });
+
+        it('does not create child pipeline if the pipeline already exists but not associated to this parent', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitHubFooConfig, state: 'INACTIVE' });
+            const childPipelineBarMock = getChildPipelineMock({
+                ...childPipelineGitHubBarConfig,
+                configPipelineId: 789
+            });
+
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO, SCM_URL_GITHUB_BAR]
+            };
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            pipelineFactoryMock.get
+                .withArgs({ scmUri: childPipelineGitHubBarConfig.scmUri })
+                .resolves(childPipelineBarMock);
+            pipeline.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock]);
+            buildClusterFactoryMock.list.resolves(sdBuildClusters);
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.notCalled(childPipelineFooMock.update);
+                assert.calledOnce(childPipelineFooMock.sync);
+                assert.equal(childPipelineFooMock.state, 'ACTIVE');
+                assert.notCalled(childPipelineBarMock.update);
+                assert.notCalled(childPipelineBarMock.sync);
+                assert.notCalled(pipelineFactoryMock.create);
             });
         });
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1585,6 +1585,8 @@ describe('Pipeline Model', () => {
                 .withArgs({ params: { configPipelineId: testId } })
                 .resolves([childPipelineFooMock, childPipelineBazMock]);
 
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubBarConfig.scmUri }).resolves(null);
+
             pipeline.childPipelines = {
                 scmUrls: [SCM_URL_GITHUB_BAZ]
             };
@@ -1630,6 +1632,8 @@ describe('Pipeline Model', () => {
             pipeline.childPipelines = {
                 scmUrls: [SCM_URL_GITHUB_BAZ]
             };
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitLabFooConfig.scmUri }).resolves(null);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitLabBarConfig.scmUri }).resolves(null);
 
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
@@ -1905,6 +1909,9 @@ describe('Pipeline Model', () => {
             pipeline.childPipelines = {
                 scmUrls: [SCM_URL_GITLAB_FOO, SCM_URL_GITLAB_BAR]
             };
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubFooConfig.scmUri }).resolves(null);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubBarConfig.scmUri }).resolves(null);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubBazConfig.scmUri }).resolves(null);
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync().then(p => {
@@ -1945,6 +1952,9 @@ describe('Pipeline Model', () => {
             pipeline.childPipelines = {
                 scmUrls: [SCM_URL_GITLAB_BAR]
             };
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubFooConfig.scmUri }).resolves(null);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubBarConfig.scmUri }).resolves(null);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubBazConfig.scmUri }).resolves(null);
             buildClusterFactoryMock.list.resolves(sdBuildClusters);
 
             return pipeline.sync().then(p => {


### PR DESCRIPTION
## Context
PR https://github.com/screwdriver-cd/models/pull/662 introduced a regression.
For a child pipeline scmUrl if a pipeline already exists but not associated with the parent, the logic attempted to create a child pipeline for the parent. This lead to an error and skipped further processing of child pipelines.

## Objective

For a child pipeline scmUrl, skip creation of a child pipeline if the pipeline already exists but not associated with the parent.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3460

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
