### PR TITLE
feat(3434): skip execution of virtual jobs when the event start from webhook [1]

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -425,9 +425,11 @@ function createBuilds(config) {
 
                     const hasBlockedBy = blockedBy ? blockedBy.length > 0 : false;
                     const hasFreezeWindows = freezeWindows ? freezeWindows.length > 0 : false;
+                    const isWebhookTrigger = eventConfig.webhooks;
+                    const shouldScheduled = hasFreezeWindows || hasBlockedBy || isWebhookTrigger;
 
-                    // Bypass execution of the build if the job is virtual
-                    buildConfig.start = !isVirtualJob(j) || hasFreezeWindows || hasBlockedBy;
+                    // Bypass execution of the build if the job is virtual and it does not need to be scheduled
+                    buildConfig.start = !isVirtualJob(j) || shouldScheduled;
 
                     return startBuild({
                         decoratedCommit,

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -1044,6 +1044,83 @@ describe('Event Factory', () => {
                             parentBuildId: 12345,
                             eventId: model.id,
                             jobId: 16,
+                            start: true // virtual job should start if the event start from webhook
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 17,
+                            start: true
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 18,
+                            start: true
+                        })
+                    );
+                    assert.calledOnce(pipelineMock.sync);
+                    assert.notCalled(syncedPipelineMock.syncPR);
+                });
+            });
+
+            it('should create commit builds when it was not started from webhook', () => {
+                config.startFrom = '~commit';
+                config.webhooks = false;
+                syncedPipelineMock.id = 123566;
+
+                return eventFactory.create(config).then(model => {
+                    assert.instanceOf(model, Event);
+                    assert.notCalled(jobFactoryMock.create);
+                    assert.callCount(buildFactoryMock.create, 7);
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 1,
+                            start: true
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 5,
+                            start: true
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 6,
+                            start: true
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 7,
+                            start: true
+                        })
+                    );
+                    assert.calledWith(
+                        buildFactoryMock.create,
+                        sinon.match({
+                            parentBuildId: 12345,
+                            eventId: model.id,
+                            jobId: 16,
                             start: false // should skip execution of virtual job without freeze windows
                         })
                     );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The API response is too slow when a virtual job has a large number of connected downstream jobs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Skip execution of the virtual job in the webhook request.
They will be executed in the queue-service's request and they also trigger their downstream jobs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/3434
- PR - https://github.com/screwdriver-cd/screwdriver/pull/3480

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
