### PR TITLE
fix: use SCM source of truth for latest commit SHA [1]

### DIFF
--- a/lib/eventFactory.js
+++ b/lib/eventFactory.js
@@ -692,6 +692,32 @@ class EventFactory extends BaseFactory {
     }
 
     /**
+     * Get latest pipeline event for latest commit sha in scm
+     * @method getLatestCommitEvent
+     * @param  {Object}    config
+     * @param  {Number}    config.pipelineId   Pipeline ID
+     * @return {Promise<Event|null>}
+     */
+    async getLatestCommitEvent(config) {
+        const { pipelineId } = config;
+        const sha = await this._getCommitSha(pipelineId);
+        const events = await this.list({
+            params: {
+                pipelineId,
+                type: 'pipeline',
+                sha
+            },
+            sort: 'descending',
+            sortBy: 'id',
+            paginate: {
+                count: 1
+            }
+        });
+
+        return events[0] || null;
+    }
+
+    /**
      * Create an event model
      * @method create
      * @param  {Object}  config

--- a/test/lib/eventFactory.test.js
+++ b/test/lib/eventFactory.test.js
@@ -107,6 +107,68 @@ describe('Event Factory', () => {
         });
     });
 
+    describe('getLatestCommitEvent', () => {
+        const pipelineId = 123;
+
+        it('passes scmUri/scmContext/token to getCommitSha', async () => {
+            const pipeline = {
+                scmContext: 'github:github.com',
+                scmUri: 'github.com:123:master',
+                scmRepo: {
+                    branch: 'master',
+                    name: 'foo/bar',
+                    rootDir: 'dir1',
+                    url: 'https://github.com/foo/bar/tree/master/dir1'
+                },
+                token: Promise.resolve('token')
+            };
+
+            pipelineFactoryMock.get.resolves(pipeline);
+
+            await eventFactory._getCommitSha(pipelineId);
+
+            assert.calledWith(pipelineFactoryMock.scm.getCommitSha, {
+                scmContext: pipeline.scmContext,
+                scmUri: pipeline.scmUri,
+                token: 'token'
+            });
+        });
+
+        it('lists pipeline events by latest scm sha and returns latest one', async () => {
+            const listStub = sinon.stub(eventFactory, 'list');
+            const commitShaStub = sinon.stub(eventFactory, '_getCommitSha').resolves('abc123');
+            const latestEvent = eventFactory.createClass({ id: 100 });
+
+            listStub.resolves([latestEvent]);
+
+            const result = await eventFactory.getLatestCommitEvent({ pipelineId });
+
+            assert.calledWith(commitShaStub, pipelineId);
+            assert.calledWith(listStub, {
+                params: {
+                    pipelineId,
+                    type: 'pipeline',
+                    sha: 'abc123'
+                },
+                sort: 'descending',
+                sortBy: 'id',
+                paginate: {
+                    count: 1
+                }
+            });
+            assert.equal(result, latestEvent);
+        });
+
+        it('returns null when no matching event exists', async () => {
+            sinon.stub(eventFactory, '_getCommitSha').resolves('abc123');
+            sinon.stub(eventFactory, 'list').resolves([]);
+
+            const result = await eventFactory.getLatestCommitEvent({ pipelineId });
+
+            assert.isNull(result);
+        });
+    });
+
     describe('create', () => {
         let sandbox;
 


### PR DESCRIPTION
## Context

Currently, the [GET /pipelines/{id}/latestCommitEvent](https://github.com/screwdriver-cd/screwdriver/blob/v8.0.152/plugins/pipelines/latestCommitEvent.js) endpoint calculates the latest commit event based on data from the `pipelines` table. However, depending on how events are created, an event that is **not actually linked to the latest commit** can sometimes be incorrectly returned.

**Example Scenario:**
When a user selects an event with an older (not the latest) commit SHA in the UI and triggers a `New Run (Fresh)` operation, that specific event is incorrectly determined as the `latestCommitEvent`, even though it was generated from an outdated commit SHA.

Since it is difficult to accurately determine the true `latestCommitEvent` using only the data stored within Screwdriver, we need to change the approach to fetch the latest SHA directly from the git repository for accurate validation.

## Objective

To fix this misdetermination, we will modify the logic to fetch the latest commit SHA from the git repository and use it as the source of truth to correctly identify the `latestCommitEvent`.

As the first step for this fix, this PR **adds the `getLatestCommitEvent` function to the `models` layer**.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/3499
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
