### PR TITLE
fix: enable blockedBy functionality for virtual jobs

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -421,11 +421,13 @@ function createBuilds(config) {
 
                     buildConfig.configPipelineSha = pipelineConfig.configPipelineSha;
 
-                    const { freezeWindows } = j.permutations[0];
+                    const { blockedBy, freezeWindows } = j.permutations[0];
+
+                    const hasBlockedBy = blockedBy ? blockedBy.length > 0 : false;
                     const hasFreezeWindows = freezeWindows ? freezeWindows.length > 0 : false;
 
                     // Bypass execution of the build if the job is virtual
-                    buildConfig.start = !isVirtualJob(j) || hasFreezeWindows;
+                    buildConfig.start = !isVirtualJob(j) || hasFreezeWindows || hasBlockedBy;
 
                     return startBuild({
                         decoratedCommit,

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -184,6 +184,7 @@ describe('Event Factory', () => {
                         { name: 'main' },
                         { name: 'firstVirtual' },
                         { name: 'secondVirtual' },
+                        { name: 'thirdVirtual' },
                         { name: 'disabledJob' },
                         { name: 'stage@integration:setup', stageName: 'integration' },
                         { name: 'int-deploy', stageName: 'integration' },
@@ -207,6 +208,7 @@ describe('Event Factory', () => {
                         { src: '~commit', dest: 'main' },
                         { src: '~commit', dest: 'firstVirtual' },
                         { src: '~commit', dest: 'secondVirtual' },
+                        { src: '~commit', dest: 'thirdVirtual' },
                         { src: 'main', dest: 'disabledJob' },
                         { src: 'main', dest: 'stage@integration:setup' },
                         { src: 'stage@integration:setup', dest: 'int-deploy' },
@@ -248,6 +250,7 @@ describe('Event Factory', () => {
                         { name: 'main' },
                         { name: 'firstVirtual' },
                         { name: 'secondVirtual' },
+                        { name: 'thirdVirtual' },
                         { name: 'disabledJob' },
                         { name: 'stage@integration:setup', stageName: 'integration' },
                         { name: 'int-deploy', stageName: 'integration' },
@@ -271,6 +274,7 @@ describe('Event Factory', () => {
                         { src: '~commit', dest: 'main' },
                         { src: '~commit', dest: 'firstVirtual' },
                         { src: '~commit', dest: 'secondVirtual' },
+                        { src: '~commit', dest: 'thirdVirtual' },
                         { src: 'main', dest: 'disabledJob' },
                         { src: 'main', dest: 'stage@integration:setup' },
                         { src: 'stage@integration:setup', dest: 'int-deploy' },
@@ -523,6 +527,22 @@ describe('Event Factory', () => {
                     },
                     {
                         id: 18,
+                        pipelineId: 8765,
+                        name: 'thirdVirtual',
+                        permutations: [
+                            {
+                                requires: ['~commit', '~pr'],
+                                blockedBy: ['~main'],
+                                annotations: {
+                                    'screwdriver.cd/virtualJob': true
+                                }
+                            }
+                        ],
+                        state: 'ENABLED',
+                        isPR: sinon.stub().returns(false)
+                    },
+                    {
+                        id: 19,
                         pipelineId: 8765,
                         name: 'prClosedJob',
                         permutations: [
@@ -981,7 +1001,7 @@ describe('Event Factory', () => {
                 return eventFactory.create(config).then(model => {
                     assert.instanceOf(model, Event);
                     assert.notCalled(jobFactoryMock.create);
-                    assert.callCount(buildFactoryMock.create, 6);
+                    assert.callCount(buildFactoryMock.create, 7);
                     assert.calledWith(
                         buildFactoryMock.create,
                         sinon.match({
@@ -1033,6 +1053,15 @@ describe('Event Factory', () => {
                             parentBuildId: 12345,
                             eventId: model.id,
                             jobId: 17,
+                            start: true
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 18,
                             start: true
                         })
                     );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When an event is triggered via `POST /event`, if the first job in the workflow is a `virtual job` with `blockedBy` configured, the job remains stuck in the `CREATED` state and does not progress.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Enable `blockedBy` functionality for virtual jobs triggered via `POST /event`, ensuring that their status transitions correctly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
As a reference, the following change enabled `blockedBy` functionality for virtual jobs in build-triggered cases:
https://github.com/screwdriver-cd/queue-service/pull/84

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
