### PR TITLE
fix: GHEC child pipeline scmContext fallback

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -258,7 +258,10 @@ function getScmContextFromScmUrl(scmUrl, scm) {
     const hostname = matched[MATCH_COMPONENT_HOSTNAME];
 
     // Get scmContext
-    return scm.getScmContext({ hostname });
+    const scmContext = scm.getScmContext({ hostname });
+
+    // getScmContext() can return a ValidationError object when no context matches.
+    return typeof scmContext === 'string' ? scmContext : null;
 }
 
 /**

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -1993,6 +1993,9 @@ describe('Pipeline Model', () => {
         it('syncs child pipelines for a GHEC-style parent context when the child scmUrl host is github.com', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
             const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+            const validationError = new Error('"value" is required');
+
+            validationError.name = 'ValidationError';
 
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
@@ -2008,7 +2011,7 @@ describe('Pipeline Model', () => {
             buildClusterFactoryMock.list.resolves(ghecBuildClusters);
 
             pipeline.scmContext = SCM_CONTEXT_GHEC;
-            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(undefined);
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(validationError);
             scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
 
             return pipeline.sync().then(p => {
@@ -2038,6 +2041,9 @@ describe('Pipeline Model', () => {
         it('skips child pipelines for a GHEC-style parent context when the scmUrl cannot be parsed by the parent context', () => {
             const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
             const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+            const validationError = new Error('"value" is required');
+
+            validationError.name = 'ValidationError';
 
             jobs = [mainJob, publishJob];
             jobFactoryMock.list.resolves(jobs);
@@ -2052,7 +2058,7 @@ describe('Pipeline Model', () => {
             buildClusterFactoryMock.list.resolves(ghecBuildClusters);
 
             pipeline.scmContext = SCM_CONTEXT_GHEC;
-            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(undefined);
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(validationError);
             scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
             pipelineFactoryMock.scm.parseUrl
                 .withArgs(


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR is a follow-up to https://github.com/screwdriver-cd/models/pull/669.

The previous fix assumed that `getScmContext()` would return null when no matching SCM context was found. In practice, it can return a validation error object from [scm-base](https://github.com/screwdriver-cd/scm-base/blob/v10.0.2/index.js#L658) instead.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR updates the child pipeline sync logic to treat only string values as valid SCM contexts.

This keeps the existing fallback behavior intact while avoiding cases where a non-string result from `getScmContext()` is treated as a valid `scmContext`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
