### PR TITLE
fix(3460): re-point migrated child pipelines instead of orphaning them on SCM migration

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1009,6 +1009,9 @@ class PipelineModel extends BaseModel {
      * - Updates existing pipelines with new configuration and state
      * - Deactivates pipelines no longer in the SCM URL list
      * - Validates admin permissions for same-context operations
+     * Each scmUrl is processed independently: a url that fails to resolve, lacks admin permissions,
+     * already belongs to another parent, or is being deleted is skipped without aborting the rest,
+     * so the deactivation pass always runs and a removed/replaced child is never left orphaned.
      * @param   {String}  scmContext                           The SCM context identifier (e.g., 'github:github.com')
      * @param   {Array}   scmUrls                              Array of SCM URLs to process for child pipelines
      * @param   {Array}   childPipelines                       Existing child pipelines in the same SCM context
@@ -1033,95 +1036,27 @@ class PipelineModel extends BaseModel {
             return map;
         }, {});
 
-        const pipelineFactory = this._getPipelineFactory();
-
         for (const scmUrl of scmUrls) {
-            const scmUri = await this._getScmUri({
-                scmUrl,
-                scmContext,
-                token: scmContextToTokenMap[scmContext]
-            });
-
-            if (scmContext === this.scmContext) {
-                // Check permissions
-                const hasAdminPermission = await this._hasAdminPermission(scmUri);
-
-                if (!hasAdminPermission) {
-                    // TODO: figure out how to bubble up this err to user
-                    logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
-                    break;
-                }
-            }
-
-            const scmRepo = await this.scm.decorateUrl({
-                scmUri,
-                scmContext,
-                token: scmContextToTokenMap[scmContext]
-            });
-
-            // find existing pipeline from same scm context
-            let pipeline = scmUriToChildPipelineMap[scmUri];
-
-            delete scmUriToChildPipelineMap[scmUri];
-
-            if (!pipeline) {
-                // Check if pipeline already exists that is not associated with the parent pipeline
-                pipeline = await pipelineFactory.get({ scmUri });
-                if (pipeline && pipeline.configPipelineId !== this.id) {
-                    logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
-                    break;
-                }
-
-                // find and migrate pipeline from another scm context
-                pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, true);
-            }
-
-            // find and migrate pipeline from another scm context without matching the repo owner
-            if (!pipeline) {
-                pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, false);
-            }
-
-            if (pipeline) {
-                if (pipeline.state === 'DELETING') {
-                    logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} is been deleted.`);
-                    break;
-                }
-
-                // Preserve DISABLED state; otherwise set to ACTIVE
-                const newState = pipeline.state === 'DISABLED' ? 'DISABLED' : 'ACTIVE';
-
-                createOrUpdatePromises.push(
-                    this._updateChildPipeline(
-                        pipeline,
-                        {
-                            ...pipelineConfigOverrides,
-                            scmContext,
-                            scmUri,
-                            scmRepo,
-                            name: scmRepo.name,
-                            state: newState
-                        },
-                        scmUrl
-                    )
-                );
-            } else {
-                const pipelineConfig = {
-                    ...pipelineConfigOverrides,
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                const scmUrlPromises = await this._reconcileChildPipelineForScmUrl({
+                    scmUrl,
                     scmContext,
-                    scmUri
-                };
+                    scmUriToChildPipelineMap,
+                    childPipelinesEligibleForMigration,
+                    scmContextToTokenMap,
+                    pipelineConfigOverrides
+                });
 
-                createOrUpdatePromises.push(
-                    pipelineFactory.create(pipelineConfig).then(async p => {
-                        logger.info(
-                            `pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`
-                        );
-                        // sync pipeline to create jobs
-                        await p.sync();
-                        if (SD_API_URI) {
-                            await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
-                        }
-                    })
+                createOrUpdatePromises = createOrUpdatePromises.concat(scmUrlPromises);
+            } catch (err) {
+                // A failure resolving or decorating one scmUrl must not abort reconciliation of the
+                // remaining urls, and must not skip the deactivation pass below. Otherwise a child
+                // whose repo was removed or replaced (for example after an SCM migration) would be
+                // left orphaned and ACTIVE in its old SCM context instead of being migrated or
+                // marked INACTIVE.
+                logger.error(
+                    `pipelineId:${this.id}: Failed to reconcile child pipeline for ${scmUrl}: ${err.message}.`
                 );
             }
         }
@@ -1137,6 +1072,126 @@ class PipelineModel extends BaseModel {
         );
 
         return createOrUpdatePromises;
+    }
+
+    /**
+     * Reconcile a single child-pipeline scmUrl against the existing child pipelines.
+     * Resolves the url to an scmUri, then returns the create/update promise(s) needed to either
+     * re-point an existing child (matched in the same SCM context, or migrated from another SCM
+     * context by matching repo name/branch/rootDir) or create a new child. Returns an empty array
+     * when the url should be skipped: no admin permission, the scmUri is owned by another parent,
+     * or the matched child is being deleted. Mutates scmUriToChildPipelineMap and
+     * childPipelinesEligibleForMigration as children are consumed, so whatever the caller is left
+     * with can be deactivated. Throwing is left to the caller to catch so one failing url does not
+     * abort reconciliation of the others.
+     * @param   {Object}  config
+     * @param   {String}  config.scmUrl                              SCM checkout url to reconcile
+     * @param   {String}  config.scmContext                          The SCM context being processed
+     * @param   {Object}  config.scmUriToChildPipelineMap            Same-context children keyed by scmUri (mutated)
+     * @param   {Array}   config.childPipelinesEligibleForMigration  Children from other contexts available to migrate (mutated)
+     * @param   {Object}  config.scmContextToTokenMap                Map of SCM contexts to authentication tokens
+     * @param   {Object}  config.pipelineConfigOverrides             Configuration overrides to apply
+     * @return  {Promise<Array<Promise>>}                            Promises to add to the reconciliation set
+     * @private
+     */
+    async _reconcileChildPipelineForScmUrl({
+        scmUrl,
+        scmContext,
+        scmUriToChildPipelineMap,
+        childPipelinesEligibleForMigration,
+        scmContextToTokenMap,
+        pipelineConfigOverrides
+    }) {
+        const pipelineFactory = this._getPipelineFactory();
+        const scmUri = await this._getScmUri({
+            scmUrl,
+            scmContext,
+            token: scmContextToTokenMap[scmContext]
+        });
+
+        if (scmContext === this.scmContext) {
+            // Check permissions
+            const hasAdminPermission = await this._hasAdminPermission(scmUri);
+
+            if (!hasAdminPermission) {
+                // TODO: figure out how to bubble up this err to user
+                logger.error(`pipelineId:${this.id}: No admins have admin permissions on ${scmUrl}.`);
+
+                return [];
+            }
+        }
+
+        const scmRepo = await this.scm.decorateUrl({
+            scmUri,
+            scmContext,
+            token: scmContextToTokenMap[scmContext]
+        });
+
+        // find existing pipeline from same scm context
+        let pipeline = scmUriToChildPipelineMap[scmUri];
+
+        delete scmUriToChildPipelineMap[scmUri];
+
+        if (!pipeline) {
+            // Check if pipeline already exists that is not associated with the parent pipeline
+            pipeline = await pipelineFactory.get({ scmUri });
+            if (pipeline && pipeline.configPipelineId !== this.id) {
+                logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} already exists: ${pipeline.id}.`);
+
+                return [];
+            }
+
+            // find and migrate pipeline from another scm context
+            pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, true);
+        }
+
+        // find and migrate pipeline from another scm context without matching the repo owner
+        if (!pipeline) {
+            pipeline = findAndRemovePipelineByScmRepo(childPipelinesEligibleForMigration, scmRepo, false);
+        }
+
+        if (pipeline) {
+            if (pipeline.state === 'DELETING') {
+                logger.error(`pipelineId:${this.id}: Pipeline ${scmUrl} is been deleted.`);
+
+                return [];
+            }
+
+            // Preserve DISABLED state; otherwise set to ACTIVE
+            const newState = pipeline.state === 'DISABLED' ? 'DISABLED' : 'ACTIVE';
+
+            return [
+                this._updateChildPipeline(
+                    pipeline,
+                    {
+                        ...pipelineConfigOverrides,
+                        scmContext,
+                        scmUri,
+                        scmRepo,
+                        name: scmRepo.name,
+                        state: newState
+                    },
+                    scmUrl
+                )
+            ];
+        }
+
+        const pipelineConfig = {
+            ...pipelineConfigOverrides,
+            scmContext,
+            scmUri
+        };
+
+        return [
+            pipelineFactory.create(pipelineConfig).then(async p => {
+                logger.info(`pipelineId:${this.id}: Creating child pipeline for ${scmUrl} with pipelineId:${p.id}.`);
+                // sync pipeline to create jobs
+                await p.sync();
+                if (SD_API_URI) {
+                    await p.addWebhook(`${SD_API_URI}/v4/webhooks`);
+                }
+            })
+        ];
     }
 
     /**

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -2083,6 +2083,225 @@ describe('Pipeline Model', () => {
             });
         });
 
+        it('re-points an existing old-SCM child to a GHEC parent context when the corrected scmUrl repo name matches', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+            const validationError = new Error('"value" is required');
+
+            validationError.name = 'ValidationError';
+
+            // existing child still on the old SCM (GitLab), same repo name as the corrected url
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitLabFooConfig, state: 'ACTIVE' });
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true }, SCM_CONTEXT_GHEC);
+            getUserPermissionMocks({ username: 'robin', push: true }, SCM_CONTEXT_GHEC);
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock]);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubFooConfig.scmUri }).resolves(null);
+            buildClusterFactoryMock.list.resolves(ghecBuildClusters);
+
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            pipeline.childPipelines = { scmUrls: [SCM_URL_GITLAB_FOO] };
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(validationError);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                // existing child re-pointed, not duplicated
+                assert.notCalled(pipelineFactoryMock.create);
+                assert.calledOnce(childPipelineFooMock.sync);
+                assert.notCalled(childPipelineFooMock.update);
+                assert.equal(childPipelineFooMock.scmContext, SCM_CONTEXT_GHEC);
+                assert.equal(childPipelineFooMock.scmUri, childPipelineGitHubFooConfig.scmUri);
+                assert.equal(childPipelineFooMock.state, 'ACTIVE');
+            });
+        });
+
+        it('preserves DISABLED state when re-pointing an old-SCM child to a GHEC parent context', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+            const validationError = new Error('"value" is required');
+
+            validationError.name = 'ValidationError';
+
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitLabFooConfig, state: 'DISABLED' });
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true }, SCM_CONTEXT_GHEC);
+            getUserPermissionMocks({ username: 'robin', push: true }, SCM_CONTEXT_GHEC);
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock]);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubFooConfig.scmUri }).resolves(null);
+            buildClusterFactoryMock.list.resolves(ghecBuildClusters);
+
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            pipeline.childPipelines = { scmUrls: [SCM_URL_GITLAB_FOO] };
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(validationError);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.notCalled(pipelineFactoryMock.create);
+                assert.notCalled(childPipelineFooMock.sync);
+                assert.calledOnce(childPipelineFooMock.update);
+                assert.equal(childPipelineFooMock.scmContext, SCM_CONTEXT_GHEC);
+                assert.equal(childPipelineFooMock.state, 'DISABLED');
+            });
+        });
+
+        it('deactivates an old-SCM child and creates a new one when the corrected scmUrl repo name does not match', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+            const validationError = new Error('"value" is required');
+
+            validationError.name = 'ValidationError';
+
+            // existing child name owner/bar does not match the corrected url owner/foo
+            const childPipelineBarMock = getChildPipelineMock({ ...childPipelineGitLabBarConfig, state: 'ACTIVE' });
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true }, SCM_CONTEXT_GHEC);
+            getUserPermissionMocks({ username: 'robin', push: true }, SCM_CONTEXT_GHEC);
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineBarMock]);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubFooConfig.scmUri }).resolves(null);
+            buildClusterFactoryMock.list.resolves(ghecBuildClusters);
+
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            pipeline.childPipelines = { scmUrls: [SCM_URL_GITLAB_BAR] };
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(validationError);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                // no repo-name match: the unmatched old child is deactivated, a new GHEC child created
+                assert.calledOnce(pipelineFactoryMock.create);
+                assert.calledWith(
+                    pipelineFactoryMock.create,
+                    sinon.match({
+                        scmContext: SCM_CONTEXT_GHEC,
+                        scmUri: childPipelineGitHubFooConfig.scmUri
+                    })
+                );
+                assert.calledOnce(childPipelineBarMock.update);
+                assert.equal(childPipelineBarMock.state, 'INACTIVE');
+            });
+        });
+
+        it('does not orphan other children when one scmUrl fails to resolve during reconciliation', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+            const validationError = new Error('"value" is required');
+
+            validationError.name = 'ValidationError';
+
+            // old child with a repo name matching neither corrected url -> must still be deactivated
+            const childPipelineBazMock = getChildPipelineMock({ ...childPipelineGitLabBazConfig, state: 'ACTIVE' });
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true }, SCM_CONTEXT_GHEC);
+            getUserPermissionMocks({ username: 'robin', push: true }, SCM_CONTEXT_GHEC);
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO, SCM_URL_GITHUB_BAR]
+            };
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineBazMock]);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubBarConfig.scmUri }).resolves(null);
+            buildClusterFactoryMock.list.resolves(ghecBuildClusters);
+
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            pipeline.childPipelines = { scmUrls: [SCM_URL_GITLAB_BAZ] };
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(validationError);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
+            // the first url fails to decorate inside reconciliation; the second must still be processed
+            scmMock.decorateUrl
+                .withArgs(sinon.match({ scmUri: childPipelineGitHubFooConfig.scmUri }))
+                .rejects(new Error('repo no longer exists'));
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                // BAR still created despite FOO failing earlier in the loop
+                assert.calledOnce(pipelineFactoryMock.create);
+                assert.calledWith(
+                    pipelineFactoryMock.create,
+                    sinon.match({
+                        scmContext: SCM_CONTEXT_GHEC,
+                        scmUri: childPipelineGitHubBarConfig.scmUri
+                    })
+                );
+                // removed old-SCM child still deactivated, not orphaned
+                assert.calledOnce(childPipelineBazMock.update);
+                assert.equal(childPipelineBazMock.state, 'INACTIVE');
+            });
+        });
+
+        it('deactivates an eligible child instead of orphaning it when its only corrected scmUrl fails to resolve', () => {
+            const parsedYaml = hoek.clone(EXTERNAL_PARSED_YAML);
+            const ghecBuildClusters = sdBuildClusters.map(cluster => ({ ...cluster, scmContext: SCM_CONTEXT_GHEC }));
+            const validationError = new Error('"value" is required');
+
+            validationError.name = 'ValidationError';
+
+            // would have migrated to the corrected url, but resolution fails -> must be deactivated, not orphaned
+            const childPipelineFooMock = getChildPipelineMock({ ...childPipelineGitLabFooConfig, state: 'ACTIVE' });
+
+            jobs = [mainJob, publishJob];
+            jobFactoryMock.list.resolves(jobs);
+            getUserPermissionMocks({ username: 'batman', push: true, admin: true }, SCM_CONTEXT_GHEC);
+            getUserPermissionMocks({ username: 'robin', push: true }, SCM_CONTEXT_GHEC);
+            parsedYaml.childPipelines = {
+                scmUrls: [SCM_URL_GITHUB_FOO]
+            };
+            scmMock.getFile.resolves('yamlcontentwithscmurls');
+            parserMock.withArgs({ ...parserConfig, ...{ yaml: 'yamlcontentwithscmurls' } }).resolves(parsedYaml);
+            pipelineFactoryMock.list
+                .withArgs({ params: { configPipelineId: testId } })
+                .resolves([childPipelineFooMock]);
+            pipelineFactoryMock.get.withArgs({ scmUri: childPipelineGitHubFooConfig.scmUri }).resolves(null);
+            buildClusterFactoryMock.list.resolves(ghecBuildClusters);
+
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            pipeline.childPipelines = { scmUrls: [SCM_URL_GITLAB_FOO] };
+            scmMock.getScmContext.withArgs({ hostname: 'github.com' }).returns(validationError);
+            scmMock.getReadOnlyInfo.withArgs({ scmContext: SCM_CONTEXT_GHEC }).returns({ enabled: false });
+            scmMock.decorateUrl
+                .withArgs(sinon.match({ scmUri: childPipelineGitHubFooConfig.scmUri }))
+                .rejects(new Error('repo no longer exists'));
+
+            return pipeline.sync().then(p => {
+                assert.equal(p.id, testId);
+                assert.notCalled(pipelineFactoryMock.create);
+                assert.calledOnce(childPipelineFooMock.update);
+                assert.equal(childPipelineFooMock.state, 'INACTIVE');
+            });
+        });
+
         it('does not sync child pipelines if the YAML has errors', () => {
             scmMock.getFile.resolves('yamlcontentwithscmurls');
             parserMock


### PR DESCRIPTION
## Summary

**What changed**
- When a parent pipeline is migrated to a new SCM and a `childPipelines.scmUrls` entry is later corrected to the new-SCM repo, the existing old-SCM child is now re-pointed to the new repo (matched by repo name/branch/rootDir) instead of being left orphaned and ACTIVE in its old SCM context.
- Each `scmUrl` is now reconciled independently (extracted into `_reconcileChildPipelineForScmUrl`): a url that fails to resolve, lacks admin permission, is owned by another parent, or is being deleted is skipped without aborting the rest of the loop.
- The deactivation pass always runs, so a removed/replaced child is always either migrated or marked `INACTIVE` — never left orphaned.

**Why**
- After a parent SCM migration (e.g. GHES -> GHEC), an old-SCM child pipeline could be left ACTIVE and keep running daily builds against a repo that no longer exists. The reconciliation could abort early (e.g. a throw while resolving a removed repo) before the deactivation/migration pass ran.

## Example (before -> after)

Migrated a pipeline from `GitHub` to `BitBucket`

**GitHub screwdriver.yaml**
```
childPipelines:
  scmUrls:
    - git@github.com:sagar1312/screwdriver-migration-external-config-test-pipeline.git#main:child-pipeline-alpha
    - git@github.com:sagar1312/screwdriver-migration-external-config-test-pipeline.git#main:child-pipeline-beta
    - git@github.com:sagar1312/screwdriver-migration-external-config-test-pipeline.git#main:child-pipeline-charlie
    - git@github.com:sagar1312/screwdriver-migration-external-config-child-pipeline-apple.git#main
parameters:
  p1: p1
  p2:
    value: p2
    description: User running build
jobs:
  main:
    image: node:20
    steps:
      - secrets: echo ALPHA_SECRET:$ALPHA_SECRET && echo BETA_SECRET:$BETA_SECRET && echo CHARLIE_SECRET:$CHARLIE_SECRET && echo DELTA_SECRET:$DELTA_SECRET && echo APPLE_SECRET:$APPLE_SECRET
      - step-from-github-parent: echo "Step from GitHub parent"
    requires: [~pr, ~commit]
    secrets:
      - ALPHA_SECRET
      - BETA_SECRET
      - CHARLIE_SECRET
      - DELTA_SECRET
      - APPLE_SECRET
```
<img width="3456" height="1184" alt="image" src="https://github.com/user-attachments/assets/ab78be15-83c1-4370-b1aa-e15bbdc61976" />


**BitBucket screwdriver.yaml**
```
childPipelines:
  scmUrls:
    - git@bitbucket.org:sagar-1312/screwdriver-migration-external-config-test-pipeline.git#main:child-pipeline-alpha
    # Beta - Still pointing to GitHub
    - git@github.com:sagar1312/screwdriver-migration-external-config-test-pipeline.git#main:child-pipeline-beta
    # Beta - Corrected to point to BitBucket
    # - git@bitbucket.org:sagar-1312/screwdriver-migration-external-config-test-pipeline.git#main:child-pipeline-beta
    - git@bitbucket.org:sagar-1312/screwdriver-migration-external-config-test-pipeline.git#main:child-pipeline-delta
    - git@bitbucket.org:sagar-1312/screwdriver-migration-external-config-child-pipeline-apple.git#main
parameters:
  p1: p1
  p2:
    value: p2
    description: User running build
jobs:
  main:
    image: node:20
    steps:
      - secrets: echo ALPHA_SECRET:$ALPHA_SECRET && echo BETA_SECRET:$BETA_SECRET && echo CHARLIE_SECRET:$CHARLIE_SECRET && echo DELTA_SECRET:$DELTA_SECRET && echo APPLE_SECRET:$APPLE_SECRET
      - step-from-github-parent: echo "Step from BitBucket parent"
    requires: [~pr, ~commit]
    secrets:
      - ALPHA_SECRET
      - BETA_SECRET
      - CHARLIE_SECRET
      - DELTA_SECRET
      - APPLE_SECRET
```
<img width="3450" height="1386" alt="image" src="https://github.com/user-attachments/assets/7769dc19-9332-4e51-b2d9-59fef69b71b4" />




## References

https://github.com/screwdriver-cd/screwdriver/issues/3460

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.