### PR TITLE
fix(3460): deactivate orphaned child pipelines without re-decorating their SCM url

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -973,6 +973,26 @@ class PipelineModel extends BaseModel {
     }
 
     /**
+     * Deactivate this pipeline by setting its state to INACTIVE and persisting the change
+     * without re-decorating the SCM url.
+     *
+     * A child pipeline's SCM context may no longer be reachable: the repository can be removed,
+     * or the parent pipeline can migrate to a different SCM and leave the child in an SCM context
+     * that has no valid token. In those cases this.update() throws while decorating the stale
+     * scmUri, so the state change never persists and the child is left orphaned and ACTIVE. Like
+     * remove(), bypass update() and write the state directly via super.update(), which does not
+     * require SCM access.
+     * @param   {Object}  [configOverrides]  Optional fields to merge before persisting
+     * @return  {Promise}
+     */
+    async deactivate(configOverrides = {}) {
+        Object.assign(this, configOverrides);
+        this.state = 'INACTIVE';
+
+        return super.update();
+    }
+
+    /**
      * Deactivate child pipelines by setting their state to INACTIVE
      * Iterates through child pipelines and creates update promises to deactivate them.
      * Pipelines in 'DELETING' state are logged as errors and skipped.
@@ -991,9 +1011,13 @@ class PipelineModel extends BaseModel {
                     `pipelineId:${pipeline.configPipelineId}: Child pipeline with id ${pipeline.id} is been deleted.`
                 );
             } else if (pipeline.state !== 'INACTIVE') {
-                updatePromises.push(
-                    this._updateChildPipeline(pipeline, { ...pipelineConfigOverrides, state: 'INACTIVE' })
+                logger.info(
+                    `pipelineId:${pipeline.configPipelineId}: Deactivating child pipeline with id ${pipeline.id}.`
                 );
+                // Deactivate without re-decorating the SCM url - the child's SCM context may be
+                // unreachable (e.g. the parent migrated away), where update()'s decorateUrl would
+                // throw and leave the child orphaned and ACTIVE.
+                updatePromises.push(pipeline.deactivate(pipelineConfigOverrides));
             }
         }
 
@@ -1306,7 +1330,17 @@ class PipelineModel extends BaseModel {
             );
         });
 
-        return Promise.allSettled(toCreateOrUpdatePromises);
+        const results = await Promise.allSettled(toCreateOrUpdatePromises);
+
+        // Surface failures that allSettled would otherwise swallow, so a child that failed to
+        // create/update/deactivate is visible to operators instead of silently left behind.
+        results
+            .filter(result => result.status === 'rejected')
+            .forEach(result => {
+                logger.error(`pipelineId:${this.id}: Failed to sync child pipeline: ${result.reason}.`);
+            });
+
+        return results;
     }
 
     /**

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -210,7 +210,7 @@ describe('Pipeline Model', () => {
     };
 
     const getChildPipelineMock = config => {
-        return {
+        const mock = {
             ...config,
             state: config.state || 'ACTIVE',
             id: Date.now(),
@@ -219,6 +219,15 @@ describe('Pipeline Model', () => {
             sync: sinon.stub().resolves(null),
             update: sinon.stub().resolves(null)
         };
+
+        // Mirror the real Pipeline.deactivate(): merge overrides and set state to INACTIVE.
+        mock.deactivate = sinon.stub().callsFake(configOverrides => {
+            Object.assign(mock, configOverrides, { state: 'INACTIVE' });
+
+            return Promise.resolve(mock);
+        });
+
+        return mock;
     };
 
     beforeEach(() => {
@@ -1676,7 +1685,7 @@ describe('Pipeline Model', () => {
                 );
                 assert.calledOnce(childPipelineFooMock.sync);
                 assert.equal(childPipelineFooMock.state, 'ACTIVE');
-                assert.calledOnce(childPipelineBazMock.update);
+                assert.calledOnce(childPipelineBazMock.deactivate);
                 assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
@@ -1719,7 +1728,7 @@ describe('Pipeline Model', () => {
                 );
                 assert.notCalled(childPipelineFooMock.update);
                 assert.equal(childPipelineFooMock.state, 'INACTIVE');
-                assert.calledOnce(childPipelineBazMock.update);
+                assert.calledOnce(childPipelineBazMock.deactivate);
                 assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
@@ -1752,7 +1761,7 @@ describe('Pipeline Model', () => {
                 assert.notCalled(pipelineFactoryMock.create);
                 assert.notCalled(childPipelineFooMock.update);
                 assert.equal(childPipelineFooMock.state, 'INACTIVE');
-                assert.calledOnce(childPipelineBazMock.update);
+                assert.calledOnce(childPipelineBazMock.deactivate);
                 assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
@@ -1908,7 +1917,7 @@ describe('Pipeline Model', () => {
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
                 assert.equal(p.childPipelines, null);
-                assert.calledOnce(childPipelineBarMock.update);
+                assert.calledOnce(childPipelineBarMock.deactivate);
                 assert.equal(childPipelineBarMock.state, 'INACTIVE');
             });
         });
@@ -1932,7 +1941,7 @@ describe('Pipeline Model', () => {
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
                 assert.equal(p.childPipelines, null);
-                assert.calledOnce(childPipelineBazMock.update);
+                assert.calledOnce(childPipelineBazMock.deactivate);
                 assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
@@ -2205,7 +2214,7 @@ describe('Pipeline Model', () => {
                         scmUri: childPipelineGitHubFooConfig.scmUri
                     })
                 );
-                assert.calledOnce(childPipelineBarMock.update);
+                assert.calledOnce(childPipelineBarMock.deactivate);
                 assert.equal(childPipelineBarMock.state, 'INACTIVE');
             });
         });
@@ -2256,7 +2265,7 @@ describe('Pipeline Model', () => {
                     })
                 );
                 // removed old-SCM child still deactivated, not orphaned
-                assert.calledOnce(childPipelineBazMock.update);
+                assert.calledOnce(childPipelineBazMock.deactivate);
                 assert.equal(childPipelineBazMock.state, 'INACTIVE');
             });
         });
@@ -2297,7 +2306,7 @@ describe('Pipeline Model', () => {
             return pipeline.sync().then(p => {
                 assert.equal(p.id, testId);
                 assert.notCalled(pipelineFactoryMock.create);
-                assert.calledOnce(childPipelineFooMock.update);
+                assert.calledOnce(childPipelineFooMock.deactivate);
                 assert.equal(childPipelineFooMock.state, 'INACTIVE');
             });
         });
@@ -4447,6 +4456,43 @@ describe('Pipeline Model', () => {
                 assert.calledWith(datastore.update, expected);
                 assert.ok(p);
             });
+        });
+    });
+
+    describe('deactivate', () => {
+        it('persists INACTIVE state without re-decorating the SCM url', () => {
+            // The pipeline's SCM context may be unreachable (e.g. the parent migrated away), so
+            // decorateUrl would throw. deactivate() must still persist the state, unlike update().
+            scmMock.decorateUrl.rejects(new Error('repo no longer exists'));
+            datastore.update.resolves({});
+
+            return pipeline.deactivate().then(() => {
+                assert.notCalled(scmMock.decorateUrl);
+                assert.calledOnce(datastore.update);
+
+                const { params } = datastore.update.getCall(0).args[0];
+
+                assert.strictEqual(params.state, 'INACTIVE');
+                assert.strictEqual(pipeline.state, 'INACTIVE');
+            });
+        });
+
+        it('merges config overrides before persisting', () => {
+            scmMock.decorateUrl.rejects(new Error('should not be called'));
+            datastore.update.resolves({});
+
+            return pipeline
+                .deactivate({ admins: { batman: true }, adminUserIds: [44], configPipelineId: 999 })
+                .then(() => {
+                    assert.notCalled(scmMock.decorateUrl);
+
+                    const { params } = datastore.update.getCall(0).args[0];
+
+                    assert.strictEqual(params.state, 'INACTIVE');
+                    assert.deepEqual(params.admins, { batman: true });
+                    assert.deepEqual(params.adminUserIds, [44]);
+                    assert.strictEqual(params.configPipelineId, 999);
+                });
         });
     });
 


### PR DESCRIPTION
## Summary

**What changed**
- Orphaned child pipelines are now deactivated via a new `Pipeline.deactivate()` that writes the INACTIVE state directly, without contacting the SCM.
- `_syncChildPipelines` now logs child create/update/deactivate failures instead of silently swallowing them via `Promise.allSettled`.

**Why**
- When a parent pipeline stops referencing a child (e.g. after the parent migrates to a different SCM), the child should be marked INACTIVE. Deactivation went through `Pipeline.update()`, which always calls `scm.decorateUrl()` against the child's stored `scmUri`/`scmContext` first. If that old SCM context is no longer reachable (repo removed, or no valid token after migration), `decorateUrl` throws, the state change never persists, and the child is left **orphaned and ACTIVE**.
- `deactivate()` mirrors how `remove()` already bypasses `update()` for the same reason ("calling this.update() will throw … preventing this.state from being updated").

## Example (before → after)
Parent migrates to a new SCM; old-context child no longer referenced and its old repo is unreachable:
- before: deactivation calls `update()` → `decorateUrl(oldScmUri)` throws → child stays **ACTIVE** (error swallowed)
- after: `deactivate()` persists `state = INACTIVE` directly → child correctly **INACTIVE**; any failure is logged

## References

https://github.com/screwdriver-cd/screwdriver/issues/3460

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.