### PR TITLE
BREAKING CHANGE: migrate queries from MySQL 5.7 to 8.0

### DIFF
--- a/lib/rawQueries.js
+++ b/lib/rawQueries.js
@@ -22,17 +22,12 @@ const Queries = {
         WHERE rank > :offset AND rank <= :maxRank
         ORDER BY "jobId", "id" ASC`,
 
-    getStatusesQueryMySql: (tablePrefix = '') => `SELECT id, jobId, status, startTime, endTime, meta FROM (
-        SELECT
-            id, jobId, status, startTime, endTime, meta,
-            IF(jobId=@lastJobId,
-                IF(id=@lastId,@curRank:=@curRank,@curRank:=@_sequence),
-            @_sequence:=1) AS rank,
-            @_sequence:=@_sequence+1,
-            @lastId:=id,
-            @lastJobId:=jobId
-        FROM \`${tablePrefix}builds\` a, (SELECT @curRank:=1, @_sequence:=1, @lastJobId:=0) as b WHERE jobId IN (:jobIds) ORDER BY jobId, id DESC ) AS rank WHERE rank.rank > :offset AND rank.rank <= :maxRank ORDER
-        BY jobId, id ASC`,
+    getStatusesQueryMySql: (tablePrefix = '') => `SELECT id, jobId, status, startTime, endTime, meta
+        FROM (SELECT id, jobId, status, startTime, endTime, meta,
+        RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
+        FROM \`${tablePrefix}builds\` WHERE jobId in (:jobIds)) as R
+        WHERE \`rank\` > :offset AND \`rank\` <= :maxRank
+        ORDER BY jobId, id ASC`,
 
     // getLatestBuilds()
     getLatestBuildQuery: (tablePrefix = '') => `SELECT * FROM (
@@ -41,19 +36,10 @@ const Queries = {
         WHERE rank = 1
         ORDER BY "jobId", "id" DESC`,
 
-    getLatestBuildQueryMySql: (tablePrefix = '') =>
-        `SELECT id, environment, eventId, jobId, parentBuildId, number, container, cause, sha,
-                createTime, startTime, endTime, parameters, meta, status, statusMessage,
-                buildClusterName, stats, parentBuilds, templateId FROM (
-        SELECT a.id, a.environment, a.eventId, a.jobId, a.parentBuildId, a.number, a.container, a.cause, a.sha,
-                a.createTime, a.startTime, a.endTime, a.parameters, a.meta, a.status, a.statusMessage,
-                a.buildClusterName, a.stats, a.parentBuilds, a.templateId, count(b.id) AS rank
-        FROM \`${tablePrefix}builds\` a LEFT JOIN (SELECT id, jobId FROM \`${tablePrefix}builds\` WHERE eventId IN
-                                    (SELECT id FROM \`${tablePrefix}events\` WHERE groupEventId = :groupEventId)) b
-                ON a.id<=b.id AND a.jobId=b.jobId
-            WHERE a.eventId IN (SELECT id FROM \`${tablePrefix}events\` WHERE groupEventId = :groupEventId)
-            GROUP BY a.jobId, a.id) as R
-        WHERE rank=1
+    getLatestBuildQueryMySql: (tablePrefix = '') => `SELECT * FROM (
+        SELECT *, RANK() OVER ( PARTITION BY jobId ORDER BY id DESC ) AS \`rank\`
+        FROM \`${tablePrefix}builds\` WHERE eventId in (SELECT id FROM \`${tablePrefix}events\` WHERE groupEventId = (:groupEventId))) AS events
+        WHERE \`rank\` = 1
         ORDER BY jobId, id DESC`,
 
     // removeSteps()


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

For the migration to MySQL 8.0, we will fix any incompatible queries.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

fix below raw query.

- getStatusesQueryMySql
- getLatestBuildQueryMySql

I do not believe compatibility with MySQL 5.7 is necessary.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
