### PR TITLE
fix(3500): persist scmUri/scmContext atomically with scmRepo on pipeline update

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -2334,6 +2334,18 @@ class PipelineModel extends BaseModel {
                     this.scmRepo = scmRepo;
                     this.name = scmRepo.name;
 
+                    // scmRepo and name are re-derived from (scmUri, scmContext) above, so the
+                    // four fields form a single SCM-identity unit. Persist scmUri and scmContext
+                    // together with scmRepo/name on every update (even when unchanged) so a stale
+                    // or concurrent update can never leave the row half-migrated, e.g. scmRepo
+                    // pointing at the new SCM while scmUri/scmContext still reference the old one
+                    // after an SCM migration. Re-assigning marks them dirty so the datastore
+                    // writes the whole identity unit in one update.
+                    const { scmUri, scmContext } = this;
+
+                    this.scmUri = scmUri;
+                    this.scmContext = scmContext;
+
                     const annotations = hoek.reach(this, 'annotations', { default: {} });
                     const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
 

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -4417,7 +4417,8 @@ describe('Pipeline Model', () => {
                     id: testId,
                     name: 'owner/repo',
                     scmContext,
-                    scmRepo
+                    scmRepo,
+                    scmUri
                 },
                 table: 'pipelines'
             };
@@ -4446,6 +4447,50 @@ describe('Pipeline Model', () => {
                 });
                 assert.calledWith(datastore.update, expected);
                 assert.ok(p);
+            });
+        });
+
+        it('persists the full SCM identity unit together so a migration cannot half-update the row', () => {
+            // Regression: scmRepo/name are re-derived from (scmUri, scmContext) on every
+            // update, but scmUri used to be written only when explicitly reassigned. After
+            // an SCM migration this could persist scmRepo on the new SCM while leaving
+            // scmUri/scmContext on the old one. scmUri, scmContext, scmRepo and name must
+            // be written in a single datastore update.
+            const newScmUri = 'enterprise-cloud.com:12345:master';
+            const newScmRepo = {
+                branch: 'master',
+                url: 'https://enterprise-cloud.com/owner/repo/tree/master',
+                name: 'owner/repo'
+            };
+
+            userFactoryMock.get
+                .withArgs({
+                    username: 'd2lam',
+                    scmContext: SCM_CONTEXT_GHEC
+                })
+                .resolves({
+                    unsealToken: sinon.stub().resolves('foo'),
+                    getPermissions: sinon.stub().resolves({
+                        push: true
+                    })
+                });
+            scmMock.decorateUrl.resolves(newScmRepo);
+            datastore.update.resolves({});
+
+            pipeline.scmUri = newScmUri;
+            pipeline.scmContext = SCM_CONTEXT_GHEC;
+            pipeline.admins = {
+                d2lam: true
+            };
+
+            return pipeline.update().then(() => {
+                assert.calledOnce(datastore.update);
+                const { params } = datastore.update.getCall(0).args[0];
+
+                assert.strictEqual(params.scmUri, newScmUri);
+                assert.strictEqual(params.scmContext, SCM_CONTEXT_GHEC);
+                assert.deepEqual(params.scmRepo, newScmRepo);
+                assert.strictEqual(params.name, newScmRepo.name);
             });
         });
     });


### PR DESCRIPTION
## Summary

**What changed**
- `Pipeline.update()` now writes the full SCM-identity unit (`scmUri`, `scmContext`, `scmRepo`, `name`) together in a single datastore update, instead of only whichever of those fields happened to be dirty.

**Why**
- After an SCM migration (e.g. GHES → GHEC), pipelines were left half-updated: `scmRepo` reflected the new SCM while `scmUri`/`scmContext` stayed on the old one, making the pipeline unusable (can't start jobs, "Sync pipeline" fails).
- Root cause: `update()` re-derives `scmRepo`/`name` from `(scmUri, scmContext)` on every call, but `BaseModel.update()` persists only dirty fields. `scmContext` is always dirty (set via the setter in the constructor) while `scmUri` is dirty only when reassigned, so the identity fields could desync at the DB level.

## Example (before → after)
A migration-time update could persist:
- before: `scmRepo=github.com/yahoo-storage/repo`, `scmUri=git.ouryahoo.com:…`, `scmContext=github:git.ouryahoo.com`  ← half-migrated
- after: `scmUri`, `scmContext`, `scmRepo`, `name` always written together and mutually consistent

## Test plan
- [x] `npx mocha test/lib/pipeline.test.js` — 150 passing (added 1 regression test)
- [x] `npx eslint lib/pipeline.js test/lib/pipeline.test.js` — 0 errors
- Regression test added: *persists the full SCM identity unit together so a migration cannot half-update the row*

## References
https://github.com/screwdriver-cd/screwdriver/issues/3500


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.