### PR TITLE
fix: Make commit status updates non-blocking to reduce webhook timeouts

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -767,7 +767,9 @@ class BuildModel extends BaseModel {
                                 });
                             });
                         })
-                        .then(() => this.updateCommitStatus(pipeline))
+                        .then(() => {
+                            this.updateCommitStatus(pipeline).catch(() => {}); // fire and forget
+                        })
                 ) // update github
                 .then(() => this)
         );
@@ -790,8 +792,10 @@ class BuildModel extends BaseModel {
 
         // check if the status is changing
         if (this.isDirty('status')) {
-            // update scm with status
-            prom = prom.then(() => this.pipeline).then(pipeline => this.updateCommitStatus(pipeline));
+            // update scm with status - fire and forget, don't block main flow
+            prom.then(() => this.pipeline)
+                .then(pipeline => this.updateCommitStatus(pipeline))
+                .catch(() => {});
         }
 
         return prom


### PR DESCRIPTION
## Context

Webhook handling from SCM providers such as GitHub can be delayed because commit status updates are executed inline.
When a single webhook triggers many jobs, those status updates can accumulate and make the webhook response slow enough to time out.

## Objective

Make commit status updates non-blocking so webhook responses can return without waiting for SCM status updates to complete.

This PR:
- moves commit status updates off the blocking webhook path

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
