### PR TITLE
feat: pass YAML merge key limit to config parser [2]

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -413,13 +413,16 @@ class PipelineModel extends BaseModel {
     /**
      * Insert provider yaml to screwdriver config
      * @method _getYamlWithProvider
-     * @param  {String} config  The Screwdriver yaml configuration (yaml format)
-     * @param  {String} token   The token used to authenticate to the SCM
-     * @return {Promise}        Resolves to string containing contents of config file (yaml format)
+     * @param  {String} config                  The Screwdriver yaml configuration (yaml format)
+     * @param  {String} token                   The token used to authenticate to the SCM
+     * @param  {Number} [maxTotalMergeKeys]     Maximum total number of YAML merge keys
+     * @return {Promise}                        Resolves to string containing contents of config file (yaml format)
      */
-    async _getYamlWithProvider({ config, token }) {
+    async _getYamlWithProvider({ config, token, maxTotalMergeKeys }) {
+        const yamlParserOptions = maxTotalMergeKeys === undefined ? {} : { maxTotalMergeKeys };
+
         // Convert config to JSON
-        const documents = yamlParser.loadAll(config);
+        const documents = yamlParser.loadAll(config, yamlParserOptions);
 
         let doc;
 
@@ -439,7 +442,7 @@ class PipelineModel extends BaseModel {
         ) {
             // Get provider yaml and convert to JSON
             const providerConfig = await this._getFile({ token, path: doc.shared.provider });
-            const providerJson = yamlParser.load(providerConfig);
+            const providerJson = yamlParser.load(providerConfig, yamlParserOptions);
 
             doc.shared.provider = providerJson.provider || providerJson;
         }
@@ -450,7 +453,7 @@ class PipelineModel extends BaseModel {
                 if (val.provider && typeof val.provider === 'string' && CHECKOUT_URL.test(val.provider)) {
                     // Get provider yaml and convert to JSON
                     const providerConfig = await this._getFile({ token, path: val.provider });
-                    const providerJson = yamlParser.load(providerConfig);
+                    const providerJson = yamlParser.load(providerConfig, yamlParserOptions);
 
                     val.provider = providerJson.provider || providerJson;
                 }
@@ -517,6 +520,7 @@ class PipelineModel extends BaseModel {
                 })
                 // parse the content of the yaml file
                 .then(async config => {
+                    const maxTotalMergeKeys = pipelineFactory.getMaxTotalMergeKeys();
                     let parserConfig = {
                         yaml: config,
                         templateFactory,
@@ -525,12 +529,12 @@ class PipelineModel extends BaseModel {
                         pipelineTemplateTagFactory,
                         pipelineTemplateFactory,
                         notificationsValidationErr: pipelineFactory.getNotificationsValidationErrFlag(),
-                        maxTotalMergeKeys: pipelineFactory.getMaxTotalMergeKeys()
+                        maxTotalMergeKeys
                     };
 
                     // Check if we need to fetch provider file
                     if (config.search(PROVIDER_YAML_KEY) !== -1) {
-                        parserConfig.yaml = await this._getYamlWithProvider({ config, token });
+                        parserConfig.yaml = await this._getYamlWithProvider({ config, token, maxTotalMergeKeys });
                     }
 
                     if (pipelineFactory.getExternalJoinFlag()) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -524,7 +524,8 @@ class PipelineModel extends BaseModel {
                         pipelineTemplateVersionFactory,
                         pipelineTemplateTagFactory,
                         pipelineTemplateFactory,
-                        notificationsValidationErr: pipelineFactory.getNotificationsValidationErrFlag()
+                        notificationsValidationErr: pipelineFactory.getNotificationsValidationErrFlag(),
+                        maxTotalMergeKeys: pipelineFactory.getMaxTotalMergeKeys()
                     };
 
                     // Check if we need to fetch provider file

--- a/lib/pipelineFactory.js
+++ b/lib/pipelineFactory.js
@@ -13,12 +13,14 @@ class PipelineFactory extends BaseFactory {
      * @param  {Boolean}   config.multiBuildClusterEnabled      Enable multiple build cluster feature or not
      * @param  {Boolean}   config.externalJoin                  Flag to allow external join
      * @param  {Boolean}   config.notificationsValidationErr    Flag to throw error for notification validation or not
+     * @param  {Number}    config.maxTotalMergeKeys             Maximum total number of YAML merge keys
      */
     constructor(config) {
         super('pipeline', config);
         this.multiBuildClusterEnabled = config.multiBuildClusterEnabled;
         this.externalJoin = config.externalJoin || false;
         this.notificationsValidationErr = config.notificationsValidationErr;
+        this.maxTotalMergeKeys = config.maxTotalMergeKeys;
     }
 
     /**
@@ -128,6 +130,14 @@ class PipelineFactory extends BaseFactory {
      */
     getNotificationsValidationErrFlag() {
         return this.notificationsValidationErr;
+    }
+
+    /**
+     * Return maximum total number of YAML merge keys
+     * @return {Number}
+     */
+    getMaxTotalMergeKeys() {
+        return this.maxTotalMergeKeys;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "dayjs": "^1.11.13",
     "deepcopy": "^2.1.0",
     "docker-parse-image": "^3.0.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "lodash": "^4.17.23",
     "screwdriver-config-parser": "^12.0.0",
     "screwdriver-data-schema": "^26.1.0",

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -9,6 +9,7 @@ const schema = require('screwdriver-data-schema');
 const rewire = require('rewire');
 const dayjs = require('dayjs');
 const rewiremock = require('rewiremock/node');
+const yamlParser = require('js-yaml');
 
 sinon.assert.expose(assert, { prefix: '' });
 const YAML_WITH_PROVIDER_FILE_PATH = '../data/yamlWithProviderPath.yaml';
@@ -3994,6 +3995,9 @@ describe('Pipeline Model', () => {
         });
 
         it('gets pipeline config with provider config', () => {
+            const loadAllSpy = sinon.spy(yamlParser, 'loadAll');
+            const loadSpy = sinon.spy(yamlParser, 'load');
+
             getFileConfig = {
                 scmUri,
                 scmContext,
@@ -4021,22 +4025,32 @@ describe('Pipeline Model', () => {
             scmMock.getFile.onCall(2).resolves(loadData(PROVIDER_YAML));
             parserMock.withArgs(parserConfig).resolves(PARSED_YAML_WITH_PROVIDER);
 
-            return pipeline.getConfiguration({ ref: 'bar' }).then(config => {
-                assert.calledWith(parserMock, parserConfig);
-                assert.deepEqual(config, PARSED_YAML_WITH_PROVIDER);
-                assert.calledWith(scmMock.getFile.thirdCall, {
-                    scmUri: 'github.com:12345:master',
-                    scmContext: 'github:github.com',
-                    path: 'git@github.com:screwdriver-cd/provider.git:configuration/aws/provider.yaml',
-                    token: 'foo',
-                    scmRepo: {
-                        branch: 'branch',
-                        url: 'https://host/owner/repo/tree/branch',
-                        name: 'owner/repo'
-                    }
+            return pipeline
+                .getConfiguration({ ref: 'bar' })
+                .then(config => {
+                    assert.calledWith(loadAllSpy, loadData(YAML_WITH_PROVIDER_FILE_PATH), {
+                        maxTotalMergeKeys: 11000
+                    });
+                    assert.alwaysCalledWithMatch(loadSpy, sinon.match.string, { maxTotalMergeKeys: 11000 });
+                    assert.calledWith(parserMock, parserConfig);
+                    assert.deepEqual(config, PARSED_YAML_WITH_PROVIDER);
+                    assert.calledWith(scmMock.getFile.thirdCall, {
+                        scmUri: 'github.com:12345:master',
+                        scmContext: 'github:github.com',
+                        path: 'git@github.com:screwdriver-cd/provider.git:configuration/aws/provider.yaml',
+                        token: 'foo',
+                        scmRepo: {
+                            branch: 'branch',
+                            url: 'https://host/owner/repo/tree/branch',
+                            name: 'owner/repo'
+                        }
+                    });
+                    assert.calledWith(scmMock.getFile.firstCall, getFileConfig);
+                })
+                .finally(() => {
+                    loadAllSpy.restore();
+                    loadSpy.restore();
                 });
-                assert.calledWith(scmMock.getFile.firstCall, getFileConfig);
-            });
         });
 
         it('gets pipeline config from an alternate ref', () => {

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -408,6 +408,7 @@ describe('Pipeline Model', () => {
         pipelineFactoryMock = {
             getExternalJoinFlag: sinon.stub(),
             getNotificationsValidationErrFlag: sinon.stub(),
+            getMaxTotalMergeKeys: sinon.stub(),
             get: sinon.stub().resolves(configPipelineMock),
             update: sinon.stub().resolves(null),
             create: sinon.stub(),
@@ -489,6 +490,7 @@ describe('Pipeline Model', () => {
 
         pipelineFactoryMock.getExternalJoinFlag.returns(false);
         pipelineFactoryMock.getNotificationsValidationErrFlag.returns(true);
+        pipelineFactoryMock.getMaxTotalMergeKeys.returns(11000);
 
         buildClusterFactoryMock = {
             list: sinon.stub().resolves([]),
@@ -764,7 +766,8 @@ describe('Pipeline Model', () => {
                 pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock,
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
-                notificationsValidationErr: true
+                notificationsValidationErr: true,
+                maxTotalMergeKeys: 11000
             };
             parserMock.withArgs(parserConfig).resolves(PARSED_YAML);
             parserMock
@@ -2465,7 +2468,8 @@ describe('Pipeline Model', () => {
                 pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock,
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
-                notificationsValidationErr: true
+                notificationsValidationErr: true,
+                maxTotalMergeKeys: 11000
             };
             datastore.update.resolves(null);
             scmMock.getFile.resolves(SCM_CONTEXT_GITHUB);
@@ -3126,7 +3130,8 @@ describe('Pipeline Model', () => {
                 pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock,
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
-                notificationsValidationErr: true
+                notificationsValidationErr: true,
+                maxTotalMergeKeys: 11000
             };
             datastore.update.resolves(null);
             scmMock.getFile.resolves(SCM_CONTEXT_GITHUB);
@@ -3957,7 +3962,8 @@ describe('Pipeline Model', () => {
                 pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock,
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
-                notificationsValidationErr: true
+                notificationsValidationErr: true,
+                maxTotalMergeKeys: 11000
             };
             scmMock.getFile.resolves(SCM_CONTEXT_GITHUB);
             parserMock.withArgs(parserConfig).resolves(PARSED_YAML);
@@ -4007,7 +4013,8 @@ describe('Pipeline Model', () => {
                 pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock,
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
-                notificationsValidationErr: true
+                notificationsValidationErr: true,
+                maxTotalMergeKeys: 11000
             };
             scmMock.getFile.onCall(0).resolves(loadData(YAML_WITH_PROVIDER_FILE_PATH));
             scmMock.getFile.onCall(1).resolves(loadData(SHARED_PROVIDER_YAML));

--- a/test/lib/pipeline.test.js
+++ b/test/lib/pipeline.test.js
@@ -491,7 +491,7 @@ describe('Pipeline Model', () => {
 
         pipelineFactoryMock.getExternalJoinFlag.returns(false);
         pipelineFactoryMock.getNotificationsValidationErrFlag.returns(true);
-        pipelineFactoryMock.getMaxTotalMergeKeys.returns(11000);
+        pipelineFactoryMock.getMaxTotalMergeKeys.returns(10000);
 
         buildClusterFactoryMock = {
             list: sinon.stub().resolves([]),
@@ -768,7 +768,7 @@ describe('Pipeline Model', () => {
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
                 notificationsValidationErr: true,
-                maxTotalMergeKeys: 11000
+                maxTotalMergeKeys: 10000
             };
             parserMock.withArgs(parserConfig).resolves(PARSED_YAML);
             parserMock
@@ -2470,7 +2470,7 @@ describe('Pipeline Model', () => {
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
                 notificationsValidationErr: true,
-                maxTotalMergeKeys: 11000
+                maxTotalMergeKeys: 10000
             };
             datastore.update.resolves(null);
             scmMock.getFile.resolves(SCM_CONTEXT_GITHUB);
@@ -3132,7 +3132,7 @@ describe('Pipeline Model', () => {
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
                 notificationsValidationErr: true,
-                maxTotalMergeKeys: 11000
+                maxTotalMergeKeys: 10000
             };
             datastore.update.resolves(null);
             scmMock.getFile.resolves(SCM_CONTEXT_GITHUB);
@@ -3964,7 +3964,7 @@ describe('Pipeline Model', () => {
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
                 notificationsValidationErr: true,
-                maxTotalMergeKeys: 11000
+                maxTotalMergeKeys: 10000
             };
             scmMock.getFile.resolves(SCM_CONTEXT_GITHUB);
             parserMock.withArgs(parserConfig).resolves(PARSED_YAML);
@@ -4018,7 +4018,7 @@ describe('Pipeline Model', () => {
                 pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
                 pipelineTemplateFactory: pipelineTemplateFactoryMock,
                 notificationsValidationErr: true,
-                maxTotalMergeKeys: 11000
+                maxTotalMergeKeys: 10000
             };
             scmMock.getFile.onCall(0).resolves(loadData(YAML_WITH_PROVIDER_FILE_PATH));
             scmMock.getFile.onCall(1).resolves(loadData(SHARED_PROVIDER_YAML));
@@ -4029,9 +4029,9 @@ describe('Pipeline Model', () => {
                 .getConfiguration({ ref: 'bar' })
                 .then(config => {
                     assert.calledWith(loadAllSpy, loadData(YAML_WITH_PROVIDER_FILE_PATH), {
-                        maxTotalMergeKeys: 11000
+                        maxTotalMergeKeys: 10000
                     });
-                    assert.alwaysCalledWithMatch(loadSpy, sinon.match.string, { maxTotalMergeKeys: 11000 });
+                    assert.alwaysCalledWithMatch(loadSpy, sinon.match.string, { maxTotalMergeKeys: 10000 });
                     assert.calledWith(parserMock, parserConfig);
                     assert.deepEqual(config, PARSED_YAML_WITH_PROVIDER);
                     assert.calledWith(scmMock.getFile.thirdCall, {

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -314,4 +314,13 @@ describe('Pipeline Factory', () => {
             assert.isTrue(factory.getNotificationsValidationErrFlag());
         });
     });
+
+    describe('getMaxTotalMergeKeys', () => {
+        it('returns the configured maximum total number of YAML merge keys', () => {
+            pipelineConfig.maxTotalMergeKeys = 11000;
+            factory = new PipelineFactory(pipelineConfig);
+
+            assert.strictEqual(factory.getMaxTotalMergeKeys(), 11000);
+        });
+    });
 });

--- a/test/lib/pipelineFactory.test.js
+++ b/test/lib/pipelineFactory.test.js
@@ -317,10 +317,10 @@ describe('Pipeline Factory', () => {
 
     describe('getMaxTotalMergeKeys', () => {
         it('returns the configured maximum total number of YAML merge keys', () => {
-            pipelineConfig.maxTotalMergeKeys = 11000;
+            pipelineConfig.maxTotalMergeKeys = 10000;
             factory = new PipelineFactory(pipelineConfig);
 
-            assert.strictEqual(factory.getMaxTotalMergeKeys(), 11000);
+            assert.strictEqual(factory.getMaxTotalMergeKeys(), 10000);
         });
     });
 });


### PR DESCRIPTION
## Context

The configurable YAML merge key limit must be applied to pipeline parsing in models, including provider YAML processing.

## Objective

Pass `maxTotalMergeKeys` to config-parser and direct js-yaml calls used during provider YAML processing.

## References
- https://github.com/screwdriver-cd/config-parser/pull/186
- https://github.com/screwdriver-cd/screwdriver/pull/3506

These three PRs are designed to be backward-compatible, so merging them in any order should not cause failures. However, merging them in the numbered order—[1] config-parser, [2] models, and [3] screwdriver—is recommended to ensure the configuration is propagated correctly.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.