### PR TITLE
feat(3475): Preserve DISABLED state of child pipelines during sync

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1076,6 +1076,9 @@ class PipelineModel extends BaseModel {
                     break;
                 }
 
+                // Preserve DISABLED state; otherwise set to ACTIVE
+                const newState = pipeline.state === 'DISABLED' ? 'DISABLED' : 'ACTIVE';
+
                 createOrUpdatePromises.push(
                     this._updateChildPipeline(
                         pipeline,
@@ -1085,7 +1088,7 @@ class PipelineModel extends BaseModel {
                             scmUri,
                             scmRepo,
                             name: scmRepo.name,
-                            state: 'ACTIVE'
+                            state: newState
                         },
                         scmUrl
                     )

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "js-yaml": "^4.1.1",
     "lodash": "^4.17.23",
     "screwdriver-config-parser": "^12.0.0",
-    "screwdriver-data-schema": "^25.12.0",
+    "screwdriver-data-schema": "^26.1.0",
     "screwdriver-logger": "^3.0.0",
     "screwdriver-workflow-parser": "^6.0.0"
   }

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1719,6 +1719,36 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('preserves DISABLED state of child pipeline during sync', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitHubFooConfig, state: 'DISABLED' });
+
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true });
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock]);
+
+            pipeline.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.notCalled(childPipelineFooMock.sync);
+                assert.calledOnce(childPipelineFooMock.update);
+                assert.equal(childPipelineFooMock.state, 'DISABLED');
+            });
+        });
+
         it('does not update child pipelines if does not belong to this parent', () => {
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);


### PR DESCRIPTION
## Context

Schema changes have been made to support a new state `DISABLED` for the pipeline.
https://github.com/screwdriver-cd/data-schema/pull/612

## Objective

   - Preserve `DISABLED` state of child pipelines during parent pipeline sync (previously always reset to `ACTIVE`)                                                                                                                                                                                                         
   - Bump `screwdriver-data-schema` to `^26.1.0` which adds the `DISABLED` pipeline state                                                                                                                                                                                                                                   
   - Add test to verify DISABLED state is preserved during sync

## References

https://github.com/screwdriver-cd/screwdriver/issues/3475

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
