### PR TITLE
fix: child pipeline creation for GHEC repositories

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1156,36 +1156,54 @@ class PipelineModel extends BaseModel {
 
         const invalidNewScmUrls = [];
 
-        newScmUrls.forEach(newScmUrl => {
-            const scmContext = getScmContextFromScmUrl(newScmUrl, this.scm);
+        for (const newScmUrl of newScmUrls) {
+            let scmContext = getScmContextFromScmUrl(newScmUrl, this.scm);
 
-            if (scmContext === this.scmContext) {
-                scmContextToNewScmUrlsMap[scmContext].push(newScmUrl);
-            } else {
-                let isReadOnlyScm = scmContextToReadOnlyScmFlagMap[scmContext];
-
-                if (isReadOnlyScm === undefined) {
-                    // If read-only scm, consider the scmUrl and use the token from the config
-                    const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
-
-                    isReadOnlyScm = !!readOnlyInfo.enabled;
-                    scmContextToReadOnlyScmFlagMap[scmContext] = isReadOnlyScm;
-
-                    if (isReadOnlyScm) {
-                        scmContextToTokenMap[scmContext] = readOnlyInfo.accessToken;
-                    }
-                }
-
-                if (isReadOnlyScm) {
-                    const scmUrls = scmContextToNewScmUrlsMap[scmContext] || [];
-
-                    scmUrls.push(newScmUrl);
-                    scmContextToNewScmUrlsMap[scmContext] = scmUrls;
-                } else {
+            // Fallback for contexts like GHEC where the scmContext host can differ
+            // from the checkout URL host (for example github.com URLs under a custom context).
+            if (!scmContext) {
+                try {
+                    await this._getScmUri({
+                        scmUrl: newScmUrl,
+                        scmContext: this.scmContext,
+                        token: scmContextToTokenMap[this.scmContext]
+                    });
+                    scmContext = this.scmContext;
+                } catch (error) {
                     invalidNewScmUrls.push(newScmUrl);
+                    scmContext = null;
                 }
             }
-        });
+
+            if (scmContext) {
+                if (scmContext === this.scmContext) {
+                    scmContextToNewScmUrlsMap[scmContext].push(newScmUrl);
+                } else {
+                    let isReadOnlyScm = scmContextToReadOnlyScmFlagMap[scmContext];
+
+                    if (isReadOnlyScm === undefined) {
+                        // If read-only scm, consider the scmUrl and use the token from the config
+                        const readOnlyInfo = this.scm.getReadOnlyInfo({ scmContext });
+
+                        isReadOnlyScm = !!readOnlyInfo.enabled;
+                        scmContextToReadOnlyScmFlagMap[scmContext] = isReadOnlyScm;
+
+                        if (isReadOnlyScm) {
+                            scmContextToTokenMap[scmContext] = readOnlyInfo.accessToken;
+                        }
+                    }
+
+                    if (isReadOnlyScm) {
+                        const scmUrls = scmContextToNewScmUrlsMap[scmContext] || [];
+
+                        scmUrls.push(newScmUrl);
+                        scmContextToNewScmUrlsMap[scmContext] = scmUrls;
+                    } else {
+                        invalidNewScmUrls.push(newScmUrl);
+                    }
+                }
+            }
+        }
 
         if (invalidNewScmUrls.length) {
             logger.error(

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -47,6 +47,7 @@ const DEFAULT_PAGE = 1;
 const MAX_METRIC_GET_COUNT = 1000;
 const FAKE_MAX_METRIC_GET_COUNT = 5;
 const SCM_CONTEXT_GITHUB = 'github:github.com';
+const SCM_CONTEXT_GHEC = 'github:enterprise-cloud.com';
 const SCM_CONTEXT_GITLAB = 'gitlab:gitlab.com';
 const DEFAULT_COMMIT_SHA = 'aebcdcbdb267ad4395a40aa8b8908f44babd4a18';
 
@@ -1986,6 +1987,93 @@ describe('Pipeline Model', () => {
                 assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITLAB_FOO]);
                 assert.equal(childPipelineGitLabFooMock.state, 'ACTIVE');
                 assert.calledOnce(childPipelineGitLabFooMock.sync);
+            });
+        });
+
+        it('syncs child pipelines for a GHEC-style parent context when the child scmUrl host is github.com', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true }, SCM_CONTEXT_GHEC);
+            getUserPermissionMocks({ username: 'robin', push: true }, SCM_CONTEXT_GHEC);
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            pipelineFactoryMock.list.withArgs({ params: { configPipelineId: testId } }).resolves([]);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubFooConfig.scmUri }).resolves(null);
+            buildClusterFactoryMock.list.resolves(ghecBuildClusters);
+
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(undefined);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITHUB_FOO]);
+                assert.calledWith(
+                    pipelineFactoryMock.scm.parseUrl,
+                    sinon.match({
+                        scmContext: SCM_CONTEXT_GHEC,
+                        checkoutUrl: SCM_URL_GITHUB_FOO
+                    })
+                );
+                assert.calledOnce(pipelineFactoryMock.create);
+                assert.calledWith(
+                    pipelineFactoryMock.create,
+                    sinon.match({
+                        admins: pipeline.admins,
+                        adminUserIds: pipeline.adminUserIds,
+                        configPipelineId: pipeline.id,
+                        scmContext: SCM_CONTEXT_GHEC,
+                        scmUri: childPipelineGitHubFooConfig.scmUri
+                    })
+                );
+            });
+        });
+
+        it('skips child pipelines for a GHEC-style parent context when the scmUrl cannot be parsed by the parent context', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true }, SCM_CONTEXT_GHEC);
+            getUserPermissionMocks({ username: 'robin', push: true }, SCM_CONTEXT_GHEC);
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            pipelineFactoryMock.list.withArgs({ params: { configPipelineId: testId } }).resolves([]);
+            buildClusterFactoryMock.list.resolves(ghecBuildClusters);
+
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(undefined);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
+            pipelineFactoryMock.scm.parseUrl
+                .withArgs(
+                    sinon.match({
+                        scmContext: SCM_CONTEXT_GHEC,
+                        checkoutUrl: SCM_URL_GITHUB_FOO
+                    })
+                )
+                .rejects(new Error('This checkoutUrl is not supported for your current login host.'));
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.deepEqual(p.childPipelines.scmUrls, [SCM_URL_GITHUB_FOO]);
+                assert.calledWith(
+                    pipelineFactoryMock.scm.parseUrl,
+                    sinon.match({
+                        scmContext: SCM_CONTEXT_GHEC,
+                        checkoutUrl: SCM_URL_GITHUB_FOO
+                    })
+                );
+                assert.notCalled(pipelineFactoryMock.create);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Child pipelines could not be created for repositories associated with GitHub Enterprise Cloud.

Child pipeline SCM context resolution currently depends on reverse lookup from the child pipeline checkout URL host.
This works when the SCM context name matches the actual checkout host, but it breaks in GHEC setups that use a custom `gheCloudContext`.

In those environments, child pipeline URLs may still use `github.com`, while the configured SCM context is a custom value such as `github:enterprise-cloud.com`.
Because the current logic only tries to resolve the SCM context from the URL host, valid GHEC child pipeline URLs may fail to resolve to the parent pipeline's SCM context.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds a fallback for child pipeline SCM context resolution in `_syncChildPipelines`.

When SCM context lookup from the child pipeline URL host fails, the code now attempts to parse the child URL using the parent pipeline's SCM context.
If that succeeds, the child pipeline is treated as belonging to the parent pipeline's SCM context.
If it still cannot be parsed, the child pipeline URL is skipped as unsupported instead of being processed further.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
